### PR TITLE
Fix compiling and linking config for macOS

### DIFF
--- a/compiler+runtime/CMakeLists.txt
+++ b/compiler+runtime/CMakeLists.txt
@@ -62,6 +62,7 @@ endif()
 
 set(
   jank_aot_compiler_flags
+  $<$<PLATFORM_ID:Darwin>:-I/opt/homebrew/include>
   -Wall -Wextra -Wpedantic
   -Wfloat-equal -Wuninitialized -Wswitch-enum -Wnon-virtual-dtor
   -Wold-style-cast -Wno-gnu-case-range
@@ -95,6 +96,7 @@ set(
 
 set(
   jank_linker_flags
+  $<$<PLATFORM_ID:Darwin>:-L/opt/homebrew/lib>
   #-stdlib=libc++ -lc++abi
   )
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -244,6 +246,7 @@ target_link_libraries(
   readline
   clangInterpreter
   Boost::boost
+  $<$<PLATFORM_ID:Darwin>:crypto>
 )
 
 jank_hook_llvm(jank_lib)

--- a/compiler+runtime/doc/build.md
+++ b/compiler+runtime/doc/build.md
@@ -41,6 +41,11 @@ cd -
 export CC=$PWD/build/llvm-install/usr/local/bin/clang; export CXX=$PWD/build/llvm-install/usr/local/bin/clang++
 ```
 
+On macOS also do this:
+```
+export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
+```
+
 At this point, you're ready to build jank.
 
 


### PR DESCRIPTION
Fixes #86 as discussed there.

I built clang and jank from scratch with the updated CMakeLists.txt and following the udpated instructions for macOS without any problems now.