### PR TITLE
feat(objs): adds native_pointer_wrapper obj

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 test.jank
 jank-generated.hpp
 a.out
+.jank-native-repl-history
+.jank-repl-history
 
 # Vim files
 /.ycm_extra_conf.py*

--- a/compiler+runtime/CMakeLists.txt
+++ b/compiler+runtime/CMakeLists.txt
@@ -176,6 +176,7 @@ add_library(
   src/cpp/jank/runtime/obj/native_function_wrapper.cpp
   src/cpp/jank/runtime/obj/jit_function.cpp
   src/cpp/jank/runtime/obj/multi_function.cpp
+  src/cpp/jank/runtime/obj/native_pointer_wrapper.cpp
   src/cpp/jank/runtime/obj/symbol.cpp
   src/cpp/jank/runtime/obj/keyword.cpp
   src/cpp/jank/runtime/obj/character.cpp

--- a/compiler+runtime/include/cpp/jank/runtime/core/make_box.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core/make_box.hpp
@@ -83,14 +83,6 @@ namespace jank::runtime
   }
 
   template <typename T>
-  requires std::is_pointer_v<T>
-  [[gnu::always_inline, gnu::flatten, gnu::hot]]
-  inline auto make_box(T const d)
-  {
-    return make_box<obj::native_pointer_wrapper>(static_cast<void *>(d));
-  }
-
-  template <typename T>
   requires std::is_floating_point_v<T>
   [[gnu::always_inline, gnu::flatten, gnu::hot]]
   inline auto make_box(T const d)

--- a/compiler+runtime/include/cpp/jank/runtime/core/make_box.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core/make_box.hpp
@@ -83,6 +83,14 @@ namespace jank::runtime
   }
 
   template <typename T>
+  requires std::is_pointer_v<T>
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
+  inline auto make_box(T const d)
+  {
+    return make_box<obj::native_pointer_wrapper>(static_cast<void *>(d));
+  }
+
+  template <typename T>
   requires std::is_floating_point_v<T>
   [[gnu::always_inline, gnu::flatten, gnu::hot]]
   inline auto make_box(T const d)

--- a/compiler+runtime/include/cpp/jank/runtime/erasure.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/erasure.hpp
@@ -34,6 +34,7 @@
 #include <jank/runtime/obj/jit_function.hpp>
 #include <jank/runtime/obj/multi_function.hpp>
 #include <jank/runtime/obj/native_function_wrapper.hpp>
+#include <jank/runtime/obj/native_pointer_wrapper.hpp>
 #include <jank/runtime/obj/persistent_vector_sequence.hpp>
 #include <jank/runtime/obj/persistent_string_sequence.hpp>
 #include <jank/runtime/obj/persistent_list_sequence.hpp>
@@ -361,6 +362,12 @@ namespace jank::runtime
       case object_type::native_function_wrapper:
         {
           return fn(expect_object<obj::native_function_wrapper>(erased),
+                    std::forward<Args>(args)...);
+        }
+        break;
+      case object_type::native_pointer_wrapper:
+        {
+          return fn(expect_object<obj::native_pointer_wrapper>(erased),
                     std::forward<Args>(args)...);
         }
         break;

--- a/compiler+runtime/include/cpp/jank/runtime/obj/native_pointer_wrapper.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/native_pointer_wrapper.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <jank/runtime/object.hpp>
+
+namespace jank::runtime
+{
+  template <>
+  struct static_object<object_type::native_pointer_wrapper> : gc
+  {
+    static constexpr native_bool pointer_free{ false };
+
+    static_object() = default;
+    static_object(static_object &&) = default;
+    static_object(static_object const &) = default;
+    static_object(void *);
+
+    /* behavior::object_like */
+    native_bool equal(object const &) const;
+    native_persistent_string to_string() const;
+    void to_string(fmt::memory_buffer &buff) const;
+    native_persistent_string to_code_string() const;
+    native_hash to_hash() const;
+
+    template <typename T>
+    T *as() const
+    {
+      return reinterpret_cast<T *>(data);
+    }
+
+    object base{ object_type::native_pointer_wrapper };
+
+    void *data{};
+  };
+
+  namespace obj
+  {
+    using native_pointer_wrapper = static_object<object_type::native_pointer_wrapper>;
+    using native_pointer_wrapper_ptr = native_box<native_pointer_wrapper>;
+  }
+}

