### PR TITLE
feat(multimethods): adds remaining related fns to core

### DIFF
--- a/compiler+runtime/CMakeLists.txt
+++ b/compiler+runtime/CMakeLists.txt
@@ -233,6 +233,7 @@ target_include_directories(
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third-party/immer>"
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third-party/magic_enum/include/magic_enum>"
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third-party/cli11/include>"
+  "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third-party/fmt/include>"
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third-party/libzippp/src>"
 )
 target_precompile_headers(

--- a/compiler+runtime/src/cpp/jank/runtime/obj/multi_function.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/multi_function.cpp
@@ -232,7 +232,7 @@ namespace jank::runtime
     {
       throw std::runtime_error{ fmt::format(
         "Preference conflict in multimethod '{}': {} is already preferred to {}",
-        name,
+        runtime::to_string(name),
         runtime::to_string(y),
         runtime::to_string(x)) };
     }
@@ -304,7 +304,7 @@ namespace jank::runtime
     if(target == obj::nil::nil_const())
     {
       throw std::runtime_error{ fmt::format("No method in multimethod '{}' for dispatch value: {}",
-                                            name,
+                                            runtime::to_string(name),
                                             runtime::to_string(dispatch_val)) };
     }
     return target;
@@ -350,7 +350,7 @@ namespace jank::runtime
           throw std::runtime_error{ fmt::format(
             "Multiple methods in multimethod '{}' match dispatch value: {} -> {} and {}, and "
             "neither is preferred",
-            name,
+            runtime::to_string(name),
             runtime::to_string(dispatch_val),
             runtime::to_string(entry_key),
             runtime::to_string(best_entry->first())) };

--- a/compiler+runtime/src/jank/clojure/core.jank
+++ b/compiler+runtime/src/jank/clojure/core.jank
@@ -3240,46 +3240,37 @@
   [multifn dispatch-val & fn-tail]
   `(defmethod* ~multifn ~dispatch-val (fn ~@fn-tail)))
 
-;(defn remove-all-methods
-;  "Removes all of the methods of multimethod."
-;  {:added "1.2"
-;   :static true}
-; [^clojure.lang.MultiFn multifn]
-; (.reset multifn))
-;
-;(defn remove-method
-;  "Removes the method of multimethod associated with dispatch-value."
-;  {:added "1.0"
-;   :static true}
-; [^clojure.lang.MultiFn multifn dispatch-val]
-; (. multifn removeMethod dispatch-val))
-;
-;(defn prefer-method
-;  "Causes the multimethod to prefer matches of dispatch-val-x over dispatch-val-y
-;   when there is a conflict"
-;  {:added "1.0"
-;   :static true}
-;  [^clojure.lang.MultiFn multifn dispatch-val-x dispatch-val-y]
-;  (. multifn preferMethod dispatch-val-x dispatch-val-y))
-;
-;(defn methods
-;  "Given a multimethod, returns a map of dispatch values -> dispatch fns"
-;  {:added "1.0"
-;   :static true}
-;  [^clojure.lang.MultiFn multifn] (.getMethodTable multifn))
-;
-;(defn get-method
-;  "Given a multimethod and a dispatch value, returns the dispatch fn
-;  that would apply to that value, or nil if none apply and no default"
-;  {:added "1.0"
-;   :static true}
-;  [^clojure.lang.MultiFn multifn dispatch-val] (.getMethod multifn dispatch-val))
-;
-;(defn prefers
-;  "Given a multimethod, returns a map of preferred value -> set of other values"
-;  {:added "1.0"
-;   :static true}
-;  [^clojure.lang.MultiFn multifn] (.getPreferTable multifn))
+(defn remove-all-methods
+  "Removes all of the methods of multimethod."
+  [multifn]
+  (native/raw "__value = try_object<obj::multi_function>(~{ multifn })->reset();"))
+
+(defn remove-method
+  "Removes the method of multimethod associated with dispatch-value."
+  [multifn dispatch-val]
+  (native/raw "__value = try_object<obj::multi_function>(~{ multifn })->remove_method(~{ dispatch-val });"))
+
+(defn prefer-method
+  "Causes the multimethod to prefer matches of dispatch-val-x over dispatch-val-y
+  when there is a conflict"
+  [multifn dispatch-val-x dispatch-val-y]
+  (native/raw "__value = try_object<obj::multi_function>(~{ multifn })->prefer_method(~{ dispatch-val-x }, ~{ dispatch-val-y });"))
+
+(defn methods
+  "Given a multimethod, returns a map of dispatch values -> dispatch fns"
+  [multifn]
+  (native/raw "__value = try_object<obj::multi_function>(~{ multifn })->method_table;"))
+
+(defn get-method
+  "Given a multimethod and a dispatch value, returns the dispatch fn
+  that would apply to that value, or nil if none apply and no default"
+  [multifn dispatch-val]
+  (native/raw "__value = try_object<obj::multi_function>(~{ multifn })->get_fn(~{ dispatch-val });"))
+
+(defn prefers
+  "Given a multimethod, returns a map of preferred value -> set of other values"
+  [multifn]
+  (native/raw "__value = try_object<obj::multi_function>(~{ multifn })->prefer_table;"))
 
 ;; Hierarchies.
 (defn make-hierarchy


### PR DESCRIPTION
```clojure
➜  compiler+runtime git:(feat/multimethods) ✗ ./build/jank repl
Bottom of clojure.core
> (defmulti hello identity)
nil
> (derive ::third ::first)
nil
> (derive ::third ::second)
nil
> (defmethod hello ::first [_] (println "first"))
clojure.core/hello (multi_function@0x1783b9148)
> (defmethod hello ::second [_] (println "second"))
clojure.core/hello (multi_function@0x1783b9148)
> (hello ::third)
Exception: Multiple methods in multimethod 'box(0x1686e7380)' match dispatch value: :clojure.core/third -> :clojure.core/second and :clojure.core/first, and neither is preferred
> (prefer-method hello ::first ::second)
clojure.core/hello (multi_function@0x1783b9148)
> (hello ::third)
first
nil
> (methods hello)
{:clojure.core/first clojure.core/fn-28 (jit_function@0x17847c6c8), :clojure.core/second clojure.core/fn-32 (jit_function@0x1686d8808)}
> (prefers hello)
{:clojure.core/first #{:clojure.core/second}}
> (get-method hello ::third)
clojure.core/fn-28 (jit_function@0x17847c6c8)
> (get-method hello ::first)
clojure.core/fn-28 (jit_function@0x17847c6c8)
> (remove-method hello ::second)
clojure.core/hello (multi_function@0x1783b9148)
> (methods hello)
{:clojure.core/first clojure.core/fn-28 (jit_function@0x17847c6c8)}
> (hello ::second)
Exception: No method in multimethod 'box(0x1686e7380)' for dispatch value: :clojure.core/second
> (remove-all-methods hello)
clojure.core/hello (multi_function@0x1783b9148)
> (methods hello)
{}
> (prefers hello)
{}
>
```