### PR TITLE
feat/support unicode identifiers

### DIFF
--- a/compiler+runtime/include/cpp/jank/read/lex.hpp
+++ b/compiler+runtime/include/cpp/jank/read/lex.hpp
@@ -152,7 +152,7 @@ namespace jank::read::lex
     result<token, error> next();
     option<char> peek() const;
     option<error> check_whitespace(native_bool const found_space);
-
+    
     iterator begin();
     iterator end();
 
@@ -162,5 +162,11 @@ namespace jank::read::lex
     /* True when seeing a '/' following a number. */
     native_bool found_slash_after_number{};
     native_persistent_string_view file;
+
+  private:
+    /* State for conversion */
+    void reset_state();
+    native_bool check_mb_error(size_t len);
+    std::mbstate_t state;
   };
 }

--- a/compiler+runtime/include/cpp/jank/read/lex.hpp
+++ b/compiler+runtime/include/cpp/jank/read/lex.hpp
@@ -127,6 +127,7 @@ namespace jank::read
 
 namespace jank::read::lex
 {
+  struct codepoint;
   struct processor
   {
     struct iterator
@@ -150,7 +151,7 @@ namespace jank::read::lex
     processor(native_persistent_string_view const &f);
 
     result<token, error> next();
-    option<char> peek() const;
+    result<codepoint, error> peek() const;
     option<error> check_whitespace(native_bool const found_space);
     
     iterator begin();
@@ -162,11 +163,5 @@ namespace jank::read::lex
     /* True when seeing a '/' following a number. */
     native_bool found_slash_after_number{};
     native_persistent_string_view file;
-
-  private:
-    /* State for conversion */
-    void reset_state();
-    native_bool check_mb_error(size_t len);
-    std::mbstate_t state;
   };
 }

--- a/compiler+runtime/include/cpp/jank/result.hpp
+++ b/compiler+runtime/include/cpp/jank/result.hpp
@@ -184,6 +184,25 @@ namespace jank
       return std::move(boost::get<R>(data));
     }
 
