### PR TITLE
Add support for ratio

### DIFF
--- a/compiler+runtime/bin/build-clang
+++ b/compiler+runtime/bin/build-clang
@@ -54,7 +54,7 @@ function build()
   cd "${srcdir}/llvm-build"
 
   cmake -DCMAKE_BUILD_TYPE=Release \
-	-DLLVM_ENABLE_RUNTIMES=all \
+        -DLLVM_ENABLE_RUNTIMES=all \
         -DCMAKE_CXX_STANDARD=20 \
         -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra" \
         -DLLVM_TARGETS_TO_BUILD="host" \

--- a/compiler+runtime/include/cpp/jank/read/lex.hpp
+++ b/compiler+runtime/include/cpp/jank/read/lex.hpp
@@ -42,11 +42,21 @@ namespace jank::read::lex
     integer,
     /* Has double data. */
     real,
+    /* Has two integer data. */
+    ratio,
     /* Has string data. */
     string,
     /* Has string data. */
     escaped_string,
     eof,
+  };
+
+  struct ratio
+  {
+    native_integer numerator{};
+    native_integer denominator{};
+    native_bool operator==(ratio const &rhs) const;
+    native_bool operator!=(ratio const &rhs) const;
   };
 
   struct token
@@ -65,6 +75,7 @@ namespace jank::read::lex
     token(size_t const p, size_t const s, token_kind const k, native_persistent_string_view const);
     token(size_t const p, size_t const s, token_kind const k, char const * const);
     token(size_t const p, size_t const s, token_kind const k, native_bool const);
+    token(size_t const p, size_t const s, token_kind const k, ratio const);
 
     native_bool operator==(token const &rhs) const;
     native_bool operator!=(token const &rhs) const;
@@ -81,12 +92,18 @@ namespace jank::read::lex
     size_t pos{ ignore_pos };
     size_t size{ 1 };
     token_kind kind{ token_kind::eof };
-    boost::variant<no_data, native_integer, native_real, native_persistent_string_view, native_bool>
+    boost::variant<no_data,
+                   native_integer,
+                   native_real,
+                   native_persistent_string_view,
+                   native_bool,
+                   ratio>
       data;
   };
 
   std::ostream &operator<<(std::ostream &os, token const &t);
   std::ostream &operator<<(std::ostream &os, token::no_data const &t);
+  std::ostream &operator<<(std::ostream &os, ratio const &t);
 }
 
 namespace jank::read
@@ -142,6 +159,8 @@ namespace jank::read::lex
     size_t pos{};
     /* Whether or not the previous token requires a space after it. */
     native_bool require_space{};
+    /* True when seeing a '/' following a number. */
+    native_bool found_slash_after_number{};
     native_persistent_string_view file;
   };
 }

--- a/compiler+runtime/include/cpp/jank/read/parse.hpp
+++ b/compiler+runtime/include/cpp/jank/read/parse.hpp
@@ -107,6 +107,7 @@ namespace jank::read::parse
     object_result parse_boolean();
     object_result parse_keyword();
     object_result parse_integer();
+    object_result parse_ratio();
     object_result parse_real();
     object_result parse_string();
     object_result parse_escaped_string();

--- a/compiler+runtime/include/cpp/jank/runtime/behavior/comparable.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/behavior/comparable.hpp
@@ -4,7 +4,7 @@ namespace jank::runtime::behavior
 {
   template <typename T>
   concept comparable = requires(T * const t) {
-      /* Returns how this object compares to the specified object. Comparison, unlike equality,
+    /* Returns how this object compares to the specified object. Comparison, unlike equality,
        * can only be done for objects of the same type. If there's a type mismatch, this function
        * is expected to throw. There are three cases to handle:
        *
@@ -14,6 +14,6 @@ namespace jank::runtime::behavior
        *
        * For sequences, all values need to be considered for comparison.
        */
-      { t->compare(std::declval<object const &>()) } -> std::convertible_to<native_integer>;
+    { t->compare(std::declval<object const &>()) } -> std::convertible_to<native_integer>;
   };
 }

--- a/compiler+runtime/include/cpp/jank/runtime/core/make_box.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core/make_box.hpp
@@ -35,7 +35,6 @@ namespace jank::runtime
   {
     return make_box<runtime::obj::integer>(static_cast<native_integer>(i));
   }
-
   [[gnu::always_inline, gnu::flatten, gnu::hot]]
   inline auto make_box(native_integer const i)
   {

--- a/compiler+runtime/include/cpp/jank/runtime/core/make_box.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core/make_box.hpp
@@ -35,6 +35,7 @@ namespace jank::runtime
   {
     return make_box<runtime::obj::integer>(static_cast<native_integer>(i));
   }
+
   [[gnu::always_inline, gnu::flatten, gnu::hot]]
   inline auto make_box(native_integer const i)
   {

--- a/compiler+runtime/src/cpp/jank/analyze/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/analyze/processor.cpp
@@ -837,8 +837,7 @@ namespace jank::analyze
     }
 
     auto const condition(o->data.rest().first().unwrap());
-    auto condition_expr(
-      analyze(condition, current_frame, expression_type::nested, fn_ctx, false));
+    auto condition_expr(analyze(condition, current_frame, expression_type::nested, fn_ctx, false));
     if(condition_expr.is_err())
     {
       return condition_expr.expect_err_move();
@@ -1402,8 +1401,7 @@ namespace jank::analyze
         return found_special->second(o, current_frame, expr_type, fn_ctx, needs_box);
       }
 
-      auto sym_result(
-        analyze_symbol(sym, current_frame, expression_type::nested, fn_ctx, true));
+      auto sym_result(analyze_symbol(sym, current_frame, expression_type::nested, fn_ctx, true));
       if(sym_result.is_err())
       {
         return sym_result;
@@ -1466,8 +1464,7 @@ namespace jank::analyze
     }
     else
     {
-      auto callable_expr(
-        analyze(first, current_frame, expression_type::nested, fn_ctx, needs_box));
+      auto callable_expr(analyze(first, current_frame, expression_type::nested, fn_ctx, needs_box));
       if(callable_expr.is_err())
       {
         return callable_expr;

--- a/compiler+runtime/src/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/src/cpp/jank/read/lex.cpp
@@ -154,6 +154,24 @@ namespace jank::read
     {
     }
 
+    token::token(size_t const p, size_t const s, token_kind const k, ratio const d)
+      : pos{ p }
+      , size{ s }
+      , kind{ k }
+      , data{ d }
+    {
+    }
+
+    native_bool ratio::operator==(ratio const &rhs) const
+    {
+      return numerator == rhs.numerator && denominator == rhs.denominator;
+    }
+
+    native_bool ratio::operator!=(ratio const &rhs) const
+    {
+      return !(*this == rhs);
+    }
+
     native_bool token::no_data::operator==(no_data const &) const
     {
       return true;
@@ -184,6 +202,11 @@ namespace jank::read
     std::ostream &operator<<(std::ostream &os, token::no_data const &)
     {
       return os << "<no data>";
+    }
+
+    std::ostream &operator<<(std::ostream &os, ratio const &r)
+    {
+      return os << r.numerator << "/" << r.denominator;
     }
 
     processor::processor(native_persistent_string_view const &f)
@@ -405,6 +428,33 @@ namespace jank::read
                   return err(error{ token_start, pos, "invalid number" });
                 }
                 found_exponent_sign = true;
+              }
+              else if(c == '/')
+              {
+                require_space = false;
+                ++pos;
+                if(found_exponent_sign || is_scientific || expecting_exponent || contains_dot
+                   || found_slash_after_number)
+                {
+                  return err(error{ token_start, pos, "invalid ratio" });
+                }
+                found_slash_after_number = true;
+                /* skip the '/' char and look for the denominator number. */
+                ++pos;
+                auto const denominator(next());
+                if(denominator.is_ok() && denominator.expect_ok().kind == token_kind::integer)
+                {
+                  auto const &denominator_token(denominator.expect_ok());
+                  found_slash_after_number = false;
+                  return ok(
+                    token(token_start,
+                          pos - token_start,
+                          token_kind::ratio,
+                          { .numerator = std::strtoll(file.data() + token_start, nullptr, 10),
+                            .denominator = boost::get<native_integer>(denominator_token.data) }));
+                }
+                return err(
+                  error{ token_start, pos, "invalid ratio: expecting an integer denominator" });
               }
               else if(std::isdigit(c) == 0)
               {

--- a/compiler+runtime/src/cpp/jank/read/parse.cpp
+++ b/compiler+runtime/src/cpp/jank/read/parse.cpp
@@ -182,6 +182,8 @@ namespace jank::read::parse
           return parse_integer();
         case lex::token_kind::real:
           return parse_real();
+        case lex::token_kind::ratio:
+          return parse_ratio();
         case lex::token_kind::string:
           return parse_string();
         case lex::token_kind::escaped_string:
@@ -1162,6 +1164,21 @@ namespace jank::read::parse
     auto const token(token_current->expect_ok());
     ++token_current;
     return object_source_info{ make_box<obj::integer>(boost::get<native_integer>(token.data)),
+                               token,
+                               token };
+  }
+
+  processor::object_result processor::parse_ratio()
+  {
+    auto const token(token_current->expect_ok());
+    ++token_current;
+    auto const &ratio_data(boost::get<lex::ratio>(token.data));
+    if(ratio_data.denominator == 0)
+    {
+      return err(error{ token.pos, "Divide by zero" });
+    }
+    return object_source_info{ make_box<obj::real>(static_cast<native_real>(ratio_data.numerator)
+                                                   / ratio_data.denominator),
                                token,
                                token };
   }

--- a/compiler+runtime/test/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/test/cpp/jank/read/lex.cpp
@@ -393,949 +393,948 @@ namespace jank::read::lex
               == make_tokens({
                 { 0, 4, token_kind::ratio, { .numerator = -4, .denominator = 5 } }
         }));
-        SUBCASE("Success - -x/-x")
-        {
-          processor p{ "-4/-5" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, 5, token_kind::ratio, { .numerator = -4, .denominator = -5 } }
-          }));
-        }
-        SUBCASE("Failures - x//x")
-        {
-          processor p{ "4//5" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_results(
-                  { { error(0, 4, "invalid ratio: expecting an integer denominator") } }));
-        }
-        SUBCASE("Failures - x/x/x")
-        {
-          processor p{ "4/5/4" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(
-            tokens
-            == make_results({ { error(0, 3, "invalid ratio: expecting an integer denominator") },
-                              { error(3, 3, "invalid symbol") } }));
-        }
-        SUBCASE("Failures - x/x/x/x")
-        {
-          processor p{ "4/5/4/5/6/7/7" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(
-            tokens
-            == make_results({ { error(0, 3, "invalid ratio: expecting an integer denominator") },
-                              { error(3, 3, "invalid symbol") } }));
-        }
-        SUBCASE("Failures - x.x/x")
-        {
-          processor p{ "4.4/5" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_results(
-                  { { error(0, 3, "invalid ratio") }, { error(3, 3, "invalid symbol") } }));
-        }
-        SUBCASE("Failures - x/x.x")
-        {
-          processor p{ "4/5.9" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_results(
-                  { { error(0, 5, "invalid ratio: expecting an integer denominator") } }));
-        }
       }
-      TEST_CASE("Integer")
+      SUBCASE("Success - -x/-x")
       {
-        SUBCASE("Positive single-char")
-        {
-          processor p{ "0" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, token_kind::integer, 0ll }
-          }));
-        }
-
-        SUBCASE("Positive multi-char")
-        {
-          processor p{ "1234" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, 4, token_kind::integer, 1234ll }
-          }));
-        }
-
-        SUBCASE("Negative single-char")
-        {
-          processor p{ "-1" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, 2, token_kind::integer, -1ll }
-          }));
-        }
-
-        SUBCASE("Negative multi-char")
-        {
-          processor p{ "-1234" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, 5, token_kind::integer, -1234ll }
-          }));
-        }
-
-        SUBCASE("Expect space")
-        {
-          SUBCASE("Required")
-          {
-            processor p{ "1234abc" };
-            native_vector<result<token, error>> tokens(p.begin(), p.end());
-            CHECK(tokens
-                  == make_results({
-                    token{ 0, 4, token_kind::integer, 1234ll },
-                    error{ 4, "expected whitespace before next token" },
-                    token{ 4, 3, token_kind::symbol, "abc"sv },
-            }));
-          }
-
-          SUBCASE("Not required")
-          {
-            processor p{ "(1234)" };
-            native_vector<result<token, error>> tokens(p.begin(), p.end());
-            CHECK(tokens
-                  == make_results({
-                    token{ 0, token_kind::open_paren },
-                    token{ 1, 4, token_kind::integer, 1234ll },
-                    token{ 5, token_kind::close_paren },
-            }));
-          }
-        }
+        processor p{ "-4/-5" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 5, token_kind::ratio, { .numerator = -4, .denominator = -5 } }
+        }));
       }
