### PR TITLE
Compile and run on Mac OS 15.1 (Sequoia)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ CMakeUserPresets.json
 
 # Rust
 rust/jank
+/compiler+runtime/llvm-build/
+/compiler+runtime/llvm-install/
+/compiler+runtime/llvm/

--- a/compiler+runtime/CMakeLists.txt
+++ b/compiler+runtime/CMakeLists.txt
@@ -62,7 +62,6 @@ endif()
 
 set(
   jank_aot_compiler_flags
-  $<$<PLATFORM_ID:Darwin>:-I/opt/homebrew/include>
   -Wall -Wextra -Wpedantic
   -Wfloat-equal -Wuninitialized -Wswitch-enum -Wnon-virtual-dtor
   -Wold-style-cast -Wno-gnu-case-range
@@ -82,6 +81,7 @@ set(
   -w
 )
 
+
 # TODO: Remove FMT_HEADER_ONLY once the extern template Clang bug is fixed.
 set(
   jank_common_compiler_flags
@@ -98,6 +98,8 @@ set(
   jank_linker_flags
   $<$<PLATFORM_ID:Darwin>:-L/opt/homebrew/lib>
   #-stdlib=libc++ -lc++abi
+  ${CMAKE_SOURCE_DIR}/llvm-install/usr/local/lib/libunwind.a
+  ${CMAKE_SOURCE_DIR}/llvm-install/usr/local/lib/libc++abi.a
   )
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   list(APPEND jank_common_compiler_flags #-Werror
@@ -247,6 +249,8 @@ target_link_libraries(
   clangInterpreter
   Boost::boost
   $<$<PLATFORM_ID:Darwin>:crypto>
+  ${CMAKE_SOURCE_DIR}/llvm-install/usr/local/lib/libunwind.a
+  ${CMAKE_SOURCE_DIR}/llvm-install/usr/local/lib/libc++abi.a
 )
 
 jank_hook_llvm(jank_lib)
@@ -270,6 +274,13 @@ foreach(dir ${jank_lib_includes})
     string(APPEND jank_lib_includes_str "-isystem ${dir} ")
   endif()
 endforeach()
+target_include_directories(
+    jank_lib
+    SYSTEM
+    PUBLIC
+    "$<$<PLATFORM_ID:Darwin>:/opt/homebrew/include>"
+)
+
 
 target_compile_options(
   jank_lib

--- a/compiler+runtime/bin/build-clang
+++ b/compiler+runtime/bin/build-clang
@@ -10,28 +10,28 @@ make_j="$(nproc || echo 4)"
 
 while getopts ":hj:" opt; do
   case "${opt}" in
-    h)
-      echo "Usage ${0} [-j N] [srcdir]"
-      exit 0
-      ;;
-    j)
-      make_j="${OPTARG}"
-      ;;
-    \?)
-      echo "Invalid option: ${OPTARG}" 1>&2
-      exit 1
-      ;;
-    :)
-      echo "Invalid option: ${OPTARG} requires an argument" 1>&2
-      exit 1
-      ;;
-    *)
-      echo "Unexpected input: ${OPTARG}" 1>&2
-      exit 1
-      ;;
+  h)
+    echo "Usage ${0} [-j N] [srcdir]"
+    exit 0
+    ;;
+  j)
+    make_j="${OPTARG}"
+    ;;
+  \?)
+    echo "Invalid option: ${OPTARG}" 1>&2
+    exit 1
+    ;;
+  :)
+    echo "Invalid option: ${OPTARG} requires an argument" 1>&2
+    exit 1
+    ;;
+  *)
+    echo "Unexpected input: ${OPTARG}" 1>&2
+    exit 1
+    ;;
   esac
 done
-shift $((OPTIND -1))
+shift $((OPTIND - 1))
 
 echo "Using ${make_j} cores to build"
 
@@ -40,31 +40,29 @@ srcdir="${PWD}"
 llvm_url="https://github.com/jank-lang/llvm-project.git"
 llvm_branch="main"
 
-function prepare()
-{
-  if [[ ! -d "${srcdir}/llvm" ]];
-  then
+function prepare() {
+  if [[ ! -d "${srcdir}/llvm" ]]; then
     git clone -b "${llvm_branch}" --shallow-submodules --single-branch "${llvm_url}" "${srcdir}"/llvm
   fi
 }
 
-function build()
-{
+function build() {
   mkdir -p "${srcdir}/llvm-build"
   cd "${srcdir}/llvm-build"
 
   cmake -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_CXX_STANDARD=20 \
-        -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra" \
-        -DLLVM_TARGETS_TO_BUILD="host" \
-        -DLLVM_ENABLE_EH=OFF \
-        -DLLVM_ENABLE_RTTI=OFF \
-        -DLLVM_INCLUDE_BENCHMARKS=OFF \
-        -DLLVM_INCLUDE_EXAMPLES=OFF \
-        -DLLVM_INCLUDE_TESTS=OFF \
-        -DLLVM_ENABLE_ZSTD=OFF \
-        -G "Unix Makefiles" \
-        ../llvm/llvm
+    -DLLVM_ENABLE_RUNTIMES=all \
+    -DCMAKE_CXX_STANDARD=20 \
+    -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra" \
+    -DLLVM_TARGETS_TO_BUILD="host" \
+    -DLLVM_ENABLE_EH=OFF \
+    -DLLVM_ENABLE_RTTI=OFF \
+    -DLLVM_INCLUDE_BENCHMARKS=OFF \
+    -DLLVM_INCLUDE_EXAMPLES=OFF \
+    -DLLVM_INCLUDE_TESTS=OFF \
+    -DLLVM_ENABLE_ZSTD=OFF \
+    -G "Unix Makefiles" \
+    ../llvm/llvm
 
   DESTDIR="${srcdir}/llvm-install" make clang clang-repl clang-cpp clang-tidy install -j"${make_j}"
 }


### PR DESCRIPTION
### Summary
Compile and test jank on a MacOS system

### Context
jank would not compile on Mac OS 15.1 (Sequoia).

### Changes Made
* Moved /opt/homebrew/include as the last preprocessor dependency
*  Built libunwind.a and libc++abi.a in llvm-install subdirectory
* Added libraries to link dependencies