+    constexpr R &unwrap_or(R &fallback)
+    {
+      if(is_ok())
+      {
+        return boost::get<R>(data);
+      }
+      return fallback;
+    }
+
+    /* We don't take const& and return it since that's just asking for lifetime issues. */
+    constexpr R unwrap_or(R fallback) const
+    {
+      if(is_ok())
+      {
+        return boost::get<R>(data);
+      }
+      return std::move(fallback);
+    }
+
     constexpr native_bool operator==(result const &rhs) const
     {
       return rhs.data == data;

--- a/compiler+runtime/src/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/src/cpp/jank/read/lex.cpp
@@ -316,7 +316,6 @@ namespace jank::read
 
     result<token, error> processor::next()
     {
-      //std::cout << "Starting Pos: " << pos << "\n";
       /* Skip whitespace. */
       native_bool found_space{};
       while(true)
@@ -345,16 +344,12 @@ namespace jank::read
         start = oc.expect_ok().character;
         len = oc.expect_ok().len;
       }
-      //std::cout << "Current character: '" << static_cast<char>(start) << "'\n";
-      //std::cout << "++++++++++++++++++++++++++++++++++++\n";
       switch(start)
       {
         case '(':
-          //std::cout << "Open Paren Token\n";
           require_space = false;
           return ok(token{ pos++, token_kind::open_paren });
         case ')':
-          //std::cout << "Closed Paren Token\n";
           require_space = false;
           return ok(token{ pos++, token_kind::close_paren });
         case '[':
@@ -376,7 +371,6 @@ namespace jank::read
           {
             require_space = false;
 
-            //std::cout << "Character Token\n";
             auto const ch(peek());
             pos++;
 
@@ -402,7 +396,6 @@ namespace jank::read
               }
               if(pt.is_err() || !is_symbol_char(cpoint))
               {
-                //std::cout << "This isn't a char: '" << static_cast<char>(cpoint) << "'\n";
                 break;
               }
               pos += size;
@@ -410,7 +403,6 @@ namespace jank::read
 
             native_persistent_string_view const data{ file.data() + token_start,
                                                       ++pos - token_start };
-            //std::cout << "Character: " << data << " : " << data.size() << "\n";
             return ok(token{ token_start, pos - token_start, token_kind::character, data });
           }
         case ';':
@@ -457,7 +449,6 @@ namespace jank::read
         case '-':
         case '0' ... '9':
           {
-            //std::cout << "Number Token\n";
             auto &&e(check_whitespace(found_space));
             if(e.is_some())
             {
@@ -551,7 +542,6 @@ namespace jank::read
 
               ++pos;
             }
-            //std::cout << "Number Pos: " << pos << "\n";
 
             if(expecting_exponent)
             {
@@ -598,7 +588,6 @@ namespace jank::read
         case '>':
         case '%':
           {
-            //std::cout << "Symbol Token\n";
             
             auto &&e(check_whitespace(found_space));
             if(e.is_some())
@@ -616,16 +605,13 @@ namespace jank::read
               auto const size(oc.expect_ok().len);
               if(!is_symbol_char(c))
               {
-                //std::cout << "This isn't a symbol char: '" << static_cast<char>(c) << "'\n";
                 break;
               }
-              //std::cout << "Symbol (char : size): " << static_cast<char>(c) << " : " << size << "\n";              
               pos += size;
             }
             require_space = true;
             native_persistent_string_view const name{ file.data() + token_start,
                                                       ++pos - token_start };
-            //std::cout << "Symbol Pos: " << pos << "\n";
             if(name[0] == '/' && name.size() > 1)
             {
               return err(error{ token_start, "invalid symbol" });
@@ -642,13 +628,11 @@ namespace jank::read
             {
               return ok(token{ token_start, pos - token_start, token_kind::boolean, false });
             }
-            //std::cout << "Symbol: " << name << " : " << name.size() << "\n";
             return ok(token{ token_start, pos - token_start, token_kind::symbol, name });
           }
         /* Keywords. */
         case ':':
           {
-            //std::cout << "Keyword Token\n";
  
             auto &&e(check_whitespace(found_space));
             if(e.is_some())
@@ -683,16 +667,13 @@ namespace jank::read
               auto const size(oc.expect_ok().len);
               if(!is_symbol_char(c))
               {
-                //std::cout << "This isn't a keyword char: '" << static_cast<char>(c) << "'\n";
                 break;
               }
-              //std::cout << "Keyword (char : size): " << static_cast<char>(c) << " : " << size << "\n";              
               pos += size;
             }
             require_space = true;
             native_persistent_string_view const name{ file.data() + token_start + 1,
                                                       ++pos - token_start - 1 };
-            //std::cout << "Keyword Pos: " << pos << "\n";
 
             if(name[0] == '/' && name.size() > 1)
             {
@@ -703,8 +684,6 @@ namespace jank::read
               return err(error{ token_start, "invalid keyword: incorrect number of :" });
             }
 
-            //std::cout << "Keyword: " << name << " | Keyword Size: " << name.size() << "\n";
-            //std::cout << "Token Start: " << token_start << " | Pos: " << pos << "\n";
             return ok(token{ token_start, pos - token_start, token_kind::keyword, name });
           }
         /* Strings. */
@@ -787,7 +766,6 @@ namespace jank::read
         /* Reader macros. */
         case '#':
           {
-            //std::cout << "Reader Macro Token\n";
             auto &&e(check_whitespace(found_space));
             if(e.is_some())
             {
@@ -799,7 +777,6 @@ namespace jank::read
             size_t size{};
             if (oc.is_err())
             {
-              //std::cout << "c now equals = ' '\n";
               c = ' ';
               ++pos;
             }
@@ -809,7 +786,6 @@ namespace jank::read
               size = oc.expect_ok().len;
               pos += size;
             }
-            //std::cout << "Reader char: " << static_cast<char>(c) << "\n";
             switch(c)
             {
               case '_':
@@ -818,7 +794,6 @@ namespace jank::read
                   token{ token_start, pos - token_start, token_kind::reader_macro_comment });
               case '?':
                 {
-                  //std::cout << "Question Mark case in Reader macro!\n";
                   auto const maybe_splice(peek());
                   char32_t c{};
                   size_t size{};
@@ -848,16 +823,13 @@ namespace jank::read
                   }
                 }
               default:
-                //std::cout << "Default case in Reader macro!\n";
                 break;
             }
-            //std::cout << "Reader Macro Pos: " << pos << " Token Start: " << token_start << "\n";
             return ok(token{ token_start, pos - token_start, token_kind::reader_macro });
           }
         /* Syntax quoting. */
         case '`':
           {
-            //std::cout << "Syntax quoting token\n";
             auto &&e(check_whitespace(found_space));
             if(e.is_some())
             {
@@ -871,7 +843,6 @@ namespace jank::read
         /* Syntax unquoting. */
         case '~':
           {
-            //std::cout << "Syntax unquoting token\n";
             auto &&e(check_whitespace(found_space));
             if(e.is_some())
             {
@@ -918,7 +889,6 @@ namespace jank::read
             return ok(token{ token_start, pos - token_start, token_kind::deref });
           }
         default:
-          //std::cout << "Default Case\n";
           if (is_symbol_char(start))
           {
             auto &&e(check_whitespace(found_space));
@@ -927,32 +897,24 @@ namespace jank::read
               return err(std::move(e.unwrap()));
             }
             pos += len;
-            //std::cout << "Symbol Pos: " << pos << "\n";
             while(pos <= file.size())
             {
               auto const oc(convert_to_codepoint(file.substr(pos), pos));
               if(oc.is_err())
               {
-                //std::cout << file.substr(pos);
-                //std::cout << "----------Peeking error in Symbol-----------\n";
                 break;
               }
               auto const c(oc.expect_ok().character);
               auto const size(oc.expect_ok().len);
               if(!is_symbol_char(c))
               {
-                //std::cout << "This isn't a symbol char: '" << static_cast<char>(c) << "'\n";
                 break;
               }
-              //std::cout << "Symbol (char : size): " << static_cast<char>(c) << " : " << size << "\n";              
               pos += size;
             }
             require_space = true;
             native_persistent_string_view const name{ file.data() + token_start,
                                                       pos - token_start };
-            //std::cout << "Symbol Pos: " << pos << "\n";
-            //std::cout << "Symbol: " << name << " | Symbol Size: " << name.size() << "\n";
-            //std::cout << "Token Start: " << token_start << " | Pos: " << pos << "\n";
 
             return ok(token{ token_start, pos - token_start, token_kind::symbol, name });
           }

--- a/compiler+runtime/src/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/src/cpp/jank/read/lex.cpp
@@ -165,7 +165,7 @@ namespace jank::read
     struct codepoint
     {
       char32_t character{};
-      size_t len{};
+      uint8_t len{};
     };
 
     native_bool ratio::operator==(ratio const &rhs) const
@@ -281,7 +281,7 @@ namespace jank::read
       {
         return err(error{ pos, "Invalid character" });
       }
-      return ok(codepoint{ static_cast<char32_t>(wc), len });
+      return ok(codepoint{ static_cast<char32_t>(wc), static_cast<uint8_t>(len) });
     }
 
     static native_bool is_utf8_char(char32_t const c)

--- a/compiler+runtime/src/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/src/cpp/jank/read/lex.cpp
@@ -299,12 +299,18 @@ namespace jank::read
       }
       return false;
     }