-
-      TEST_CASE("Real")
+      SUBCASE("Failures - x//x")
       {
-        SUBCASE("Positive 0.")
-        {
-          processor p{ "0." };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, 2, token_kind::real, 0.0l }
-          }));
-        }
-
-        SUBCASE("Positive 0.0")
-        {
-          processor p{ "0.0" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, 3, token_kind::real, 0.0l }
-          }));
-        }
-
-        SUBCASE("Negative 1.")
-        {
-          processor p{ "-1." };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, 3, token_kind::real, -1.0l }
-          }));
-        }
-
-        SUBCASE("Negative 1.5")
-        {
-          processor p{ "-1.5" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, 4, token_kind::real, -1.5l }
-          }));
-        }
-
-        SUBCASE("Negative multi-char")
-        {
-          processor p{ "-1234.1234" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, 10, token_kind::real, -1234.1234l }
-          }));
-        }
-
-        SUBCASE("Positive no leading digit")
-        {
-          processor p{ ".0" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_results({
-                  error{ 0, "unexpected character: ." },
-                  token{ 1, token_kind::integer, 0ll },
-          }));
-        }
-
-        SUBCASE("Negative no leading digit")
-        {
-          processor p{ "-.0" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_results({
-                  error{ 0, 1, "invalid number" },
-                  error{ 1, "unexpected character: ." },
-                  token{ 2, token_kind::integer, 0ll },
-          }));
-        }
-
-        SUBCASE("Too many dots")
-        {
-          {
-            processor p{ "0.0." };
-            native_vector<result<token, error>> tokens(p.begin(), p.end());
-            CHECK(tokens
-                  == make_results({
-                    error{ 0, 3, "invalid number" },
-                    error{ 3, "unexpected character: ." },
-            }));
-          }
-
-          {
-            processor p{ "0..0" };
-            native_vector<result<token, error>> tokens(p.begin(), p.end());
-            CHECK(tokens
-                  == make_results({
-                    error{ 0, 2, "invalid number" },
-                    error{ 2, "unexpected character: ." },
-                    token{ 3, token_kind::integer, 0ll },
-            }));
-          }
-          {
-            processor p{ "0.0.0" };
-            native_vector<result<token, error>> tokens(p.begin(), p.end());
-            CHECK(tokens
-                  == make_results({
-                    error{ 0, 3, "invalid number" },
-                    error{ 3, "unexpected character: ." },
-                    token{ 4, token_kind::integer, 0ll },
-            }));
-          }
-        }
-
-        SUBCASE("Expect space")
-        {
-          SUBCASE("Required")
-          {
-            processor p{ "12.34abc" };
-            native_vector<result<token, error>> tokens(p.begin(), p.end());
-            CHECK(tokens
-                  == make_results({
-                    token{ 0, 5, token_kind::real, 12.34l },
-                    error{ 5, "expected whitespace before next token" },
-                    token{ 5, 3, token_kind::symbol, "abc"sv },
-            }));
-          }
-
-          SUBCASE("Not required")
-          {
-            processor p{ "(12.34)" };
-            native_vector<result<token, error>> tokens(p.begin(), p.end());
-            CHECK(tokens
-                  == make_results({
-                    token{ 0, token_kind::open_paren },
-                    token{ 1, 5, token_kind::real, 12.34l },
-                    token{ 6, token_kind::close_paren },
-            }));
-          }
-        }
-
-        SUBCASE("Scientific notation")
-        {
-          SUBCASE("Valid")
-          {
-            processor p{ "1e3 -1e2 2.E-3 22.3e-8 -12E+18\\a" };
-            native_vector<result<token, error>> tokens(p.begin(), p.end());
-            CHECK(tokens
-                  == make_results({
-                    token{  0, 3,      token_kind::real,   1000.0l },
-                    token{  4, 4,      token_kind::real,   -100.0l },
-                    token{  9, 5,      token_kind::real,    0.002l },
-                    token{ 15, 7,      token_kind::real, 2.23e-07l },
-                    token{ 23, 7,      token_kind::real, -1.2e+19l },
-                    token{ 30, 2, token_kind::character,   "\\a"sv },
-            }));
-          }
-
-          SUBCASE("Missing exponent")
-          {
-            processor p{ "1e 23E-1 12e- -0.2e" };
-            native_vector<result<token, error>> tokens(p.begin(), p.end());
-            CHECK(tokens
-                  == make_results({
-                    error{ 0, 2, "unexpected end of real, expecting exponent" },
-                    token{ 3, 5, token_kind::real, 2.3l },
-                    error{ 9, 13, "unexpected end of real, expecting exponent" },
-                    error{ 14, 19, "unexpected end of real, expecting exponent" },
-            }));
-          }
-
-          SUBCASE("Signs after exponent found")
-          {
-            processor p{ "12.3 -1e3- 2.3E+" };
-            native_vector<result<token, error>> tokens(p.begin(), p.end());
-            CHECK(tokens
-                  == make_results({
-                    token{ 0, 4, token_kind::real, 12.3l },
-                    error{ 5, 9, "invalid number" },
-                    error{ 9, "expected whitespace before next token" },
-                    token{ 9, token_kind::symbol, "-"sv },
-                    error{ 11, 16, "unexpected end of real, expecting exponent" },
-            }));
-          }
-
-          SUBCASE("Extra dots")
-          {
-            processor p{ "1e3. 12.3 -1e4.3" };
-            native_vector<result<token, error>> tokens(p.begin(), p.end());
-            CHECK(tokens
-                  == make_results({
-                    error{ 0, 3, "invalid number" },
-                    error{ 3, "unexpected character: ." },
-                    token{ 5, 4, token_kind::real, 12.3l },
-                    error{ 10, 14, "invalid number" },
-                    error{ 14, "unexpected character: ." },
-                    error{ 15, "expected whitespace before next token" },
-                    token{ 15, token_kind::integer, 3ll },
-            }));
-          }
-
-          SUBCASE("Extra characters in exponent")
-          {
-            processor p{ "2.ee4 -1e4E3 1.eFoo 3E5fOo" };
-            native_vector<result<token, error>> tokens(p.begin(), p.end());
-            CHECK(tokens
-                  == make_results({
-                    error{ 0, 3, "invalid number" },
-                    token{ 3, 2, token_kind::symbol, "e4"sv },
-                    error{ 6, 10, "invalid number" },
-                    error{ 10, "expected whitespace before next token" },
-                    token{ 10, 2, token_kind::symbol, "E3"sv },
-                    error{ 13, 16, "unexpected end of real, expecting exponent" },
-                    error{ 16, "expected whitespace before next token" },
-                    token{ 16, 3, token_kind::symbol, "Foo"sv },
-                    token{ 20, 3, token_kind::real, 300000.0l },
-                    error{ 23, "expected whitespace before next token" },
-                    token{ 23, 3, token_kind::symbol, "fOo"sv },
-            }));
-          }
-        }
+        processor p{ "4//5" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(
+          tokens
+          == make_results({ { error(0, 4, "invalid ratio: expecting an integer denominator") } }));
       }
-
-      TEST_CASE("Character")
+      SUBCASE("Failures - x/x/x")
       {
-        SUBCASE("Whitespace after \\")
-        {
-          processor p{ R"(\ )" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_results({ { error(0, "Expecting a valid character literal after \\") } }));
-        }
-
-        SUBCASE("Dangling \\")
-        {
-          processor p{ R"(\)" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_results({ { error(0, "Expecting a valid character literal after \\") } }));
-        }
-
-        SUBCASE("Alphabetic")
-        {
-          processor p{ R"(\a)" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, 2, token_kind::character, "\\a"sv }
-          }));
-        }
-
-        SUBCASE("Numeric")
-        {
-          processor p{ R"(\1)" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, 2, token_kind::character, "\\1"sv }
-          }));
-        }
-
-        SUBCASE("Multiple characters after \\")
-        {
-          processor p{ R"(\11)" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, 3, token_kind::character, "\\11"sv }
-          }));
-        }
-
-        SUBCASE("Invalid symbol after a valid char")
-        {
-          processor p{ R"(\1:)" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_results({
-                  token{ 0, 2, token_kind::character, "\\1"sv },
-                  error{ 2, "invalid keyword: expected non-whitespace character after :" }
-          }));
-        }
-
-        SUBCASE("Valid consecutive characters")
-        {
-          processor p{ R"(\1 \newline\' \\)" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  {  0, 2, token_kind::character,       "\\1"sv },
-                  {  3, 8, token_kind::character, "\\newline"sv },
-                  { 11, 2, token_kind::character,       "\\'"sv },
-                  { 14, 2, token_kind::character,      "\\\\"sv }
-          }));
-        }
-
-        SUBCASE("Character followed by a backticked keyword")
-        {
-          processor p{ R"(\a`:kw)" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_results({
-                  token{ 0, 2, token_kind::character, "\\a"sv },
-                  token{ 2, token_kind::syntax_quote },
-                  token{ 3, 3, token_kind::keyword, "kw"sv }
-          }));
-        }
+        processor p{ "4/5/4" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({ { error(0, 3, "invalid ratio: expecting an integer denominator") },
+                                { error(3, 3, "invalid symbol") } }));
       }
-
-      TEST_CASE("Symbol")
+      SUBCASE("Failures - x/x/x/x")
       {
-        SUBCASE("Single-char")
-        {
-          processor p{ "a" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, token_kind::symbol, "a"sv }
-          }));
-        }
-
-        SUBCASE("Multi-char")
-        {
-          processor p{ "abc" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, 3, token_kind::symbol, "abc"sv }
-          }));
-        }
-
-        SUBCASE("Single slash")
-        {
-          processor p{ "/" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, token_kind::symbol, "/"sv }
-          }));
-        }
-
-        SUBCASE("Multi slash")
-        {
-          processor p{ "//" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_results({
-                  error{ 0, "invalid symbol" },
-          }));
-        }
-
-        SUBCASE("Starting with a slash")
-        {
-          processor p{ "/foo" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_results({
-                  error{ 0, "invalid symbol" },
-          }));
-        }
-
-        SUBCASE("With numbers")
-        {
-          processor p{ "abc123" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, 6, token_kind::symbol, "abc123"sv }
-          }));
-        }
-
-        SUBCASE("With other symbols")
-        {
-          processor p{ "abc_.123/-foo+?=!&<>#%" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, 22, token_kind::symbol, "abc_.123/-foo+?=!&<>#%"sv }
-          }));
-        }
-
-        SUBCASE("Only -")
-        {
-          processor p{ "-" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, token_kind::symbol, "-"sv }
-          }));
-        }
-
-        SUBCASE("Starting with -")
-        {
-          processor p{ "-main" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, 5, token_kind::symbol, "-main"sv }
-          }));
-        }
-
-        SUBCASE("Quoted")
-        {
-          processor p{ "'foo" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, token_kind::single_quote },
-                  { 1, 3, token_kind::symbol, "foo"sv }
-          }));
-        }
+        processor p{ "4/5/4/5/6/7/7" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({ { error(0, 3, "invalid ratio: expecting an integer denominator") },
+                                { error(3, 3, "invalid symbol") } }));
       }
-
-      TEST_CASE("Keyword")
+      SUBCASE("Failures - x.x/x")
       {
-        SUBCASE("Single-char")
-        {
-          processor p{ ":a" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, 2, token_kind::keyword, "a"sv }
-          }));
-        }
+        processor p{ "4.4/5" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(
+          tokens
+          == make_results({ { error(0, 3, "invalid ratio") }, { error(3, 3, "invalid symbol") } }));
+      }
+      SUBCASE("Failures - x/x.x")
+      {
+        processor p{ "4/5.9" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(
+          tokens
+          == make_results({ { error(0, 5, "invalid ratio: expecting an integer denominator") } }));
+      }
+    }
+    TEST_CASE("Integer")
+    {
+      SUBCASE("Positive single-char")
+      {
+        processor p{ "0" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, token_kind::integer, 0ll }
+        }));
+      }
 
