### PR TITLE
Remove ocaml bindings from the clang build and change ubuntu instructions

### DIFF
--- a/compiler+runtime/bin/build-clang
+++ b/compiler+runtime/bin/build-clang
@@ -64,6 +64,8 @@ function build()
         -DLLVM_INCLUDE_EXAMPLES=OFF \
         -DLLVM_INCLUDE_TESTS=OFF \
         -DLLVM_ENABLE_ZSTD=OFF \
+        -DLLVM_BUILD_OCAML_BINDINGS=OFF \
+        -DLLVM_ENABLE_OCAMLDOC=OFF \
         -G "Unix Makefiles" \
         ../llvm/llvm
 

--- a/compiler+runtime/doc/build.md
+++ b/compiler+runtime/doc/build.md
@@ -3,10 +3,7 @@
 For Debian-based distros, this should be all you need:
 
 ```bash
-sudo apt-get install -y curl git git-lfs zip build-essential entr libssl-dev libdouble-conversion-dev pkg-config ninja-build python3-pip cmake debhelper devscripts gnupg zlib1g-dev entr libffi-dev clang libreadline-dev libzip-dev libbz2-dev doctest-dev libboost-all-dev
-
-# Using this PPA: https://apt.llvm.org/
-sudo apt install clang-20 llvm-20 libclang-20-dev libllvm20 libzstd-dev libedit-dev
+sudo apt-get install -y curl git git-lfs zip build-essential entr libssl-dev libdouble-conversion-dev pkg-config ninja-build python3-pip cmake debhelper devscripts gnupg zlib1g-dev entr libffi-dev clang libreadline-dev libzip-dev libbz2-dev doctest-dev libboost-all-dev gcc-14 g++-14
 ```
 
 For Arch:


### PR DESCRIPTION
Removed the unnecessary ocaml bindings and ocamldoc building that hindered building if ocaml was installed.
Added gcc14 (for libstdc++) to build clang on Ubuntu.