+
+    static native_bool is_list_delimiter(char32_t c)
+    {
+      return c == '(' || c == ')' || c == '{' || c == '}' || c == '[' || c == ']';
+    }
     
     static native_bool is_symbol_char(char32_t const c)
     {
-      return !std::iswspace(c) && (std::iswalnum(static_cast<wint_t>(c)) != 0 || c == '_' || c == '-' || c == '/'
-                                   || c == '?' || c == '!' || c == '+' || c == '*' || c == '=' || c == '.' || c == '&'
-                                   || c == '<' || c == '>' || c == '#' || c == '%' || is_utf8_char(c));
+      return !std::iswspace(c) && !is_list_delimiter(c) &&
+        (std::iswalnum(static_cast<wint_t>(c)) != 0 || c == '_' || c == '-' || c == '/'
+         || c == '?' || c == '!' || c == '+' || c == '*' || c == '=' || c == '.' || c == '&'
+         || c == '<' || c == '>' || c == '#' || c == '%' || is_utf8_char(c));
     }
 
     result<token, error> processor::next()

--- a/compiler+runtime/src/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/src/cpp/jank/read/lex.cpp
@@ -340,6 +340,7 @@ namespace jank::read
       auto const oc{ convert_to_codepoint(file.substr(token_start), token_start) };
       if(oc.is_err())
       {
+        ++pos;
         return oc.expect_err();
       }
       switch(oc.expect_ok().character)

--- a/compiler+runtime/src/cpp/main.cpp
+++ b/compiler+runtime/src/cpp/main.cpp
@@ -231,7 +231,10 @@ try
   using namespace jank;
   using namespace jank::runtime;
 
-  /* Set locale */
+  /* To handle UTF-8 Text , we set the locale to the current environment locale
+   * Usage of the local locale allows better localization.
+   * Notably this might make text encoding become more platform dependent.
+   */
   std::locale::global(std::locale(""));
   
   /* The GC needs to enabled even before arg parsing, since our native types,

--- a/compiler+runtime/src/cpp/main.cpp
+++ b/compiler+runtime/src/cpp/main.cpp
@@ -231,6 +231,9 @@ try
   using namespace jank;
   using namespace jank::runtime;
 
+  /* Set locale */
+  std::locale::global(std::locale(""));
+  
   /* The GC needs to enabled even before arg parsing, since our native types,
    * like strings, use the GC for allocations. It can still be configured later. */
   GC_set_all_interior_pointers(1);

