### PR TITLE
Fix if-let and if-some by not using vectors as functions

### DIFF
--- a/src/jank/clojure/core.jank
+++ b/src/jank/clojure/core.jank
@@ -1600,7 +1600,7 @@
      (vector? bindings) "a vector for its binding"
      (nil? oldform) "1 or 2 forms after binding vector"
      (= 2 (count bindings)) "exactly 2 forms in binding vector")
-   (let [form (bindings 0) tst (bindings 1)]
+   (let [form (get bindings 0) tst (get bindings 1)]
      `(let [temp# ~tst]
         (if temp#
           (let [~form temp#]
@@ -1634,7 +1634,7 @@
      (vector? bindings) "a vector for its binding"
      (nil? oldform) "1 or 2 forms after binding vector"
      (= 2 (count bindings)) "exactly 2 forms in binding vector")
-   (let [form (bindings 0) tst (bindings 1)]
+   (let [form (get bindings 0) tst (get bindings 1)]
      `(let [temp# ~tst]
         (if (nil? temp#)
           ~else


### PR DESCRIPTION
Since calling vectors as functions isn't implemented yet we need to explicitly use `get`