-        SUBCASE("Multi-char")
-        {
-          processor p{ ":abc" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, 4, token_kind::keyword, "abc"sv }
-          }));
-        }
+      SUBCASE("Positive multi-char")
+      {
+        processor p{ "1234" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 4, token_kind::integer, 1234ll }
+        }));
+      }
 
-        SUBCASE("Whitespace after :")
+      SUBCASE("Negative single-char")
+      {
+        processor p{ "-1" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 2, token_kind::integer, -1ll }
+        }));
+      }
+
+      SUBCASE("Negative multi-char")
+      {
+        processor p{ "-1234" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 5, token_kind::integer, -1234ll }
+        }));
+      }
+
+      SUBCASE("Expect space")
+      {
+        SUBCASE("Required")
         {
-          processor p{ ": " };
+          processor p{ "1234abc" };
           native_vector<result<token, error>> tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_results({
-                  error{ 0, "invalid keyword: expected non-whitespace character after :" }
+                  token{ 0, 4, token_kind::integer, 1234ll },
+                  error{ 4, "expected whitespace before next token" },
+                  token{ 4, 3, token_kind::symbol, "abc"sv },
           }));
         }
 
-        SUBCASE("Single slash")
+        SUBCASE("Not required")
         {
-          processor p{ ":/" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, 2, token_kind::keyword, "/"sv }
-          }));
-        }
-
-        SUBCASE("Multi slash")
-        {
-          processor p{ "://" };
+          processor p{ "(1234)" };
           native_vector<result<token, error>> tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_results({
-                  error{ 0, "invalid keyword: starts with /" },
+                  token{ 0, token_kind::open_paren },
+                  token{ 1, 4, token_kind::integer, 1234ll },
+                  token{ 5, token_kind::close_paren },
           }));
         }
+      }
+    }
 
-        SUBCASE("Starting with a slash")
+    TEST_CASE("Real")
+    {
+      SUBCASE("Positive 0.")
+      {
+        processor p{ "0." };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 2, token_kind::real, 0.0l }
+        }));
+      }
+
+      SUBCASE("Positive 0.0")
+      {
+        processor p{ "0.0" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 3, token_kind::real, 0.0l }
+        }));
+      }
+
+      SUBCASE("Negative 1.")
+      {
+        processor p{ "-1." };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 3, token_kind::real, -1.0l }
+        }));
+      }
+
+      SUBCASE("Negative 1.5")
+      {
+        processor p{ "-1.5" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 4, token_kind::real, -1.5l }
+        }));
+      }
+
+      SUBCASE("Negative multi-char")
+      {
+        processor p{ "-1234.1234" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 10, token_kind::real, -1234.1234l }
+        }));
+      }
+
+      SUBCASE("Positive no leading digit")
+      {
+        processor p{ ".0" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error{ 0, "unexpected character: ." },
+                token{ 1, token_kind::integer, 0ll },
+        }));
+      }
+
+      SUBCASE("Negative no leading digit")
+      {
+        processor p{ "-.0" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error{ 0, 1, "invalid number" },
+                error{ 1, "unexpected character: ." },
+                token{ 2, token_kind::integer, 0ll },
+        }));
+      }
+
+      SUBCASE("Too many dots")
+      {
         {
-          processor p{ ":/foo" };
+          processor p{ "0.0." };
           native_vector<result<token, error>> tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_results({
-                  error{ 0, "invalid keyword: starts with /" },
+                  error{ 0, 3, "invalid number" },
+                  error{ 3, "unexpected character: ." },
           }));
         }
 
-        SUBCASE("With numbers")
         {
-          processor p{ ":abc123" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, 7, token_kind::keyword, "abc123"sv }
-          }));
-        }
-
-        SUBCASE("With other symbols")
-        {
-          processor p{ ":abc_.123/-foo+?=!&<>" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, 21, token_kind::keyword, "abc_.123/-foo+?=!&<>"sv }
-          }));
-        }
-
-        SUBCASE("Auto-resolved unqualified")
-        {
-          processor p{ "::foo-bar" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, 9, token_kind::keyword, ":foo-bar"sv }
-          }));
-        }
-
-        SUBCASE("Auto-resolved qualified")
-        {
-          processor p{ "::foo/bar" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, 9, token_kind::keyword, ":foo/bar"sv }
-          }));
-        }
-
-        SUBCASE("Too many starting colons")
-        {
-          processor p{ ":::foo" };
+          processor p{ "0..0" };
           native_vector<result<token, error>> tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_results({
-                  error{ 0, "invalid keyword: incorrect number of :" },
-                  error{ 2, "expected whitespace before next token" },
-                  token{ 2, 4, token_kind::keyword, "foo"sv }
+                  error{ 0, 2, "invalid number" },
+                  error{ 2, "unexpected character: ." },
+                  token{ 3, token_kind::integer, 0ll },
           }));
         }
-
-        SUBCASE("Way too many starting colons")
         {
-          processor p{ "::::foo" };
+          processor p{ "0.0.0" };
           native_vector<result<token, error>> tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_results({
-                  error{ 0, "invalid keyword: incorrect number of :" },
-                  error{ 2, "expected whitespace before next token" },
-                  token{ 2, 5, token_kind::keyword, ":foo"sv }
+                  error{ 0, 3, "invalid number" },
+                  error{ 3, "unexpected character: ." },
+                  token{ 4, token_kind::integer, 0ll },
           }));
         }
       }
 
-      TEST_CASE("String")
+      SUBCASE("Expect space")
+      {
+        SUBCASE("Required")
+        {
+          processor p{ "12.34abc" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_results({
+                  token{ 0, 5, token_kind::real, 12.34l },
+                  error{ 5, "expected whitespace before next token" },
+                  token{ 5, 3, token_kind::symbol, "abc"sv },
+          }));
+        }
+
+        SUBCASE("Not required")
+        {
+          processor p{ "(12.34)" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_results({
+                  token{ 0, token_kind::open_paren },
+                  token{ 1, 5, token_kind::real, 12.34l },
+                  token{ 6, token_kind::close_paren },
+          }));
+        }
+      }
+
+      SUBCASE("Scientific notation")
+      {
+        SUBCASE("Valid")
+        {
+          processor p{ "1e3 -1e2 2.E-3 22.3e-8 -12E+18\\a" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_results({
+                  token{  0, 3,      token_kind::real,   1000.0l },
+                  token{  4, 4,      token_kind::real,   -100.0l },
+                  token{  9, 5,      token_kind::real,    0.002l },
+                  token{ 15, 7,      token_kind::real, 2.23e-07l },
+                  token{ 23, 7,      token_kind::real, -1.2e+19l },
+                  token{ 30, 2, token_kind::character,   "\\a"sv },
+          }));
+        }
+
+        SUBCASE("Missing exponent")
+        {
+          processor p{ "1e 23E-1 12e- -0.2e" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_results({
+                  error{ 0, 2, "unexpected end of real, expecting exponent" },
+                  token{ 3, 5, token_kind::real, 2.3l },
+                  error{ 9, 13, "unexpected end of real, expecting exponent" },
+                  error{ 14, 19, "unexpected end of real, expecting exponent" },
+          }));
+        }
+
+        SUBCASE("Signs after exponent found")
+        {
+          processor p{ "12.3 -1e3- 2.3E+" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_results({
+                  token{ 0, 4, token_kind::real, 12.3l },
+                  error{ 5, 9, "invalid number" },
+                  error{ 9, "expected whitespace before next token" },
+                  token{ 9, token_kind::symbol, "-"sv },
+                  error{ 11, 16, "unexpected end of real, expecting exponent" },
+          }));
+        }
+
+        SUBCASE("Extra dots")
+        {
+          processor p{ "1e3. 12.3 -1e4.3" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_results({
+                  error{ 0, 3, "invalid number" },
+                  error{ 3, "unexpected character: ." },
+                  token{ 5, 4, token_kind::real, 12.3l },
+                  error{ 10, 14, "invalid number" },
+                  error{ 14, "unexpected character: ." },
+                  error{ 15, "expected whitespace before next token" },
+                  token{ 15, token_kind::integer, 3ll },
+          }));
+        }
+
+        SUBCASE("Extra characters in exponent")
+        {
+          processor p{ "2.ee4 -1e4E3 1.eFoo 3E5fOo" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_results({
+                  error{ 0, 3, "invalid number" },
+                  token{ 3, 2, token_kind::symbol, "e4"sv },
+                  error{ 6, 10, "invalid number" },
+                  error{ 10, "expected whitespace before next token" },
+                  token{ 10, 2, token_kind::symbol, "E3"sv },
+                  error{ 13, 16, "unexpected end of real, expecting exponent" },
+                  error{ 16, "expected whitespace before next token" },
+                  token{ 16, 3, token_kind::symbol, "Foo"sv },
+                  token{ 20, 3, token_kind::real, 300000.0l },
+                  error{ 23, "expected whitespace before next token" },
+                  token{ 23, 3, token_kind::symbol, "fOo"sv },
+          }));
+        }
+      }
+    }
+
+    TEST_CASE("Character")
+    {
+      SUBCASE("Whitespace after \\")
+      {
+        processor p{ R"(\ )" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({ { error(0, "Expecting a valid character literal after \\") } }));
+      }
+
+      SUBCASE("Dangling \\")
+      {
+        processor p{ R"(\)" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({ { error(0, "Expecting a valid character literal after \\") } }));
+      }
+
+      SUBCASE("Alphabetic")
+      {
+        processor p{ R"(\a)" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 2, token_kind::character, "\\a"sv }
+        }));
+      }
+
+      SUBCASE("Numeric")
+      {
+        processor p{ R"(\1)" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 2, token_kind::character, "\\1"sv }
+        }));
+      }
+
+      SUBCASE("Multiple characters after \\")
+      {
+        processor p{ R"(\11)" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 3, token_kind::character, "\\11"sv }
+        }));
+      }
+
+      SUBCASE("Invalid symbol after a valid char")
+      {
+        processor p{ R"(\1:)" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                token{ 0, 2, token_kind::character, "\\1"sv },
+                error{ 2, "invalid keyword: expected non-whitespace character after :" }
+        }));
+      }
+
+      SUBCASE("Valid consecutive characters")
+      {
+        processor p{ R"(\1 \newline\' \\)" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                {  0, 2, token_kind::character,       "\\1"sv },
+                {  3, 8, token_kind::character, "\\newline"sv },
+                { 11, 2, token_kind::character,       "\\'"sv },
+                { 14, 2, token_kind::character,      "\\\\"sv }
+        }));
+      }
+
+      SUBCASE("Character followed by a backticked keyword")
+      {
+        processor p{ R"(\a`:kw)" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                token{ 0, 2, token_kind::character, "\\a"sv },
+                token{ 2, token_kind::syntax_quote },
+                token{ 3, 3, token_kind::keyword, "kw"sv }
+        }));
+      }
+    }
+
+    TEST_CASE("Symbol")
+    {
+      SUBCASE("Single-char")
+      {
+        processor p{ "a" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, token_kind::symbol, "a"sv }
+        }));
+      }
+
+      SUBCASE("Multi-char")
+      {
+        processor p{ "abc" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 3, token_kind::symbol, "abc"sv }
+        }));
+      }
+
+      SUBCASE("Single slash")
+      {
+        processor p{ "/" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, token_kind::symbol, "/"sv }
+        }));
+      }
+
+      SUBCASE("Multi slash")
+      {
+        processor p{ "//" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error{ 0, "invalid symbol" },
+        }));
+      }
+
+      SUBCASE("Starting with a slash")
+      {
+        processor p{ "/foo" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error{ 0, "invalid symbol" },
+        }));
+      }
+
+      SUBCASE("With numbers")
+      {
+        processor p{ "abc123" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 6, token_kind::symbol, "abc123"sv }
+        }));
+      }
+
+      SUBCASE("With other symbols")
+      {
+        processor p{ "abc_.123/-foo+?=!&<>#%" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 22, token_kind::symbol, "abc_.123/-foo+?=!&<>#%"sv }
+        }));
+      }
+
+      SUBCASE("Only -")
+      {
+        processor p{ "-" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, token_kind::symbol, "-"sv }
+        }));
+      }
+
+      SUBCASE("Starting with -")
+      {
+        processor p{ "-main" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 5, token_kind::symbol, "-main"sv }
+        }));
+      }
+
+      SUBCASE("Quoted")
+      {
+        processor p{ "'foo" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, token_kind::single_quote },
+                { 1, 3, token_kind::symbol, "foo"sv }
+        }));
+      }
+    }
+
+    TEST_CASE("Keyword")
+    {
+      SUBCASE("Single-char")
+      {
+        processor p{ ":a" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 2, token_kind::keyword, "a"sv }
+        }));
+      }
+
+      SUBCASE("Multi-char")
+      {
+        processor p{ ":abc" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 4, token_kind::keyword, "abc"sv }
+        }));
+      }
+
+      SUBCASE("Whitespace after :")
+      {
+        processor p{ ": " };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error{ 0, "invalid keyword: expected non-whitespace character after :" }
+        }));
+      }
+
+      SUBCASE("Single slash")
+      {
+        processor p{ ":/" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 2, token_kind::keyword, "/"sv }
+        }));
+      }
+
+      SUBCASE("Multi slash")
+      {
+        processor p{ "://" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error{ 0, "invalid keyword: starts with /" },
+        }));
+      }
+
+      SUBCASE("Starting with a slash")
+      {
+        processor p{ ":/foo" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error{ 0, "invalid keyword: starts with /" },
+        }));
+      }
+
+      SUBCASE("With numbers")
+      {
+        processor p{ ":abc123" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 7, token_kind::keyword, "abc123"sv }
+        }));
+      }
+
+      SUBCASE("With other symbols")
+      {
+        processor p{ ":abc_.123/-foo+?=!&<>" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 21, token_kind::keyword, "abc_.123/-foo+?=!&<>"sv }
+        }));
+      }
+
+      SUBCASE("Auto-resolved unqualified")
+      {
+        processor p{ "::foo-bar" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 9, token_kind::keyword, ":foo-bar"sv }
+        }));
+      }
+
+      SUBCASE("Auto-resolved qualified")
+      {
+        processor p{ "::foo/bar" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 9, token_kind::keyword, ":foo/bar"sv }
+        }));
+      }
+
+      SUBCASE("Too many starting colons")
+      {
+        processor p{ ":::foo" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error{ 0, "invalid keyword: incorrect number of :" },
+                error{ 2, "expected whitespace before next token" },
+                token{ 2, 4, token_kind::keyword, "foo"sv }
+        }));
+      }
+
+      SUBCASE("Way too many starting colons")
+      {
+        processor p{ "::::foo" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error{ 0, "invalid keyword: incorrect number of :" },
+                error{ 2, "expected whitespace before next token" },
+                token{ 2, 5, token_kind::keyword, ":foo"sv }
+        }));
+      }
+    }
+
+    TEST_CASE("String")
+    {
+      SUBCASE("Empty")
+      {
+        processor p{ "\"\"" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 2, token_kind::string, ""sv }
+        }));
+      }
+      SUBCASE("Single-char")
+      {
+        processor p{ "\"a\"" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 3, token_kind::string, "a"sv }
+        }));
+      }
+
+      SUBCASE("Multi-char")
+      {
+        processor p{ "\"abc\"" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 5, token_kind::string, "abc"sv }
+        }));
+      }
+
+      SUBCASE("With numbers")
+      {
+        processor p{ "\"123\"" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 5, token_kind::string, "123"sv }
+        }));
+      }
+
+      SUBCASE("With other symbols")
+      {
+        processor p{ "\"and then() there was abc_123/-foo?!&<>\"" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 40, token_kind::string, "and then() there was abc_123/-foo?!&<>"sv }
+        }));
+      }
+
+      SUBCASE("With line breaks")
+      {
+        processor p{ "\"foo\nbar\nspam\t\"" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 15, token_kind::string, "foo\nbar\nspam\t"sv }
+        }));
+      }
+
+      SUBCASE("With escapes")
+      {
+        processor p{ R"("foo\"\nbar\nspam\t\r")" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 22, token_kind::escaped_string, "foo\\\"\\nbar\\nspam\\t\\r"sv }
+        }));
+
+        processor q{ R"("\??\' \\ a\a b\b f\f v\v")" };
+        native_vector<result<token, error>> tokens2(q.begin(), q.end());
+        CHECK(tokens2
+              == make_tokens({
+                { 0, 26, token_kind::escaped_string, "\\\?\?\\' \\\\ a\\a b\\b f\\f v\\v"sv }
+        }));
+      }
+
+      SUBCASE("Unterminated")
+      {
+        processor p{ "\"meow" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error{ 0, "unterminated string" },
+        }));
+      }
+    }
+
+    TEST_CASE("Meta hint")
+    {
+      SUBCASE("Empty")
+      {
+        processor p{ "^" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 1, token_kind::meta_hint }
+        }));
+      }
+
+      SUBCASE("With line breaks")
+      {
+        processor p{ "^\n:foo" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 1, token_kind::meta_hint },
+                { 2, 4, token_kind::keyword, "foo"sv }
+        }));
+      }
+    }
+
+    TEST_CASE("Reader macro")
+    {
+      SUBCASE("Empty")
+      {
+        processor p{ "#" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 1, token_kind::reader_macro }
+        }));
+      }
+
+      SUBCASE("Comment")
       {
         SUBCASE("Empty")
         {
-          processor p{ "\"\"" };
+          processor p{ "#_" };
           native_vector<result<token, error>> tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
-                  { 0, 2, token_kind::string, ""sv }
-          }));
-        }
-        SUBCASE("Single-char")
-        {
-          processor p{ "\"a\"" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, 3, token_kind::string, "a"sv }
+                  { 0, 2, token_kind::reader_macro_comment }
           }));
         }
 