--- a/compiler+runtime/test/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/test/cpp/jank/read/lex.cpp
@@ -1442,6 +1442,16 @@ namespace jank::read::lex
                 { 0, 10, token_kind::keyword, "🐝/🥀"sv }
         }));
       }
+      SUBCASE("Malformed Text")
+      {
+        processor p{ "\xC0\x80" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error({ 0, "Unfinished Character" }),
+                error({ 1, "Unfinished Character" }),
+              }));
+      }
     }
   }
 }

--- a/compiler+runtime/test/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/test/cpp/jank/read/lex.cpp
@@ -566,29 +566,6 @@ namespace jank::read::lex
         }));
       }
 
-      SUBCASE("Positive no leading digit")
-      {
-        processor p{ ".0" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_results({
-                error{ 0, "unexpected character: ." },
-                token{ 1, token_kind::integer, 0ll },
-        }));
-      }
-
-      SUBCASE("Negative no leading digit")
-      {
-        processor p{ "-.0" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_results({
-                error{ 0, 1, "invalid number" },
-                error{ 1, "unexpected character: ." },
-                token{ 2, token_kind::integer, 0ll },
-        }));
-      }
-
       SUBCASE("Too many dots")
       {
         {
@@ -597,7 +574,7 @@ namespace jank::read::lex
           CHECK(tokens
                 == make_results({
                   error{ 0, 3, "invalid number" },
-                  error{ 3, "unexpected character: ." },
+                  token{ 3, 1, token_kind::symbol, "."sv},
           }));
         }
 
@@ -607,8 +584,7 @@ namespace jank::read::lex
           CHECK(tokens
                 == make_results({
                   error{ 0, 2, "invalid number" },
-                  error{ 2, "unexpected character: ." },
-                  token{ 3, token_kind::integer, 0ll },
+                  token{ 2, 2, token_kind::symbol, ".0"sv },
           }));
         }
         {
@@ -617,8 +593,7 @@ namespace jank::read::lex
           CHECK(tokens
                 == make_results({
                   error{ 0, 3, "invalid number" },
-                  error{ 3, "unexpected character: ." },
-                  token{ 4, token_kind::integer, 0ll },
+                  token{ 3, 2, token_kind::symbol, ".0"sv },
           }));
         }
       }
@@ -701,12 +676,11 @@ namespace jank::read::lex
           CHECK(tokens
                 == make_results({
                   error{ 0, 3, "invalid number" },
-                  error{ 3, "unexpected character: ." },
+                  token{ 3, 1, token_kind::symbol, "."sv },
                   token{ 5, 4, token_kind::real, 12.3l },
                   error{ 10, 14, "invalid number" },
-                  error{ 14, "unexpected character: ." },
-                  error{ 15, "expected whitespace before next token" },
-                  token{ 15, token_kind::integer, 3ll },
+                  error{ 14, "expected whitespace before next token" },
+                  token{ 14, 2, token_kind::symbol, ".3"sv },
           }));
         }
 

--- a/compiler+runtime/test/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/test/cpp/jank/read/lex.cpp
@@ -1334,59 +1334,83 @@ namespace jank::read::lex
 
     TEST_CASE("UTF-8")
     {
-      SUBCASE("Symbol")
+      SUBCASE("Symbols")
       {
-        processor p{ "👍" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 4, token_kind::symbol, "👍"sv }
-        }));
+        SUBCASE("Single character")
+        {
+          processor p{ "👍" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 4, token_kind::symbol, "👍"sv }
+          }));
+        }
+        SUBCASE("Multiple characters")
+        {
+          processor p{ "😎👍" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 8, token_kind::symbol, "😎👍"sv }
+          }));
+        }
+        SUBCASE("Symbol with mixed characters inside")
+        {
+          processor p{ "one-🍺-please!" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 16, token_kind::symbol, "one-🍺-please!"sv }
+          }));
+        }
+        SUBCASE("Qualified Symbol")
+        {
+          processor p{ "🐝/🥀" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 9, token_kind::symbol, "🐝/🥀"sv }
+          }));
+        }
       }
