### PR TITLE
Fix compiler+runtime compilation error

### DIFF
--- a/compiler+runtime/src/cpp/jank/util/sha256.cpp
+++ b/compiler+runtime/src/cpp/jank/util/sha256.cpp
@@ -1,3 +1,5 @@
+#include <iomanip>
+
 #include <openssl/sha.h>
 
 #include <jank/util/sha256.hpp>


### PR DESCRIPTION
A tiny fix to the following error.

```
[1/6] Building CXX object CMakeFiles/jank_lib.dir/src/cpp/jank/util/sha256.cpp.o
FAILED: CMakeFiles/jank_lib.dir/src/cpp/jank/util/sha256.cpp.o 
/home/jeffr/dev/github/jank/compiler+runtime/build/llvm-install/usr/local/bin/clang++ -DCLI11_COMPILE -D__STDC_CONSTANT_MACROS -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/home/jeffr/dev/github/jank/compiler+runtime/build -I/home/jeffr/dev/github/jank/compiler+runtime -I/home/jeffr/dev/github/jank/compiler+runtime/include/cpp -isystem /home/jeffr/dev/github/jank/compiler+runtime/build/llvm-install/usr/local/include -isystem /home/jeffr/dev/github/jank/compiler+runtime/third-party/nanobench/include -isystem /home/jeffr/dev/github/jank/compiler+runtime/third-party/folly -isystem /home/jeffr/dev/github/jank/compiler+runtime/third-party/bpptree/include -isystem /home/jeffr/dev/github/jank/compiler+runtime/build/vcpkg_installed/x64-clang-static/include -isystem /home/jeffr/dev/github/jank/compiler+runtime/build/vcpkg_installed/x64-clang-static/include/libzippp -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -g -std=gnu++20 -fcolor-diagnostics -std=gnu++20 -DIMMER_HAS_LIBGC=1 -DIMMER_TAGGED_NODE=0 -DHAVE_CXX14=1 -DFMT_HEADER_ONLY=1 -DJANK_DEBUG -Wall -Wextra -Wpedantic -Wfloat-equal -Wuninitialized -Wswitch-enum -Wnon-virtual-dtor -Wold-style-cast -Wno-gnu-case-range -Wno-gnu-conditional-omitted-operand -Wno-implicit-fallthrough -Wno-covered-switch-default -fno-common -frtti -fexceptions -O0 -DJANK_VERSION=\"0.1-b1d1f2c2156d82a434d490cb94ee7dea4f36c613\" "-DJANK_JIT_FLAGS=\"-std=gnu++20 -DIMMER_HAS_LIBGC=1 -DIMMER_TAGGED_NODE=0 -DHAVE_CXX14=1 -DFMT_HEADER_ONLY=1 -DJANK_DEBUG -w\"" -DJANK_CLANG_PREFIX=\"/home/jeffr/dev/github/jank/compiler+runtime/build/llvm-install/usr/local\" -Winvalid-pch -Xclang -include-pch -Xclang /home/jeffr/dev/github/jank/compiler+runtime/build/CMakeFiles/jank_lib.dir/cmake_pch.hxx.pch -Xclang -include -Xclang /home/jeffr/dev/github/jank/compiler+runtime/build/CMakeFiles/jank_lib.dir/cmake_pch.hxx -MD -MT CMakeFiles/jank_lib.dir/src/cpp/jank/util/sha256.cpp.o -MF CMakeFiles/jank_lib.dir/src/cpp/jank/util/sha256.cpp.o.d -o CMakeFiles/jank_lib.dir/src/cpp/jank/util/sha256.cpp.o -c /home/jeffr/dev/github/jank/compiler+runtime/src/cpp/jank/util/sha256.cpp
/home/jeffr/dev/github/jank/compiler+runtime/src/cpp/jank/util/sha256.cpp:14:30: error: no member named 'setw' in namespace 'std'
   14 |       ss << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(b);
      |                         ~~~~~^
/home/jeffr/dev/github/jank/compiler+runtime/src/cpp/jank/util/sha256.cpp:14:46: error: no member named 'setfill' in namespace 'std'
   14 |       ss << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(b);
      |                                         ~~~~~^
2 errors generated.
ninja: build stopped: subcommand failed.


```