-        SUBCASE("Multi-char")
+        SUBCASE("No whitespace after")
         {
-          processor p{ "\"abc\"" };
+          processor p{ "#_[]" };
           native_vector<result<token, error>> tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
-                  { 0, 5, token_kind::string, "abc"sv }
-          }));
-        }
-
-        SUBCASE("With numbers")
-        {
-          processor p{ "\"123\"" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, 5, token_kind::string, "123"sv }
-          }));
-        }
-
-        SUBCASE("With other symbols")
-        {
-          processor p{ "\"and then() there was abc_123/-foo?!&<>\"" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, 40, token_kind::string, "and then() there was abc_123/-foo?!&<>"sv }
-          }));
-        }
-
-        SUBCASE("With line breaks")
-        {
-          processor p{ "\"foo\nbar\nspam\t\"" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, 15, token_kind::string, "foo\nbar\nspam\t"sv }
-          }));
-        }
-
-        SUBCASE("With escapes")
-        {
-          processor p{ R"("foo\"\nbar\nspam\t\r")" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, 22, token_kind::escaped_string, "foo\\\"\\nbar\\nspam\\t\\r"sv }
-          }));
-
-          processor q{ R"("\??\' \\ a\a b\b f\f v\v")" };
-          native_vector<result<token, error>> tokens2(q.begin(), q.end());
-          CHECK(tokens2
-                == make_tokens({
-                  { 0, 26, token_kind::escaped_string, "\\\?\?\\' \\\\ a\\a b\\b f\\f v\\v"sv }
-          }));
-        }
-
-        SUBCASE("Unterminated")
-        {
-          processor p{ "\"meow" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_results({
-                  error{ 0, "unterminated string" },
+                  { 0, 2, token_kind::reader_macro_comment },
+                  { 2, 1,  token_kind::open_square_bracket },
+                  { 3, 1, token_kind::close_square_bracket }
           }));
         }
       }
 
-      TEST_CASE("Meta hint")
+      SUBCASE("Conditional")
       {
         SUBCASE("Empty")
         {
-          processor p{ "^" };
+          processor p{ "#?" };
           native_vector<result<token, error>> tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
-                  { 0, 1, token_kind::meta_hint }
+                  { 0, 2, token_kind::reader_macro_conditional }
           }));
         }
 
-        SUBCASE("With line breaks")
+        SUBCASE("With following list")
         {
-          processor p{ "^\n:foo" };
+          processor p{ "#?()" };
           native_vector<result<token, error>> tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
-                  { 0, 1, token_kind::meta_hint },
-                  { 2, 4, token_kind::keyword, "foo"sv }
+                  { 0, 2, token_kind::reader_macro_conditional },
+                  { 2, 1,               token_kind::open_paren },
+                  { 3, 1,              token_kind::close_paren }
           }));
         }
       }
 
-      TEST_CASE("Reader macro")
+      SUBCASE("Set")
       {
         SUBCASE("Empty")
         {
-          processor p{ "#" };
+          processor p{ "#{}" };
           native_vector<result<token, error>> tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
-                  { 0, 1, token_kind::reader_macro }
+                  { 0, 1,        token_kind::reader_macro },
+                  { 1, 1,  token_kind::open_curly_bracket },
+                  { 2, 1, token_kind::close_curly_bracket }
           }));
         }
 
-        SUBCASE("Comment")
-        {
-          SUBCASE("Empty")
-          {
-            processor p{ "#_" };
-            native_vector<result<token, error>> tokens(p.begin(), p.end());
-            CHECK(tokens
-                  == make_tokens({
-                    { 0, 2, token_kind::reader_macro_comment }
-            }));
-          }
-
-          SUBCASE("No whitespace after")
-          {
-            processor p{ "#_[]" };
-            native_vector<result<token, error>> tokens(p.begin(), p.end());
-            CHECK(tokens
-                  == make_tokens({
-                    { 0, 2, token_kind::reader_macro_comment },
-                    { 2, 1,  token_kind::open_square_bracket },
-                    { 3, 1, token_kind::close_square_bracket }
-            }));
-          }
-        }
-
-        SUBCASE("Conditional")
-        {
-          SUBCASE("Empty")
-          {
-            processor p{ "#?" };
-            native_vector<result<token, error>> tokens(p.begin(), p.end());
-            CHECK(tokens
-                  == make_tokens({
-                    { 0, 2, token_kind::reader_macro_conditional }
-            }));
-          }
-
-          SUBCASE("With following list")
-          {
-            processor p{ "#?()" };
-            native_vector<result<token, error>> tokens(p.begin(), p.end());
-            CHECK(tokens
-                  == make_tokens({
-                    { 0, 2, token_kind::reader_macro_conditional },
-                    { 2, 1,               token_kind::open_paren },
-                    { 3, 1,              token_kind::close_paren }
-            }));
-          }
-        }
-
-        SUBCASE("Set")
-        {
-          SUBCASE("Empty")
-          {
-            processor p{ "#{}" };
-            native_vector<result<token, error>> tokens(p.begin(), p.end());
-            CHECK(tokens
-                  == make_tokens({
-                    { 0, 1,        token_kind::reader_macro },
-                    { 1, 1,  token_kind::open_curly_bracket },
-                    { 2, 1, token_kind::close_curly_bracket }
-            }));
-          }
-
-          /* Clojure doesn't actually allow this, but I don't see why not. It does for meta hints, so
+        /* Clojure doesn't actually allow this, but I don't see why not. It does for meta hints, so
          * I figure this is just a lazy inconsistency. */
-          SUBCASE("With line breaks")
-          {
-            processor p{ "#\n{}" };
-            native_vector<result<token, error>> tokens(p.begin(), p.end());
-            CHECK(tokens
-                  == make_tokens({
-                    { 0, 1,        token_kind::reader_macro },
-                    { 2, 1,  token_kind::open_curly_bracket },
-                    { 3, 1, token_kind::close_curly_bracket }
-            }));
-          }
-        }
-      }
-
-      TEST_CASE("Syntax quoting")
-      {
-        SUBCASE("Empty")
+        SUBCASE("With line breaks")
         {
-          processor p{ "`" };
+          processor p{ "#\n{}" };
           native_vector<result<token, error>> tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
-                  { 0, 1, token_kind::syntax_quote }
+                  { 0, 1,        token_kind::reader_macro },
+                  { 2, 1,  token_kind::open_curly_bracket },
+                  { 3, 1, token_kind::close_curly_bracket }
+          }));
+        }
+      }
+    }
+
+    TEST_CASE("Syntax quoting")
+    {
+      SUBCASE("Empty")
+      {
+        processor p{ "`" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 1, token_kind::syntax_quote }
+        }));
+      }
+
+      SUBCASE("With line breaks")
+      {
+        processor p{ "`\n:foo" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 1, token_kind::syntax_quote },
+                { 2, 4, token_kind::keyword, "foo"sv }
+        }));
+      }
+
+      SUBCASE("Unquote")
+      {
+        SUBCASE("Empty")
+        {
+          processor p{ "~" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 1, token_kind::unquote }
           }));
         }
 
         SUBCASE("With line breaks")
         {
-          processor p{ "`\n:foo" };
+          processor p{ "~\n:foo" };
           native_vector<result<token, error>> tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
-                  { 0, 1, token_kind::syntax_quote },
+                  { 0, 1, token_kind::unquote },
                   { 2, 4, token_kind::keyword, "foo"sv }
           }));
         }