-      SUBCASE("Keyword")
+      SUBCASE("Keywords")
       {
-        processor p{ ":🍙" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 5, token_kind::keyword, "🍙"sv },
-        }));
-      }
-      SUBCASE("Multiple characters symbol")
-      {
-        processor p{ "😎👍" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 8, token_kind::symbol, "😎👍"sv }
-        }));
-      }
-      SUBCASE("Multiple characters keyword")
-      {
-        processor p{ ":🥩🍗" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 9, token_kind::keyword, "🥩🍗"sv }
-        }));
-      }
-      SUBCASE("Symbol with mixed characters inside")
-      {
-        processor p{ "one-🍺-please!" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 16, token_kind::symbol, "one-🍺-please!"sv }
-        }));
-      }
-      SUBCASE("Keyword with mixed characters inside")
-      {
-        processor p{ ":w🍪w" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 7, token_kind::keyword, "w🍪w"sv }
-        }));
+        SUBCASE("Single character")
+        {
+          processor p{ ":🍙" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 5, token_kind::keyword, "🍙"sv },
+          }));
+        }
+        SUBCASE("Multiple characters keyword")
+        {
+          processor p{ ":🥩🍗" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 9, token_kind::keyword, "🥩🍗"sv }
+          }));
+        }
+        SUBCASE("Keyword with mixed characters inside")
+        {
+          processor p{ ":w🍪w" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 7, token_kind::keyword, "w🍪w"sv }
+          }));
+        }
+        SUBCASE("Qualified Keyword")
+        {
+          processor p{ ":🐝/🥀" };
+          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 10, token_kind::keyword, "🐝/🥀"sv }
+          }));
+        }
       }
       SUBCASE("8-wide character")
       {
@@ -1424,24 +1448,8 @@ namespace jank::read::lex
                 { 0, 7, token_kind::keyword, "  "sv }
         }));
       }
-      SUBCASE("Qualified Symbol")
-      {
-        processor p{ "🐝/🥀" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 9, token_kind::symbol, "🐝/🥀"sv }
-        }));
-      }
-      SUBCASE("Qualified Keyword")
-      {
-        processor p{ ":🐝/🥀" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 10, token_kind::keyword, "🐝/🥀"sv }
-        }));
-      }
+
+
       SUBCASE("Malformed Text")
       {
         processor p{ "\xC0\x80" };

--- a/compiler+runtime/test/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/test/cpp/jank/read/lex.cpp
@@ -1339,13 +1339,31 @@ namespace jank::read::lex
     
     TEST_CASE("UTF-8")
     {
-      SUBCASE("Symbol name with UTF-8 character")
+      SUBCASE("UTF-8 symbol")
       {
         processor p{ "👍" };
         native_vector<result<token, error>> tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
-                  { 0, 4, token_kind::symbol }
+                  { 0, 4, token_kind::symbol, "👍"sv }
+                }));
+      }
+      SUBCASE("UTF-8 keyword")
+      {
+        processor p{ ":🍙" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                  { 0, 5, token_kind::keyword, "🍙"sv },
+        }));
+      }
+      SUBCASE("Multiple UTF-8 characters symbol")
+      {
+        processor p{ "😎👍" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                  { 0, 8, token_kind::symbol, "😎👍"sv }
                 }));
       }
     }

--- a/compiler+runtime/test/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/test/cpp/jank/read/lex.cpp
@@ -1337,35 +1337,35 @@ namespace jank::read::lex
       }
     }
     
-    TEST_CASE("UTF-8")
-    {
-      SUBCASE("UTF-8 symbol")
-      {
-        processor p{ "👍" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                  { 0, 4, token_kind::symbol, "👍"sv }
-                }));
-      }
-      SUBCASE("UTF-8 keyword")
-      {
-        processor p{ ":🍙" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                  { 0, 5, token_kind::keyword, "🍙"sv },
-        }));
-      }
-      SUBCASE("Multiple UTF-8 characters symbol")
-      {
-        processor p{ "😎👍" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                  { 0, 8, token_kind::symbol, "😎👍"sv }
-                }));
-      }
-    }
+    // TEST_CASE("UTF-8")
+    // {
+    //   SUBCASE("UTF-8 symbol")
+    //   {
+    //     processor p{ "👍" };
+    //     native_vector<result<token, error>> tokens(p.begin(), p.end());
+    //     CHECK(tokens
+    //           == make_tokens({
+    //               { 0, 4, token_kind::symbol, "👍"sv }
+    //             }));
+    //   }
+    //   SUBCASE("UTF-8 keyword")
+    //   {
+    //     processor p{ ":🍙" };
+    //     native_vector<result<token, error>> tokens(p.begin(), p.end());
+    //     CHECK(tokens
+    //           == make_tokens({
+    //               { 0, 5, token_kind::keyword, "🍙"sv },
+    //     }));
+    //   }
+    //   SUBCASE("Multiple UTF-8 characters symbol")
+    //   {
+    //     processor p{ "😎👍" };
+    //     native_vector<result<token, error>> tokens(p.begin(), p.end());
+    //     CHECK(tokens
+    //           == make_tokens({
+    //               { 0, 8, token_kind::symbol, "😎👍"sv }
+    //             }));
+    //   }
+    // }
   }
 }