--- a/compiler+runtime/include/cpp/jank/runtime/obj/native_pointer_wrapper.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/native_pointer_wrapper.hpp
@@ -12,7 +12,7 @@ namespace jank::runtime
     static_object() = default;
     static_object(static_object &&) = default;
     static_object(static_object const &) = default;
-    static_object(void *);
+    static_object(void * const);
 
     /* behavior::object_like */
     native_bool equal(object const &) const;

--- a/compiler+runtime/include/cpp/jank/runtime/object.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/object.hpp
@@ -65,6 +65,8 @@ namespace jank::runtime
     jit_function,
     multi_function,
 
+    native_pointer_wrapper,
+
     atom,
     volatile_,
     reduced,

--- a/compiler+runtime/src/cpp/jank/runtime/obj/native_pointer_wrapper.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/native_pointer_wrapper.cpp
@@ -2,7 +2,7 @@
 
 namespace jank::runtime
 {
-  obj::native_pointer_wrapper::static_object(void *d)
+  obj::native_pointer_wrapper::static_object(void * const d)
     : data{ d }
   {
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/native_pointer_wrapper.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/native_pointer_wrapper.cpp
@@ -1,0 +1,45 @@
+#include <jank/runtime/obj/native_pointer_wrapper.hpp>
+
+namespace jank::runtime
+{
+  obj::native_pointer_wrapper::static_object(void *d)
+    : data{ d }
+  {
+  }
+
+  native_bool obj::native_pointer_wrapper::equal(object const &o) const
+  {
+    if(o.type != object_type::native_pointer_wrapper)
+    {
+      return false;
+    }
+
+    auto const c(expect_object<obj::native_pointer_wrapper>(&o));
+    return data == c->data;
+  }
+
+  void obj::native_pointer_wrapper::to_string(fmt::memory_buffer &buff) const
+  {
+    fmt::format_to(std::back_inserter(buff),
+                   "{}@{}",
+                   magic_enum::enum_name(base.type),
+                   fmt::ptr(&base));
+  }
+
+  native_persistent_string obj::native_pointer_wrapper::to_string() const
+  {
+    fmt::memory_buffer buff;
+    to_string(buff);
+    return native_persistent_string{ buff.data(), buff.size() };
+  }
+
+  native_persistent_string obj::native_pointer_wrapper::to_code_string() const
+  {
+    return to_string();
+  }
+
+  native_hash obj::native_pointer_wrapper::to_hash() const
+  {
+    return static_cast<native_hash>(reinterpret_cast<uintptr_t>(data));
+  }
+}


### PR DESCRIPTION
closes #136 
```cpp
➜  compiler+runtime git:(feat/native_pointer_wrapper) ✗ ./build/jank cpp-repl
Bottom of clojure.core
native> using namespace jank;
native> using namespace jank::runtime;
native> uint32_t a{22};
native> uint32_t *pa{&a};
native>
native> fmt::println("native: {}", fmt::ptr(pa));
native: 0x74b63d92d000
native>
native> auto boxed{make_box(pa)};
native> fmt::println("boxed: {}", boxed->to_string());
boxed: native_pointer_wrapper@0x74b62e8dcfc0
native>
native> auto pointer_wrapper{try_object<obj::native_pointer_wrapper>(boxed)};
native> auto unboxed{pointer_wrapper->as<uint32_t>()};
native>
native> fmt::println("unboxed: {}", fmt::ptr(unboxed));
unboxed: 0x74b63d92d000
native> fmt::println("unboxed value: {}", *unboxed);
unboxed value: 22
native>
```

After the changes:
```cpp
➜  compiler+runtime git:(feat/native_pointer_wrapper) ✗ ./build/jank cpp-repl
Bottom of clojure.core
native> using namespace jank;
native> using namespace jank::runtime;
native> uint32_t a{22};;
native> uint32_t *pa{&a};
native>
native> fmt::println("native: {}", fmt::ptr(pa));
native: 0x79e0b59e5000
native>
native> auto boxed{make_box<obj::native_pointer_wrapper>(pa)};
native> fmt::println("boxed: {}", boxed->to_string());
boxed: native_pointer_wrapper@0x79e0a6ad5fc0
native>
native> auto pointer_wrapper{try_object<obj::native_pointer_wrapper>(boxed)};
native> auto unboxed{pointer_wrapper->as<uint32_t>()};
native>
native> fmt::println("unboxed: {}", fmt::ptr(unboxed));
unboxed: 0x79e0b59e5000
native> fmt::println("unboxed value: {}", *unboxed);
unboxed value: 22
native>
```