+      }
 
-        SUBCASE("Unquote")
+      SUBCASE("Unquote splicing")
+      {
+        SUBCASE("Empty")
         {
-          SUBCASE("Empty")
-          {
-            processor p{ "~" };
-            native_vector<result<token, error>> tokens(p.begin(), p.end());
-            CHECK(tokens
-                  == make_tokens({
-                    { 0, 1, token_kind::unquote }
-            }));
-          }
-
-          SUBCASE("With line breaks")
-          {
-            processor p{ "~\n:foo" };
-            native_vector<result<token, error>> tokens(p.begin(), p.end());
-            CHECK(tokens
-                  == make_tokens({
-                    { 0, 1, token_kind::unquote },
-                    { 2, 4, token_kind::keyword, "foo"sv }
-            }));
-          }
+          processor p{ "~@" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 2, token_kind::unquote_splice }
+          }));
         }
 
-        SUBCASE("Unquote splicing")
+        SUBCASE("With line breaks before")
         {
-          SUBCASE("Empty")
-          {
-            processor p{ "~@" };
-            native_vector<result<token, error>> tokens(p.begin(), p.end());
-            CHECK(tokens
-                  == make_tokens({
-                    { 0, 2, token_kind::unquote_splice }
-            }));
-          }
+          processor p{ "~\n@:foo" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 1, token_kind::unquote },
+                  { 2, 1, token_kind::deref },
+                  { 3, 4, token_kind::keyword, "foo"sv }
+          }));
+        }
 
-          SUBCASE("With line breaks before")
-          {
-            processor p{ "~\n@:foo" };
-            native_vector<result<token, error>> tokens(p.begin(), p.end());
-            CHECK(tokens
-                  == make_tokens({
-                    { 0, 1, token_kind::unquote },
-                    { 2, 1, token_kind::deref },
-                    { 3, 4, token_kind::keyword, "foo"sv }
-            }));
-          }
-
-          SUBCASE("With line breaks after")
-          {
-            processor p{ "~@\n:foo" };
-            native_vector<result<token, error>> tokens(p.begin(), p.end());
-            CHECK(tokens
-                  == make_tokens({
-                    { 0, 2, token_kind::unquote_splice },
-                    { 3, 4, token_kind::keyword, "foo"sv }
-            }));
-          }
+        SUBCASE("With line breaks after")
+        {
+          processor p{ "~@\n:foo" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 2, token_kind::unquote_splice },
+                  { 3, 4, token_kind::keyword, "foo"sv }
+          }));
         }
       }
     }
   }
+}

--- a/compiler+runtime/test/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/test/cpp/jank/read/lex.cpp
@@ -374,898 +374,968 @@ namespace jank::read::lex
         }));
       }
     }
-
-    TEST_CASE("Integer")
+    TEST_CASE("Ratio")
     {
-      SUBCASE("Positive single-char")
+      SUBCASE("Success - x/x")
       {
-        processor p{ "0" };
+        processor p{ "4/5" };
         native_vector<result<token, error>> tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
-                { 0, token_kind::integer, 0ll }
+                { 0, 3, token_kind::ratio, { .numerator = 4, .denominator = 5 } }
         }));
       }
-
-      SUBCASE("Positive multi-char")
+      SUBCASE("Success - -x/x")
       {
-        processor p{ "1234" };
+        processor p{ "-4/5" };
         native_vector<result<token, error>> tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
-                { 0, 4, token_kind::integer, 1234ll }
+                { 0, 4, token_kind::ratio, { .numerator = -4, .denominator = 5 } }
         }));