--- a/compiler+runtime/test/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/test/cpp/jank/read/lex.cpp
@@ -566,6 +566,29 @@ namespace jank::read::lex
         }));
       }
 
+      SUBCASE("Positive no leading digit")
+      {
+        processor p{ ".0" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error{ 0, "unexpected character: ." },
+                token{ 1, token_kind::integer, 0ll },
+        }));
+      }
+
+      SUBCASE("Negative no leading digit")
+      {
+        processor p{ "-.0" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error{ 0, 1, "invalid number" },
+                error{ 1, "unexpected character: ." },
+                token{ 2, token_kind::integer, 0ll },
+        }));
+      }
+
       SUBCASE("Too many dots")
       {
         {
@@ -677,13 +700,13 @@ namespace jank::read::lex
           native_vector<result<token, error>> tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_results({
-                    error{ 0, 3, "invalid number" },
-                    error{ 3, "unexpected character: ." },
-                    token{ 5, 4, token_kind::real, 12.3l },
-                    error{ 10, 14, "invalid number" },
-                    error{ 14, "unexpected character: ." },
-                    error{ 15, "expected whitespace before next token" },
-                    token{ 15, token_kind::integer, 3ll },
+                  error{ 0, 3, "invalid number" },
+                  error{ 3, "unexpected character: ." },
+                  token{ 5, 4, token_kind::real, 12.3l },
+                  error{ 10, 14, "invalid number" },
+                  error{ 14, "unexpected character: ." },
+                  error{ 15, "expected whitespace before next token" },
+                  token{ 15, token_kind::integer, 3ll },
           }));
         }
 
@@ -1308,7 +1331,7 @@ namespace jank::read::lex
         }
       }
     }
-    
+
     TEST_CASE("UTF-8")
     {
       SUBCASE("Symbol")
@@ -1317,8 +1340,8 @@ namespace jank::read::lex
         native_vector<result<token, error>> tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
-                  { 0, 4, token_kind::symbol, "👍"sv }
-                }));
+                { 0, 4, token_kind::symbol, "👍"sv }
+        }));
       }
       SUBCASE("Keyword")
       {
@@ -1326,7 +1349,7 @@ namespace jank::read::lex
         native_vector<result<token, error>> tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
-                  { 0, 5, token_kind::keyword, "🍙"sv },
+                { 0, 5, token_kind::keyword, "🍙"sv },
         }));
       }
       SUBCASE("Multiple characters symbol")
@@ -1335,8 +1358,8 @@ namespace jank::read::lex
         native_vector<result<token, error>> tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
-                  { 0, 8, token_kind::symbol, "😎👍"sv }
-                }));
+                { 0, 8, token_kind::symbol, "😎👍"sv }
+        }));
       }
       SUBCASE("Multiple characters keyword")
       {
@@ -1344,8 +1367,8 @@ namespace jank::read::lex
         native_vector<result<token, error>> tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
-                  { 0, 9, token_kind::keyword, "🥩🍗"sv }
-                }));        
+                { 0, 9, token_kind::keyword, "🥩🍗"sv }
+        }));
       }
       SUBCASE("Symbol with mixed characters inside")
       {
@@ -1353,8 +1376,8 @@ namespace jank::read::lex
         native_vector<result<token, error>> tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
-                  { 0, 16, token_kind::symbol, "one-🍺-please!"sv }
-                }));                
+                { 0, 16, token_kind::symbol, "one-🍺-please!"sv }
+        }));
       }
       SUBCASE("Keyword with mixed characters inside")
       {
@@ -1362,8 +1385,8 @@ namespace jank::read::lex
         native_vector<result<token, error>> tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
-                  { 0, 7, token_kind::keyword, "w🍪w"sv }
-                }));                
+                { 0, 7, token_kind::keyword, "w🍪w"sv }
+        }));
       }
       SUBCASE("8-wide character")
       {
@@ -1371,8 +1394,8 @@ namespace jank::read::lex
         native_vector<result<token, error>> tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
-                  { 0, 8, token_kind::symbol, "🇪🇺"sv }
-                }));                      
+                { 0, 8, token_kind::symbol, "🇪🇺"sv }
+        }));
       }
       SUBCASE("Non-Latin Characters")
       {
@@ -1380,8 +1403,8 @@ namespace jank::read::lex
         native_vector<result<token, error>> tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
-                  { 0, 15, token_kind::symbol, "ありがとう"sv }
-                }));                      
+                { 0, 15, token_kind::symbol, "ありがとう"sv }
+        }));
       }
       SUBCASE("Non-Latin Characters")
       {
@@ -1389,8 +1412,8 @@ namespace jank::read::lex
         native_vector<result<token, error>> tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
-                  { 0, 16, token_kind::keyword, "ありがとう"sv }
-                }));                      
+                { 0, 16, token_kind::keyword, "ありがとう"sv }
+        }));
       }
       SUBCASE("Whitespace Characters")
       {
@@ -1398,8 +1421,8 @@ namespace jank::read::lex
         native_vector<result<token, error>> tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
-                  { 0, 7, token_kind::keyword, "  "sv }
-                }));                  
+                { 0, 7, token_kind::keyword, "  "sv }
+        }));
       }
       SUBCASE("Qualified Symbol")
       {
@@ -1407,8 +1430,8 @@ namespace jank::read::lex
         native_vector<result<token, error>> tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
-                  { 0, 9, token_kind::symbol, "🐝/🥀"sv }
-                }));
+                { 0, 9, token_kind::symbol, "🐝/🥀"sv }
+        }));
       }
       SUBCASE("Qualified Keyword")
       {
@@ -1416,10 +1439,9 @@ namespace jank::read::lex
         native_vector<result<token, error>> tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
-                  { 0, 10, token_kind::keyword, "🐝/🥀"sv }
-                }));
+                { 0, 10, token_kind::keyword, "🐝/🥀"sv }
+        }));
       }
-
     }
   }
 }

--- a/compiler+runtime/test/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/test/cpp/jank/read/lex.cpp
@@ -1391,11 +1391,11 @@ namespace jank::read::lex
       }
       SUBCASE("UTF-8 Whitespace Characters")
       {
-        processor p{ ":  " };
+        processor p{ ":  " };
         native_vector<result<token, error>> tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
-                  { 0, 7, token_kind::keyword, "  "sv }
+                  { 0, 7, token_kind::keyword, "  "sv }
                 }));                      
       }
       

--- a/compiler+runtime/test/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/test/cpp/jank/read/lex.cpp
@@ -1306,35 +1306,99 @@ namespace jank::read::lex
       }
     }
     
-    // TEST_CASE("UTF-8")
-    // {
-    //   SUBCASE("UTF-8 symbol")
-    //   {
-    //     processor p{ "👍" };
-    //     native_vector<result<token, error>> tokens(p.begin(), p.end());
-    //     CHECK(tokens
-    //           == make_tokens({
-    //               { 0, 4, token_kind::symbol, "👍"sv }
-    //             }));
-    //   }
-    //   SUBCASE("UTF-8 keyword")
-    //   {
-    //     processor p{ ":🍙" };
-    //     native_vector<result<token, error>> tokens(p.begin(), p.end());
-    //     CHECK(tokens
-    //           == make_tokens({
-    //               { 0, 5, token_kind::keyword, "🍙"sv },
-    //     }));
-    //   }
-    //   SUBCASE("Multiple UTF-8 characters symbol")
-    //   {
-    //     processor p{ "😎👍" };
-    //     native_vector<result<token, error>> tokens(p.begin(), p.end());
-    //     CHECK(tokens
-    //           == make_tokens({
-    //               { 0, 8, token_kind::symbol, "😎👍"sv }
-    //             }));
-    //   }
-    // }
+    TEST_CASE("UTF-8")
+    {
+      SUBCASE("UTF-8 symbol")
+      {
+        processor p{ "👍" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                  { 0, 4, token_kind::symbol, "👍"sv }
+                }));
+      }
+      SUBCASE("UTF-8 keyword")
+      {
+        processor p{ ":🍙" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                  { 0, 5, token_kind::keyword, "🍙"sv },
+        }));
+      }
+      SUBCASE("Multiple UTF-8 characters symbol")
+      {
+        processor p{ "😎👍" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                  { 0, 8, token_kind::symbol, "😎👍"sv }
+                }));
+      }
+      SUBCASE("Multiple UTF-8 characters keyword")
+      {
+        processor p{ ":🥩🍗" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                  { 0, 9, token_kind::keyword, "🥩🍗"sv }
+                }));        
+      }
+      SUBCASE("Symbol with UTF-8 characters inside")
+      {
+        processor p{ "one-🍺-please!" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                  { 0, 16, token_kind::symbol, "one-🍺-please!"sv }
+                }));                
+      }
+      SUBCASE("Keyword with UTF-8 characters inside")
+      {
+        processor p{ ":w🍪w" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                  { 0, 7, token_kind::keyword, "w🍪w"sv }
+                }));                
+      }
+      SUBCASE("8-wide UTF-8 character")
+      {
+        processor p{ "🇪🇺" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                  { 0, 8, token_kind::symbol, "🇪🇺"sv }
+                }));                      
+      }
+      SUBCASE("Non-Latin Characters")
+      {
+        processor p{ "ありがとう" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                  { 0, 15, token_kind::symbol, "ありがとう"sv }
+                }));                      
+      }
+      SUBCASE("Non-Latin Characters")
+      {
+        processor p{ ":ありがとう" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                  { 0, 16, token_kind::keyword, "ありがとう"sv }
+                }));                      
+      }
+      SUBCASE("UTF-8 Whitespace Characters")
+      {
+        processor p{ ":  " };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                  { 0, 7, token_kind::keyword, ":  "sv }
+                }));                      
+      }
+      
+    }
   }
 }