-      }
-
-      SUBCASE("Negative single-char")
-      {
-        processor p{ "-1" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 2, token_kind::integer, -1ll }
-        }));
-      }
-
-      SUBCASE("Negative multi-char")
-      {
-        processor p{ "-1234" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 5, token_kind::integer, -1234ll }
-        }));
-      }
-
-      SUBCASE("Expect space")
-      {
-        SUBCASE("Required")
+        SUBCASE("Success - -x/-x")
         {
-          processor p{ "1234abc" };
+          processor p{ "-4/-5" };
           native_vector<result<token, error>> tokens(p.begin(), p.end());
           CHECK(tokens
-                == make_results({
-                  token{ 0, 4, token_kind::integer, 1234ll },
-                  error{ 4, "expected whitespace before next token" },
-                  token{ 4, 3, token_kind::symbol, "abc"sv },
+                == make_tokens({
+                  { 0, 5, token_kind::ratio, { .numerator = -4, .denominator = -5 } }
+          }));
+        }
+        SUBCASE("Failures - x//x")
+        {
+          processor p{ "4//5" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_results(
+                  { { error(0, 4, "invalid ratio: expecting an integer denominator") } }));
+        }
+        SUBCASE("Failures - x/x/x")
+        {
+          processor p{ "4/5/4" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(
+            tokens
+            == make_results({ { error(0, 3, "invalid ratio: expecting an integer denominator") },
+                              { error(3, 3, "invalid symbol") } }));
+        }
+        SUBCASE("Failures - x/x/x/x")
+        {
+          processor p{ "4/5/4/5/6/7/7" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(
+            tokens
+            == make_results({ { error(0, 3, "invalid ratio: expecting an integer denominator") },
+                              { error(3, 3, "invalid symbol") } }));
+        }
+        SUBCASE("Failures - x.x/x")
+        {
+          processor p{ "4.4/5" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_results(
+                  { { error(0, 3, "invalid ratio") }, { error(3, 3, "invalid symbol") } }));
+        }
+        SUBCASE("Failures - x/x.x")
+        {
+          processor p{ "4/5.9" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_results(
+                  { { error(0, 5, "invalid ratio: expecting an integer denominator") } }));
+        }
+      }
+      TEST_CASE("Integer")
+      {
+        SUBCASE("Positive single-char")
+        {
+          processor p{ "0" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, token_kind::integer, 0ll }
           }));
         }
 
-        SUBCASE("Not required")
+        SUBCASE("Positive multi-char")
         {
-          processor p{ "(1234)" };
+          processor p{ "1234" };
           native_vector<result<token, error>> tokens(p.begin(), p.end());
           CHECK(tokens
-                == make_results({
-                  token{ 0, token_kind::open_paren },
-                  token{ 1, 4, token_kind::integer, 1234ll },
-                  token{ 5, token_kind::close_paren },
-          }));
-        }
-      }
-    }
-
-    TEST_CASE("Real")
-    {
-      SUBCASE("Positive 0.")
-      {
-        processor p{ "0." };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 2, token_kind::real, 0.0l }
-        }));
-      }
-
-      SUBCASE("Positive 0.0")
-      {
-        processor p{ "0.0" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 3, token_kind::real, 0.0l }
-        }));
-      }
-
-      SUBCASE("Negative 1.")
-      {
-        processor p{ "-1." };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 3, token_kind::real, -1.0l }
-        }));
-      }
-
-      SUBCASE("Negative 1.5")
-      {
-        processor p{ "-1.5" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 4, token_kind::real, -1.5l }
-        }));
-      }
-
-      SUBCASE("Negative multi-char")
-      {
-        processor p{ "-1234.1234" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 10, token_kind::real, -1234.1234l }
-        }));
-      }
-
-      SUBCASE("Positive no leading digit")
-      {
-        processor p{ ".0" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_results({
-                error{ 0, "unexpected character: ." },
-                token{ 1, token_kind::integer, 0ll },
-        }));
-      }
-
-      SUBCASE("Negative no leading digit")
-      {
-        processor p{ "-.0" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_results({
-                error{ 0, 1, "invalid number" },
-                error{ 1, "unexpected character: ." },
-                token{ 2, token_kind::integer, 0ll },
-        }));
-      }
-
-      SUBCASE("Too many dots")
-      {
-        {
-          processor p{ "0.0." };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_results({
-                  error{ 0, 3, "invalid number" },
-                  error{ 3, "unexpected character: ." },
+                == make_tokens({
+                  { 0, 4, token_kind::integer, 1234ll }
           }));
         }
 
+        SUBCASE("Negative single-char")
         {
-          processor p{ "0..0" };
+          processor p{ "-1" };
           native_vector<result<token, error>> tokens(p.begin(), p.end());
           CHECK(tokens
-                == make_results({
-                  error{ 0, 2, "invalid number" },
-                  error{ 2, "unexpected character: ." },
-                  token{ 3, token_kind::integer, 0ll },
-          }));
-        }
-        {
-          processor p{ "0.0.0" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_results({
-                  error{ 0, 3, "invalid number" },
-                  error{ 3, "unexpected character: ." },
-                  token{ 4, token_kind::integer, 0ll },
-          }));
-        }
-      }
-
-      SUBCASE("Expect space")
-      {
-        SUBCASE("Required")
-        {
-          processor p{ "12.34abc" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_results({
-                  token{ 0, 5, token_kind::real, 12.34l },
-                  error{ 5, "expected whitespace before next token" },
-                  token{ 5, 3, token_kind::symbol, "abc"sv },
+                == make_tokens({
+                  { 0, 2, token_kind::integer, -1ll }
           }));
         }
 
-        SUBCASE("Not required")
+        SUBCASE("Negative multi-char")
         {
-          processor p{ "(12.34)" };
+          processor p{ "-1234" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 5, token_kind::integer, -1234ll }
+          }));
+        }
+
+        SUBCASE("Expect space")
+        {
+          SUBCASE("Required")
+          {
+            processor p{ "1234abc" };
+            native_vector<result<token, error>> tokens(p.begin(), p.end());
+            CHECK(tokens
+                  == make_results({
+                    token{ 0, 4, token_kind::integer, 1234ll },
+                    error{ 4, "expected whitespace before next token" },
+                    token{ 4, 3, token_kind::symbol, "abc"sv },
+            }));
+          }
+
+          SUBCASE("Not required")
+          {
+            processor p{ "(1234)" };
+            native_vector<result<token, error>> tokens(p.begin(), p.end());
+            CHECK(tokens
+                  == make_results({
+                    token{ 0, token_kind::open_paren },
+                    token{ 1, 4, token_kind::integer, 1234ll },
+                    token{ 5, token_kind::close_paren },
+            }));
+          }
+        }
+      }
+
+      TEST_CASE("Real")
+      {
+        SUBCASE("Positive 0.")
+        {
+          processor p{ "0." };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 2, token_kind::real, 0.0l }
+          }));
+        }
+
+        SUBCASE("Positive 0.0")
+        {
+          processor p{ "0.0" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 3, token_kind::real, 0.0l }
+          }));
+        }
+
+        SUBCASE("Negative 1.")
+        {
+          processor p{ "-1." };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 3, token_kind::real, -1.0l }
+          }));
+        }
+
+        SUBCASE("Negative 1.5")
+        {
+          processor p{ "-1.5" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 4, token_kind::real, -1.5l }
+          }));
+        }
+
+        SUBCASE("Negative multi-char")
+        {
+          processor p{ "-1234.1234" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 10, token_kind::real, -1234.1234l }
+          }));
+        }
+
+        SUBCASE("Positive no leading digit")
+        {
+          processor p{ ".0" };
           native_vector<result<token, error>> tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_results({
-                  token{ 0, token_kind::open_paren },
-                  token{ 1, 5, token_kind::real, 12.34l },
-                  token{ 6, token_kind::close_paren },
+                  error{ 0, "unexpected character: ." },
+                  token{ 1, token_kind::integer, 0ll },
+          }));
+        }
+
+        SUBCASE("Negative no leading digit")
+        {
+          processor p{ "-.0" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_results({
+                  error{ 0, 1, "invalid number" },
+                  error{ 1, "unexpected character: ." },
+                  token{ 2, token_kind::integer, 0ll },
+          }));
+        }
+
+        SUBCASE("Too many dots")
+        {
+          {
+            processor p{ "0.0." };
+            native_vector<result<token, error>> tokens(p.begin(), p.end());
+            CHECK(tokens
+                  == make_results({
+                    error{ 0, 3, "invalid number" },
+                    error{ 3, "unexpected character: ." },
+            }));
+          }
+
+          {
+            processor p{ "0..0" };
+            native_vector<result<token, error>> tokens(p.begin(), p.end());
+            CHECK(tokens
+                  == make_results({
+                    error{ 0, 2, "invalid number" },
+                    error{ 2, "unexpected character: ." },
+                    token{ 3, token_kind::integer, 0ll },
+            }));
+          }
+          {
+            processor p{ "0.0.0" };
+            native_vector<result<token, error>> tokens(p.begin(), p.end());
+            CHECK(tokens
+                  == make_results({
+                    error{ 0, 3, "invalid number" },
+                    error{ 3, "unexpected character: ." },
+                    token{ 4, token_kind::integer, 0ll },
+            }));
+          }
+        }
+
+        SUBCASE("Expect space")
+        {
+          SUBCASE("Required")
+          {
+            processor p{ "12.34abc" };
+            native_vector<result<token, error>> tokens(p.begin(), p.end());
+            CHECK(tokens
+                  == make_results({
+                    token{ 0, 5, token_kind::real, 12.34l },
+                    error{ 5, "expected whitespace before next token" },
+                    token{ 5, 3, token_kind::symbol, "abc"sv },
+            }));
+          }
+
+          SUBCASE("Not required")
+          {
+            processor p{ "(12.34)" };
+            native_vector<result<token, error>> tokens(p.begin(), p.end());
+            CHECK(tokens
+                  == make_results({
+                    token{ 0, token_kind::open_paren },
+                    token{ 1, 5, token_kind::real, 12.34l },
+                    token{ 6, token_kind::close_paren },
+            }));
+          }
+        }
+
+        SUBCASE("Scientific notation")
+        {
+          SUBCASE("Valid")
+          {
+            processor p{ "1e3 -1e2 2.E-3 22.3e-8 -12E+18\\a" };
+            native_vector<result<token, error>> tokens(p.begin(), p.end());
+            CHECK(tokens
+                  == make_results({
+                    token{  0, 3,      token_kind::real,   1000.0l },
+                    token{  4, 4,      token_kind::real,   -100.0l },
+                    token{  9, 5,      token_kind::real,    0.002l },
+                    token{ 15, 7,      token_kind::real, 2.23e-07l },
+                    token{ 23, 7,      token_kind::real, -1.2e+19l },
+                    token{ 30, 2, token_kind::character,   "\\a"sv },
+            }));
+          }
+
+          SUBCASE("Missing exponent")
+          {
+            processor p{ "1e 23E-1 12e- -0.2e" };
+            native_vector<result<token, error>> tokens(p.begin(), p.end());
+            CHECK(tokens
+                  == make_results({
+                    error{ 0, 2, "unexpected end of real, expecting exponent" },
+                    token{ 3, 5, token_kind::real, 2.3l },
+                    error{ 9, 13, "unexpected end of real, expecting exponent" },
+                    error{ 14, 19, "unexpected end of real, expecting exponent" },
+            }));
+          }
+
+          SUBCASE("Signs after exponent found")
+          {
+            processor p{ "12.3 -1e3- 2.3E+" };
+            native_vector<result<token, error>> tokens(p.begin(), p.end());
+            CHECK(tokens
+                  == make_results({
+                    token{ 0, 4, token_kind::real, 12.3l },
+                    error{ 5, 9, "invalid number" },
+                    error{ 9, "expected whitespace before next token" },
+                    token{ 9, token_kind::symbol, "-"sv },
+                    error{ 11, 16, "unexpected end of real, expecting exponent" },
+            }));
+          }
+
+          SUBCASE("Extra dots")
+          {
+            processor p{ "1e3. 12.3 -1e4.3" };
+            native_vector<result<token, error>> tokens(p.begin(), p.end());
+            CHECK(tokens
+                  == make_results({
+                    error{ 0, 3, "invalid number" },
+                    error{ 3, "unexpected character: ." },
+                    token{ 5, 4, token_kind::real, 12.3l },
+                    error{ 10, 14, "invalid number" },
+                    error{ 14, "unexpected character: ." },
+                    error{ 15, "expected whitespace before next token" },
+                    token{ 15, token_kind::integer, 3ll },
+            }));
+          }
+
+          SUBCASE("Extra characters in exponent")
+          {
+            processor p{ "2.ee4 -1e4E3 1.eFoo 3E5fOo" };
+            native_vector<result<token, error>> tokens(p.begin(), p.end());
+            CHECK(tokens
+                  == make_results({
+                    error{ 0, 3, "invalid number" },
+                    token{ 3, 2, token_kind::symbol, "e4"sv },
+                    error{ 6, 10, "invalid number" },
+                    error{ 10, "expected whitespace before next token" },
+                    token{ 10, 2, token_kind::symbol, "E3"sv },
+                    error{ 13, 16, "unexpected end of real, expecting exponent" },
+                    error{ 16, "expected whitespace before next token" },
+                    token{ 16, 3, token_kind::symbol, "Foo"sv },
+                    token{ 20, 3, token_kind::real, 300000.0l },
+                    error{ 23, "expected whitespace before next token" },
+                    token{ 23, 3, token_kind::symbol, "fOo"sv },
+            }));
+          }
+        }
+      }
+
+      TEST_CASE("Character")
+      {
+        SUBCASE("Whitespace after \\")
+        {
+          processor p{ R"(\ )" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_results({ { error(0, "Expecting a valid character literal after \\") } }));
+        }
+
+        SUBCASE("Dangling \\")
+        {
+          processor p{ R"(\)" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_results({ { error(0, "Expecting a valid character literal after \\") } }));
+        }
+
+        SUBCASE("Alphabetic")
+        {
+          processor p{ R"(\a)" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 2, token_kind::character, "\\a"sv }
+          }));
+        }
+
+        SUBCASE("Numeric")
+        {
+          processor p{ R"(\1)" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 2, token_kind::character, "\\1"sv }
+          }));
+        }
+
+        SUBCASE("Multiple characters after \\")
+        {
+          processor p{ R"(\11)" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 3, token_kind::character, "\\11"sv }
+          }));
+        }
+
+        SUBCASE("Invalid symbol after a valid char")
+        {
+          processor p{ R"(\1:)" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_results({
+                  token{ 0, 2, token_kind::character, "\\1"sv },
+                  error{ 2, "invalid keyword: expected non-whitespace character after :" }
+          }));
+        }
+
+        SUBCASE("Valid consecutive characters")
+        {
+          processor p{ R"(\1 \newline\' \\)" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  {  0, 2, token_kind::character,       "\\1"sv },
+                  {  3, 8, token_kind::character, "\\newline"sv },
+                  { 11, 2, token_kind::character,       "\\'"sv },
+                  { 14, 2, token_kind::character,      "\\\\"sv }
+          }));
+        }
+
+        SUBCASE("Character followed by a backticked keyword")
+        {
+          processor p{ R"(\a`:kw)" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_results({
+                  token{ 0, 2, token_kind::character, "\\a"sv },
+                  token{ 2, token_kind::syntax_quote },
+                  token{ 3, 3, token_kind::keyword, "kw"sv }
           }));
         }
       }
 
-      SUBCASE("Scientific notation")
+      TEST_CASE("Symbol")
       {
-        SUBCASE("Valid")
+        SUBCASE("Single-char")
         {
-          processor p{ "1e3 -1e2 2.E-3 22.3e-8 -12E+18\\a" };
+          processor p{ "a" };
           native_vector<result<token, error>> tokens(p.begin(), p.end());
           CHECK(tokens
-                == make_results({
-                  token{  0, 3, token_kind::real,   1000.0l },
-                  token{  4, 4, token_kind::real,   -100.0l },
-                  token{  9, 5, token_kind::real,    0.002l },
-                  token{ 15, 7, token_kind::real, 2.23e-07l },
-                  token{ 23, 7, token_kind::real, -1.2e+19l },
-                  token{ 30, 2, token_kind::character, "\\a"sv },
+                == make_tokens({
+                  { 0, token_kind::symbol, "a"sv }
           }));
         }
 
-        SUBCASE("Missing exponent")
+        SUBCASE("Multi-char")
         {
-          processor p{ "1e 23E-1 12e- -0.2e" };
+          processor p{ "abc" };
           native_vector<result<token, error>> tokens(p.begin(), p.end());
           CHECK(tokens
-                == make_results({
-                  error{ 0, 2, "unexpected end of real, expecting exponent" },
-                  token{ 3, 5, token_kind::real, 2.3l },
-                  error{ 9, 13, "unexpected end of real, expecting exponent" },
-                  error{ 14, 19, "unexpected end of real, expecting exponent" },
+                == make_tokens({
+                  { 0, 3, token_kind::symbol, "abc"sv }
           }));
         }
 
-        SUBCASE("Signs after exponent found")
+        SUBCASE("Single slash")
         {
-          processor p{ "12.3 -1e3- 2.3E+" };
+          processor p{ "/" };
           native_vector<result<token, error>> tokens(p.begin(), p.end());
           CHECK(tokens
-                == make_results({
-                  token{ 0, 4, token_kind::real, 12.3l },
-                  error{ 5, 9, "invalid number" },
-                  error{ 9, "expected whitespace before next token" },
-                  token{ 9, token_kind::symbol, "-"sv },
-                  error{ 11, 16, "unexpected end of real, expecting exponent" },
+                == make_tokens({
+                  { 0, token_kind::symbol, "/"sv }
           }));
         }
 
-        SUBCASE("Extra dots")
+        SUBCASE("Multi slash")
         {
-          processor p{ "1e3. 12.3 -1e4.3" };
+          processor p{ "//" };
           native_vector<result<token, error>> tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_results({
-                  error{ 0, 3, "invalid number" },
-                  error{ 3, "unexpected character: ." },
-                  token{ 5, 4, token_kind::real, 12.3l },
-                  error{ 10, 14, "invalid number" },
-                  error{ 14, "unexpected character: ." },
-                  error{ 15, "expected whitespace before next token" },
-                  token{ 15, token_kind::integer, 3ll },
+                  error{ 0, "invalid symbol" },
           }));
         }
 
-        SUBCASE("Extra characters in exponent")
+        SUBCASE("Starting with a slash")
         {
-          processor p{ "2.ee4 -1e4E3 1.eFoo 3E5fOo" };
+          processor p{ "/foo" };
           native_vector<result<token, error>> tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_results({
-                  error{ 0, 3, "invalid number" },
-                  token{ 3, 2, token_kind::symbol, "e4"sv },
-                  error{ 6, 10, "invalid number" },
-                  error{ 10, "expected whitespace before next token" },
-                  token{ 10, 2, token_kind::symbol, "E3"sv },
-                  error{ 13, 16, "unexpected end of real, expecting exponent" },
-                  error{ 16, "expected whitespace before next token" },
-                  token{ 16, 3, token_kind::symbol, "Foo"sv },
-                  token{ 20, 3, token_kind::real, 300000.0l },
-                  error{ 23, "expected whitespace before next token" },
-                  token{ 23, 3, token_kind::symbol, "fOo"sv },
+                  error{ 0, "invalid symbol" },
+          }));
+        }
+
+        SUBCASE("With numbers")
+        {
+          processor p{ "abc123" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 6, token_kind::symbol, "abc123"sv }
+          }));
+        }
+
+        SUBCASE("With other symbols")
+        {
+          processor p{ "abc_.123/-foo+?=!&<>#%" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 22, token_kind::symbol, "abc_.123/-foo+?=!&<>#%"sv }
+          }));
+        }
+
+        SUBCASE("Only -")
+        {
+          processor p{ "-" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, token_kind::symbol, "-"sv }
+          }));
+        }
+
+        SUBCASE("Starting with -")
+        {
+          processor p{ "-main" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 5, token_kind::symbol, "-main"sv }
+          }));
+        }
+
+        SUBCASE("Quoted")
+        {
+          processor p{ "'foo" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, token_kind::single_quote },
+                  { 1, 3, token_kind::symbol, "foo"sv }
           }));
         }
       }