--- a/compiler+runtime/test/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/test/cpp/jank/read/lex.cpp
@@ -1336,5 +1336,18 @@ namespace jank::read::lex
         }
       }
     }
+    
+    TEST_CASE("UTF-8")
+    {
+      SUBCASE("Symbol name with UTF-8 character")
+      {
+        processor p{ "👍" };
+        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                  { 0, 4, token_kind::symbol }
+                }));
+      }
+    }
   }
 }

--- a/compiler+runtime/test/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/test/cpp/jank/read/lex.cpp
@@ -1395,7 +1395,7 @@ namespace jank::read::lex
         native_vector<result<token, error>> tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
-                  { 0, 7, token_kind::keyword, ":  "sv }
+                  { 0, 7, token_kind::keyword, "  "sv }
                 }));                      
       }
       

--- a/compiler+runtime/test/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/test/cpp/jank/read/lex.cpp
@@ -754,14 +754,13 @@ namespace jank::read::lex
         }));
       }
 
-      SUBCASE("Invalid symbol after a valid char")
+      SUBCASE("Valid lexed character with symbol")
       {
         processor p{ R"(\1:)" };
         native_vector<result<token, error>> tokens(p.begin(), p.end());
         CHECK(tokens
               == make_results({
-                token{ 0, 2, token_kind::character, "\\1"sv },
-                error{ 2, "invalid keyword: expected non-whitespace character after :" }
+                token{ 0, 3, token_kind::character, "\\1:"sv },
         }));
       }
 
@@ -1004,8 +1003,6 @@ namespace jank::read::lex
         CHECK(tokens
               == make_results({
                 error{ 0, "invalid keyword: incorrect number of :" },
-                error{ 2, "expected whitespace before next token" },
-                token{ 2, 4, token_kind::keyword, "foo"sv }
         }));
       }
 
@@ -1016,8 +1013,6 @@ namespace jank::read::lex
         CHECK(tokens
               == make_results({
                 error{ 0, "invalid keyword: incorrect number of :" },
-                error{ 2, "expected whitespace before next token" },
-                token{ 2, 5, token_kind::keyword, ":foo"sv }
         }));
       }
     }

--- a/compiler+runtime/test/cpp/main.cpp
+++ b/compiler+runtime/test/cpp/main.cpp
@@ -10,6 +10,9 @@
 int main(int const argc, char const **argv)
 try
 {
+  /* Set locale */
+  std::locale::global(std::locale(""));
+  
   GC_set_all_interior_pointers(1);
   GC_enable();
 

--- a/compiler+runtime/test/cpp/main.cpp
+++ b/compiler+runtime/test/cpp/main.cpp
@@ -9,8 +9,7 @@
 /* NOLINTNEXTLINE(bugprone-exception-escape): println can throw. */
 int main(int const argc, char const **argv)
 try
-{
-  /* Set locale */
+{  
   std::locale::global(std::locale(""));
   
   GC_set_all_interior_pointers(1);


### PR DESCRIPTION
Adds UTF-8 Unicode support (fixes #89).

It currently passes all the tests, though I made some modifications to some lex tests.
However, I think these changes better reflect the desired behavior matching the official Clojure implementation.