-    }
 
-    TEST_CASE("Character")
-    {
-      SUBCASE("Whitespace after \\")
+      TEST_CASE("Keyword")
       {
-        processor p{ R"(\ )" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_results({ { error(0, "Expecting a valid character literal after \\") } }));
+        SUBCASE("Single-char")
+        {
+          processor p{ ":a" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 2, token_kind::keyword, "a"sv }
+          }));
+        }
+
+        SUBCASE("Multi-char")
+        {
+          processor p{ ":abc" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 4, token_kind::keyword, "abc"sv }
+          }));
+        }
+
+        SUBCASE("Whitespace after :")
+        {
+          processor p{ ": " };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_results({
+                  error{ 0, "invalid keyword: expected non-whitespace character after :" }
+          }));
+        }
+
+        SUBCASE("Single slash")
+        {
+          processor p{ ":/" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 2, token_kind::keyword, "/"sv }
+          }));
+        }
+
+        SUBCASE("Multi slash")
+        {
+          processor p{ "://" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_results({
+                  error{ 0, "invalid keyword: starts with /" },
+          }));
+        }
+
+        SUBCASE("Starting with a slash")
+        {
+          processor p{ ":/foo" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_results({
+                  error{ 0, "invalid keyword: starts with /" },
+          }));
+        }
+
+        SUBCASE("With numbers")
+        {
+          processor p{ ":abc123" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 7, token_kind::keyword, "abc123"sv }
+          }));
+        }
+
+        SUBCASE("With other symbols")
+        {
+          processor p{ ":abc_.123/-foo+?=!&<>" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 21, token_kind::keyword, "abc_.123/-foo+?=!&<>"sv }
+          }));
+        }
+
+        SUBCASE("Auto-resolved unqualified")
+        {
+          processor p{ "::foo-bar" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 9, token_kind::keyword, ":foo-bar"sv }
+          }));
+        }
+
+        SUBCASE("Auto-resolved qualified")
+        {
+          processor p{ "::foo/bar" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 9, token_kind::keyword, ":foo/bar"sv }
+          }));
+        }
+
+        SUBCASE("Too many starting colons")
+        {
+          processor p{ ":::foo" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_results({
+                  error{ 0, "invalid keyword: incorrect number of :" },
+                  error{ 2, "expected whitespace before next token" },
+                  token{ 2, 4, token_kind::keyword, "foo"sv }
+          }));
+        }
+
+        SUBCASE("Way too many starting colons")
+        {
+          processor p{ "::::foo" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_results({
+                  error{ 0, "invalid keyword: incorrect number of :" },
+                  error{ 2, "expected whitespace before next token" },
+                  token{ 2, 5, token_kind::keyword, ":foo"sv }
+          }));
+        }
       }
 
-      SUBCASE("Dangling \\")
-      {
-        processor p{ R"(\)" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_results({ { error(0, "Expecting a valid character literal after \\") } }));
-      }
-
-      SUBCASE("Alphabetic")
-      {
-        processor p{ R"(\a)" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 2, token_kind::character, "\\a"sv }
-        }));
-      }
-
-      SUBCASE("Numeric")
-      {
-        processor p{ R"(\1)" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 2, token_kind::character, "\\1"sv }
-        }));
-      }
-
-      SUBCASE("Multiple characters after \\")
-      {
-        processor p{ R"(\11)" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 3, token_kind::character, "\\11"sv }
-        }));
-      }
-
-      SUBCASE("Invalid symbol after a valid char")
-      {
-        processor p{ R"(\1:)" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_results({
-                token{ 0, 2, token_kind::character, "\\1"sv },
-                error{ 2, "invalid keyword: expected non-whitespace character after :" }
-        }));
-      }
-
-      SUBCASE("Valid consecutive characters")
-      {
-        processor p{ R"(\1 \newline\' \\)" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                {  0, 2, token_kind::character,       "\\1"sv },
-                {  3, 8, token_kind::character, "\\newline"sv },
-                { 11, 2, token_kind::character,       "\\'"sv },
-                { 14, 2, token_kind::character,      "\\\\"sv }
-        }));
-      }
-
-      SUBCASE("Character followed by a backticked keyword")
-      {
-        processor p{ R"(\a`:kw)" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_results({
-                token{ 0, 2, token_kind::character, "\\a"sv },
-                token{ 2, token_kind::syntax_quote },
-                token{ 3, 3, token_kind::keyword, "kw"sv }
-        }));
-      }
-    }
-
-    TEST_CASE("Symbol")
-    {
-      SUBCASE("Single-char")
-      {
-        processor p{ "a" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, token_kind::symbol, "a"sv }
-        }));
-      }
-
-      SUBCASE("Multi-char")
-      {
-        processor p{ "abc" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 3, token_kind::symbol, "abc"sv }
-        }));
-      }
-
-      SUBCASE("Single slash")
-      {
-        processor p{ "/" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, token_kind::symbol, "/"sv }
-        }));
-      }
-
-      SUBCASE("Multi slash")
-      {
-        processor p{ "//" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_results({
-                error{ 0, "invalid symbol" },
-        }));
-      }
-
-      SUBCASE("Starting with a slash")
-      {
-        processor p{ "/foo" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_results({
-                error{ 0, "invalid symbol" },
-        }));
-      }
-
-      SUBCASE("With numbers")
-      {
-        processor p{ "abc123" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 6, token_kind::symbol, "abc123"sv }
-        }));
-      }
-
-      SUBCASE("With other symbols")
-      {
-        processor p{ "abc_.123/-foo+?=!&<>#%" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 22, token_kind::symbol, "abc_.123/-foo+?=!&<>#%"sv }
-        }));
-      }
-
-      SUBCASE("Only -")
-      {
-        processor p{ "-" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, token_kind::symbol, "-"sv }
-        }));
-      }
-
-      SUBCASE("Starting with -")
-      {
-        processor p{ "-main" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 5, token_kind::symbol, "-main"sv }
-        }));
-      }
-
-      SUBCASE("Quoted")
-      {
-        processor p{ "'foo" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, token_kind::single_quote },
-                { 1, 3, token_kind::symbol, "foo"sv }
-        }));
-      }
-    }
-
-    TEST_CASE("Keyword")
-    {
-      SUBCASE("Single-char")
-      {
-        processor p{ ":a" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 2, token_kind::keyword, "a"sv }
-        }));
-      }
-
-      SUBCASE("Multi-char")
-      {
-        processor p{ ":abc" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 4, token_kind::keyword, "abc"sv }
-        }));
-      }
-
-      SUBCASE("Whitespace after :")
-      {
-        processor p{ ": " };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_results({
-                error{ 0, "invalid keyword: expected non-whitespace character after :" }
-        }));
-      }
-
-      SUBCASE("Single slash")
-      {
-        processor p{ ":/" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 2, token_kind::keyword, "/"sv }
-        }));
-      }
-
-      SUBCASE("Multi slash")
-      {
-        processor p{ "://" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_results({
-                error{ 0, "invalid keyword: starts with /" },
-        }));
-      }
-
-      SUBCASE("Starting with a slash")
-      {
-        processor p{ ":/foo" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_results({
-                error{ 0, "invalid keyword: starts with /" },
-        }));
-      }
-
-      SUBCASE("With numbers")
-      {
-        processor p{ ":abc123" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 7, token_kind::keyword, "abc123"sv }
-        }));
-      }
-
-      SUBCASE("With other symbols")
-      {
-        processor p{ ":abc_.123/-foo+?=!&<>" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 21, token_kind::keyword, "abc_.123/-foo+?=!&<>"sv }
-        }));
-      }
-
-      SUBCASE("Auto-resolved unqualified")
-      {
-        processor p{ "::foo-bar" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 9, token_kind::keyword, ":foo-bar"sv }
-        }));
-      }
-
-      SUBCASE("Auto-resolved qualified")
-      {
-        processor p{ "::foo/bar" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 9, token_kind::keyword, ":foo/bar"sv }
-        }));
-      }
-
-      SUBCASE("Too many starting colons")
-      {
-        processor p{ ":::foo" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_results({
-                error{ 0, "invalid keyword: incorrect number of :" },
-                error{ 2, "expected whitespace before next token" },
-                token{ 2, 4, token_kind::keyword, "foo"sv }
-        }));
-      }
-
-      SUBCASE("Way too many starting colons")
-      {
-        processor p{ "::::foo" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_results({
-                error{ 0, "invalid keyword: incorrect number of :" },
-                error{ 2, "expected whitespace before next token" },
-                token{ 2, 5, token_kind::keyword, ":foo"sv }
-        }));
-      }
-    }
-
-    TEST_CASE("String")
-    {
-      SUBCASE("Empty")
-      {
-        processor p{ "\"\"" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 2, token_kind::string, ""sv }
-        }));
-      }
-      SUBCASE("Single-char")
-      {
-        processor p{ "\"a\"" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 3, token_kind::string, "a"sv }
-        }));
-      }
-
-      SUBCASE("Multi-char")
-      {
-        processor p{ "\"abc\"" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 5, token_kind::string, "abc"sv }
-        }));
-      }
-
-      SUBCASE("With numbers")
-      {
-        processor p{ "\"123\"" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 5, token_kind::string, "123"sv }
-        }));
-      }
-
-      SUBCASE("With other symbols")
-      {
-        processor p{ "\"and then() there was abc_123/-foo?!&<>\"" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 40, token_kind::string, "and then() there was abc_123/-foo?!&<>"sv }
-        }));
-      }
-
-      SUBCASE("With line breaks")
-      {
-        processor p{ "\"foo\nbar\nspam\t\"" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 15, token_kind::string, "foo\nbar\nspam\t"sv }
-        }));
-      }
-
-      SUBCASE("With escapes")
-      {
-        processor p{ R"("foo\"\nbar\nspam\t\r")" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 22, token_kind::escaped_string, "foo\\\"\\nbar\\nspam\\t\\r"sv }
-        }));
-
-        processor q{ R"("\??\' \\ a\a b\b f\f v\v")" };
-        native_vector<result<token, error>> tokens2(q.begin(), q.end());
-        CHECK(tokens2
-              == make_tokens({
-                { 0, 26, token_kind::escaped_string, "\\\?\?\\' \\\\ a\\a b\\b f\\f v\\v"sv }
-        }));
-      }
-
-      SUBCASE("Unterminated")
-      {
-        processor p{ "\"meow" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_results({
-                error{ 0, "unterminated string" },
-        }));
-      }
-    }
-
-    TEST_CASE("Meta hint")
-    {
-      SUBCASE("Empty")
-      {
-        processor p{ "^" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 1, token_kind::meta_hint }
-        }));
-      }
-
-      SUBCASE("With line breaks")
-      {
-        processor p{ "^\n:foo" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 1, token_kind::meta_hint },
-                { 2, 4, token_kind::keyword, "foo"sv }
-        }));
-      }
-    }
-
-    TEST_CASE("Reader macro")
-    {
-      SUBCASE("Empty")
-      {
-        processor p{ "#" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 1, token_kind::reader_macro }
-        }));
-      }
-
-      SUBCASE("Comment")
+      TEST_CASE("String")
       {
         SUBCASE("Empty")
         {
-          processor p{ "#_" };
+          processor p{ "\"\"" };
           native_vector<result<token, error>> tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
-                  { 0, 2, token_kind::reader_macro_comment }
+                  { 0, 2, token_kind::string, ""sv }
+          }));
+        }
+        SUBCASE("Single-char")
+        {
+          processor p{ "\"a\"" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 3, token_kind::string, "a"sv }
           }));
         }
 
-        SUBCASE("No whitespace after")
+        SUBCASE("Multi-char")
         {
-          processor p{ "#_[]" };
+          processor p{ "\"abc\"" };
           native_vector<result<token, error>> tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
-                  { 0, 2, token_kind::reader_macro_comment },
-                  { 2, 1,  token_kind::open_square_bracket },
-                  { 3, 1, token_kind::close_square_bracket }
-          }));
-        }
-      }
-
-      SUBCASE("Conditional")
-      {
-        SUBCASE("Empty")
-        {
-          processor p{ "#?" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, 2, token_kind::reader_macro_conditional }
+                  { 0, 5, token_kind::string, "abc"sv }
           }));
         }
 
-        SUBCASE("With following list")
+        SUBCASE("With numbers")
         {
-          processor p{ "#?()" };
+          processor p{ "\"123\"" };
           native_vector<result<token, error>> tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
-                  { 0, 2, token_kind::reader_macro_conditional },
-                  { 2, 1,               token_kind::open_paren },
-                  { 3, 1,              token_kind::close_paren }
-          }));
-        }
-      }
-
-      SUBCASE("Set")
-      {
-        SUBCASE("Empty")
-        {
-          processor p{ "#{}" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, 1,        token_kind::reader_macro },
-                  { 1, 1,  token_kind::open_curly_bracket },
-                  { 2, 1, token_kind::close_curly_bracket }
+                  { 0, 5, token_kind::string, "123"sv }
           }));
         }
 
-        /* Clojure doesn't actually allow this, but I don't see why not. It does for meta hints, so
-         * I figure this is just a lazy inconsistency. */
-        SUBCASE("With line breaks")
+        SUBCASE("With other symbols")
         {
-          processor p{ "#\n{}" };
+          processor p{ "\"and then() there was abc_123/-foo?!&<>\"" };
           native_vector<result<token, error>> tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
-                  { 0, 1,        token_kind::reader_macro },
-                  { 2, 1,  token_kind::open_curly_bracket },
-                  { 3, 1, token_kind::close_curly_bracket }
-          }));
-        }
-      }
-    }
-
-    TEST_CASE("Syntax quoting")
-    {
-      SUBCASE("Empty")
-      {
-        processor p{ "`" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 1, token_kind::syntax_quote }
-        }));
-      }
-
-      SUBCASE("With line breaks")
-      {
-        processor p{ "`\n:foo" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 1, token_kind::syntax_quote },
-                { 2, 4, token_kind::keyword, "foo"sv }
-        }));
-      }
-
-      SUBCASE("Unquote")
-      {
-        SUBCASE("Empty")
-        {
-          processor p{ "~" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
-          CHECK(tokens
-                == make_tokens({
-                  { 0, 1, token_kind::unquote }
+                  { 0, 40, token_kind::string, "and then() there was abc_123/-foo?!&<>"sv }
           }));
         }
 
         SUBCASE("With line breaks")
         {
-          processor p{ "~\n:foo" };
+          processor p{ "\"foo\nbar\nspam\t\"" };
           native_vector<result<token, error>> tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
-                  { 0, 1, token_kind::unquote },
+                  { 0, 15, token_kind::string, "foo\nbar\nspam\t"sv }
+          }));
+        }
+
+        SUBCASE("With escapes")
+        {
+          processor p{ R"("foo\"\nbar\nspam\t\r")" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 22, token_kind::escaped_string, "foo\\\"\\nbar\\nspam\\t\\r"sv }
+          }));
+
+          processor q{ R"("\??\' \\ a\a b\b f\f v\v")" };
+          native_vector<result<token, error>> tokens2(q.begin(), q.end());
+          CHECK(tokens2
+                == make_tokens({
+                  { 0, 26, token_kind::escaped_string, "\\\?\?\\' \\\\ a\\a b\\b f\\f v\\v"sv }
+          }));
+        }
+
+        SUBCASE("Unterminated")
+        {
+          processor p{ "\"meow" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_results({
+                  error{ 0, "unterminated string" },
+          }));
+        }
+      }
+
+      TEST_CASE("Meta hint")
+      {
+        SUBCASE("Empty")
+        {
+          processor p{ "^" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 1, token_kind::meta_hint }
+          }));
+        }
+
+        SUBCASE("With line breaks")
+        {
+          processor p{ "^\n:foo" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 1, token_kind::meta_hint },
                   { 2, 4, token_kind::keyword, "foo"sv }
           }));
         }
       }
 
-      SUBCASE("Unquote splicing")
+      TEST_CASE("Reader macro")
       {
         SUBCASE("Empty")
         {
-          processor p{ "~@" };
+          processor p{ "#" };
           native_vector<result<token, error>> tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
-                  { 0, 2, token_kind::unquote_splice }
+                  { 0, 1, token_kind::reader_macro }
           }));
         }
 
-        SUBCASE("With line breaks before")
+        SUBCASE("Comment")
         {
-          processor p{ "~\n@:foo" };
+          SUBCASE("Empty")
+          {
+            processor p{ "#_" };
+            native_vector<result<token, error>> tokens(p.begin(), p.end());
+            CHECK(tokens
+                  == make_tokens({
+                    { 0, 2, token_kind::reader_macro_comment }
+            }));
+          }
+
+          SUBCASE("No whitespace after")
+          {
+            processor p{ "#_[]" };
+            native_vector<result<token, error>> tokens(p.begin(), p.end());
+            CHECK(tokens
+                  == make_tokens({
+                    { 0, 2, token_kind::reader_macro_comment },
+                    { 2, 1,  token_kind::open_square_bracket },
+                    { 3, 1, token_kind::close_square_bracket }
+            }));
+          }
+        }
+
+        SUBCASE("Conditional")
+        {
+          SUBCASE("Empty")
+          {
+            processor p{ "#?" };
+            native_vector<result<token, error>> tokens(p.begin(), p.end());
+            CHECK(tokens
+                  == make_tokens({
+                    { 0, 2, token_kind::reader_macro_conditional }
+            }));
+          }
+
+          SUBCASE("With following list")
+          {
+            processor p{ "#?()" };
+            native_vector<result<token, error>> tokens(p.begin(), p.end());
+            CHECK(tokens
+                  == make_tokens({
+                    { 0, 2, token_kind::reader_macro_conditional },
+                    { 2, 1,               token_kind::open_paren },
+                    { 3, 1,              token_kind::close_paren }
+            }));
+          }
+        }
+
+        SUBCASE("Set")
+        {
+          SUBCASE("Empty")
+          {
+            processor p{ "#{}" };
+            native_vector<result<token, error>> tokens(p.begin(), p.end());
+            CHECK(tokens
+                  == make_tokens({
+                    { 0, 1,        token_kind::reader_macro },
+                    { 1, 1,  token_kind::open_curly_bracket },
+                    { 2, 1, token_kind::close_curly_bracket }
+            }));
+          }
+
+          /* Clojure doesn't actually allow this, but I don't see why not. It does for meta hints, so
+         * I figure this is just a lazy inconsistency. */
+          SUBCASE("With line breaks")
+          {
+            processor p{ "#\n{}" };
+            native_vector<result<token, error>> tokens(p.begin(), p.end());
+            CHECK(tokens
+                  == make_tokens({
+                    { 0, 1,        token_kind::reader_macro },
+                    { 2, 1,  token_kind::open_curly_bracket },
+                    { 3, 1, token_kind::close_curly_bracket }
+            }));
+          }
+        }
+      }
+
+      TEST_CASE("Syntax quoting")
+      {
+        SUBCASE("Empty")
+        {
+          processor p{ "`" };
           native_vector<result<token, error>> tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
-                  { 0, 1, token_kind::unquote },
-                  { 2, 1, token_kind::deref },
-                  { 3, 4, token_kind::keyword, "foo"sv }
+                  { 0, 1, token_kind::syntax_quote }
           }));
         }
 
-        SUBCASE("With line breaks after")
+        SUBCASE("With line breaks")
         {
-          processor p{ "~@\n:foo" };
+          processor p{ "`\n:foo" };
           native_vector<result<token, error>> tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
-                  { 0, 2, token_kind::unquote_splice },
-                  { 3, 4, token_kind::keyword, "foo"sv }
+                  { 0, 1, token_kind::syntax_quote },
+                  { 2, 4, token_kind::keyword, "foo"sv }
           }));
+        }
+
+        SUBCASE("Unquote")
+        {
+          SUBCASE("Empty")
+          {
+            processor p{ "~" };
+            native_vector<result<token, error>> tokens(p.begin(), p.end());
+            CHECK(tokens
+                  == make_tokens({
+                    { 0, 1, token_kind::unquote }
+            }));
+          }
+
+          SUBCASE("With line breaks")
+          {
+            processor p{ "~\n:foo" };
+            native_vector<result<token, error>> tokens(p.begin(), p.end());
+            CHECK(tokens
+                  == make_tokens({
+                    { 0, 1, token_kind::unquote },
+                    { 2, 4, token_kind::keyword, "foo"sv }
+            }));
+          }
+        }
+
+        SUBCASE("Unquote splicing")
+        {
+          SUBCASE("Empty")
+          {
+            processor p{ "~@" };
+            native_vector<result<token, error>> tokens(p.begin(), p.end());
+            CHECK(tokens
+                  == make_tokens({
+                    { 0, 2, token_kind::unquote_splice }
+            }));
+          }
+
+          SUBCASE("With line breaks before")
+          {
+            processor p{ "~\n@:foo" };
+            native_vector<result<token, error>> tokens(p.begin(), p.end());
+            CHECK(tokens
+                  == make_tokens({
+                    { 0, 1, token_kind::unquote },
+                    { 2, 1, token_kind::deref },
+                    { 3, 4, token_kind::keyword, "foo"sv }
+            }));
+          }
+
+          SUBCASE("With line breaks after")
+          {
+            processor p{ "~@\n:foo" };
+            native_vector<result<token, error>> tokens(p.begin(), p.end());
+            CHECK(tokens
+                  == make_tokens({
+                    { 0, 2, token_kind::unquote_splice },
+                    { 3, 4, token_kind::keyword, "foo"sv }
+            }));
+          }
         }
       }
     }
   }
-}

--- a/compiler+runtime/test/cpp/jank/read/parse.cpp
+++ b/compiler+runtime/test/cpp/jank/read/parse.cpp
@@ -63,6 +63,32 @@ namespace jank::read::parse
       CHECK(r.expect_ok().unwrap().end == r.expect_ok().unwrap().start);
     }
 
+    TEST_CASE("Ratio")
+    {
+      SUBCASE("Single Ratio")
+      {
+        lex::processor lp{ "4/5" };
+        processor p{ lp.begin(), lp.end() };
+        auto const r(p.next());
+        CHECK(equal(r.expect_ok().unwrap().ptr, make_box(0.8)));
+        CHECK(r.expect_ok().unwrap().start
+              == lex::token{
+                0,
+                3,
+                lex::token_kind::ratio,
+                { .numerator = 4, .denominator = 5 }
+        });
+        CHECK(r.expect_ok().unwrap().end == r.expect_ok().unwrap().start);
+      }
+      SUBCASE("Division by zero")
+      {
+        lex::processor lp{ "1/0" };
+        processor p{ lp.begin(), lp.end() };
+        auto const r(p.next());
+        CHECK(r.is_err());
+      }
+    }
+
     TEST_CASE("Comments")
     {
       lex::processor lp{ ";meow \n1234 ; bar\n;\n\n" };


### PR DESCRIPTION
Add support for ratio

Currently, ratio (of two integers) will be converted to a real number during parsing.

Lexing and parsing should work:

```
❯ build/jank repl   
Bottom of clojure.core
> 4/5
0.8
> 4/5/6
Read error (0 - 3): invalid number
> 4//5
Read error (0 - 4): invalid number
> 4/5/6/7
Read error (0 - 3): invalid number
> 4.4/5
Read error (0 - 3): invalid number
> 5/5.5
Read error (0 - 5): invalid number
> 5/7
0.7142857142857143
> (+ 4 4/5)
4.8
> (+ 4 -4/5)
3.2
> (+ 4 4/-5)
3.2
> (+ 4 -4/-5)
4.8
> (+ -4/5 -4/-5)
0
> 1/0
Read error (0 - 0): Divide by zero
```
