### PR TITLE
Support octal, hex, and arbitrary radix numbers

### DIFF
--- a/compiler+runtime/include/cpp/jank/analyze/expr/var_deref.hpp
+++ b/compiler+runtime/include/cpp/jank/analyze/expr/var_deref.hpp
@@ -10,6 +10,12 @@ namespace jank::analyze::expr
   template <typename E>
   struct var_deref : expression_base
   {
+    /* Holds the fully qualified name for the originally resolved var.
+     * It will be useful to know that the var deref happened through a
+     * referred var, for static analysis and error reporting.
+     *
+     * For all the other purposes, `var` member should be used that points
+     * to the actual value of the var.. */
     runtime::obj::symbol_ptr qualified_name{};
     runtime::var_ptr var{};
 

--- a/compiler+runtime/include/cpp/jank/read/lex.hpp
+++ b/compiler+runtime/include/cpp/jank/read/lex.hpp
@@ -213,14 +213,14 @@ namespace jank::read::lex
     processor(native_persistent_string_view const &f);
 
     result<token, error> next();
-    result<codepoint, error> peek() const;
+    result<codepoint, error> peek(native_integer const ahead = 1) const;
     option<error> check_whitespace(native_bool const found_space);
 
     iterator begin();
     iterator end();
 
     size_t pos{};
-    /* Whether or not the previous token requires a space after it. */
+    /* Whether the previous token requires a space after it. */
     native_bool require_space{};
     /* True when seeing a '/' following a number. */
     native_bool found_slash_after_number{};

--- a/compiler+runtime/include/cpp/jank/runtime/module/loader.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/module/loader.hpp
@@ -27,6 +27,14 @@ namespace jank::runtime::module
     latest,
   };
 
+  enum class module_type : uint8_t
+  {
+    o,
+    cpp,
+    jank,
+    cljc
+  };
+
   struct file_entry
   {
     object_ptr to_runtime_data() const;
@@ -68,6 +76,24 @@ namespace jank::runtime::module
       option<file_entry> cljc;
     };
 
+    struct find_result
+    {
+      /*
+       * All the sources for a module
+       */
+      entry sources;
+      /*
+       * On the basis of origin, source that should be loaded.
+       */
+      option<module_type> to_load;
+
+      find_result(entry const &sources, module_type const to_load)
+        : sources{ sources }
+        , to_load{ to_load }
+      {
+      }
+    };
+
     /* These separators match what the JVM does on each system. */
 #ifdef _WIN32
     static constexpr char module_separator{ ';' };
@@ -80,6 +106,8 @@ namespace jank::runtime::module
     native_bool is_loaded(native_persistent_string_view const &) const;
     void set_loaded(native_persistent_string_view const &);
 
+    string_result<find_result>
+    find(native_persistent_string_view const &module, origin const ori);
     string_result<void> load(native_persistent_string_view const &module, origin const ori);
 
     string_result<void>

--- a/compiler+runtime/include/cpp/jank/runtime/module/loader.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/module/loader.hpp
@@ -38,6 +38,8 @@ namespace jank::runtime::module
   struct file_entry
   {
     object_ptr to_runtime_data() const;
+    native_bool exists() const;
+    std::time_t last_modified_at() const;
 
     /* If the file is within a JAR, this will be the path to the JAR. */
     option<native_persistent_string> archive_path;
@@ -78,20 +80,10 @@ namespace jank::runtime::module
 
     struct find_result
     {
-      /*
-       * All the sources for a module
-       */
+      /* All the sources for a module */
       entry sources;
-      /*
-       * On the basis of origin, source that should be loaded.
-       */
+      /* On the basis of origin, source that should be loaded. */
       option<module_type> to_load;
-
-      find_result(entry const &sources, module_type const to_load)
-        : sources{ sources }
-        , to_load{ to_load }
-      {
-      }
     };
 
     /* These separators match what the JVM does on each system. */
@@ -106,8 +98,7 @@ namespace jank::runtime::module
     native_bool is_loaded(native_persistent_string_view const &) const;
     void set_loaded(native_persistent_string_view const &);
 
-    string_result<find_result>
-    find(native_persistent_string_view const &module, origin const ori);
+    string_result<find_result> find(native_persistent_string_view const &module, origin const ori);
     string_result<void> load(native_persistent_string_view const &module, origin const ori);
 
     string_result<void>

--- a/compiler+runtime/src/cpp/jank/codegen/llvm_processor.cpp
+++ b/compiler+runtime/src/cpp/jank/codegen/llvm_processor.cpp
@@ -292,7 +292,7 @@ namespace jank::codegen
   llvm::Value *llvm_processor::gen(expr::var_deref<expression> const &expr,
                                    expr::function_arity<expression> const &) const
   {
-    auto const ref(gen_var(expr.qualified_name));
+    auto const ref(gen_var(make_box<obj::symbol>(expr.var->n, expr.var->name)));
     auto const fn_type(
       llvm::FunctionType::get(ctx->builder->getPtrTy(), { ctx->builder->getPtrTy() }, false));
     auto const fn(ctx->module->getOrInsertFunction("jank_deref", fn_type));

--- a/compiler+runtime/src/cpp/jank/runtime/module/loader.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/module/loader.cpp
@@ -378,6 +378,16 @@ namespace jank::runtime::module
     }
     else
     {
+      /* Ignoring object files from the archives here for security and portability
+       * reasons.
+       *
+       * Security:
+       * A dependency can include a binary version of a module that doesn't belong
+       * to it.
+       *
+       * Portability:
+       * Unlike class files, object files are tied to the OS, architecture, c++ stdlib etc,
+       * making it hard to share them. */
       if(entry->second.o.is_some() && entry->second.o.unwrap().archive_path.is_none()
          && (entry->second.jank.is_some() || entry->second.cljc.is_some()))
       {
@@ -438,7 +448,7 @@ namespace jank::runtime::module
     auto const &found_module{ loader::find(module, ori) };
     if(found_module.is_err())
     {
-      return err(std::move(found_module.expect_err()));
+      return err(found_module.expect_err());
     }
 
     string_result<void> res(err(fmt::format("Couldn't load module: {}", module)));

--- a/compiler+runtime/src/cpp/jank/runtime/module/loader.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/module/loader.cpp
@@ -202,11 +202,11 @@ namespace jank::runtime::module
 
     if(registered)
     {
-    //   fmt::println("register_entry {} {} {} {}",
-    //               entry.archive_path.unwrap_or("None"),
-    //               entry.path,
-    //               module_path.string(),
-    //               path_to_module(module_path));
+      //   fmt::println("register_entry {} {} {} {}",
+      //               entry.archive_path.unwrap_or("None"),
+      //               entry.path,
+      //               module_path.string(),
+      //               path_to_module(module_path));
     }
   }
 
@@ -407,6 +407,11 @@ namespace jank::runtime::module
 
   string_result<void> loader::load(native_persistent_string_view const &module, origin const ori)
   {
+    if(loader::is_loaded(module))
+    {
+      return ok();
+    }
+
     auto const &found_module{ loader::find(module, ori) };
     if(found_module.is_err())
     {
@@ -439,7 +444,7 @@ namespace jank::runtime::module
       return res;
     }
 
-    loaded.emplace(module);
+    loader::set_loaded(module);
 
     return ok();
   }

--- a/compiler+runtime/src/cpp/jank/util/scope_exit.cpp
+++ b/compiler+runtime/src/cpp/jank/util/scope_exit.cpp
@@ -1,4 +1,9 @@
+#include <fmt/format.h>
+
 #include <jank/util/scope_exit.hpp>
+#include <jank/runtime/object.hpp>
+#include <jank/runtime/core/to_string.hpp>
+#include <jank/native_persistent_string/fmt.hpp>
 
 namespace jank::util
 {
@@ -14,6 +19,19 @@ namespace jank::util
 
   scope_exit::~scope_exit()
   {
-    func();
+    try
+    {
+      func();
+    }
+    catch(runtime::object_ptr const o)
+    {
+      /* TODO: Panic */
+      fmt::println(stderr, "Exception caught in scope_exit: {}", runtime::to_string(o));
+    }
+    catch(std::exception const &e)
+    {
+      /* TODO: Panic */
+      fmt::println(stderr, "Exception caught in scope_exit: {}", e.what());
+    }
   }
 }

--- a/compiler+runtime/src/cpp/main.cpp
+++ b/compiler+runtime/src/cpp/main.cpp
@@ -101,7 +101,10 @@ namespace jank
     using namespace jank;
     using namespace jank::runtime;
 
-    //__rt_ctx->load_module("/clojure.core", module::origin::latest).expect_ok();
+    if(opts.target_ns != "clojure.core")
+    {
+      __rt_ctx->load_module("/clojure.core", module::origin::latest).expect_ok();
+    }
     __rt_ctx->compile_module(opts.target_ns).expect_ok();
   }
 

--- a/compiler+runtime/src/cpp/main.cpp
+++ b/compiler+runtime/src/cpp/main.cpp
@@ -101,7 +101,7 @@ namespace jank
     using namespace jank;
     using namespace jank::runtime;
 
-    //__rt_ctx->load_module("/clojure.core", module::origin::latest).expect_ok();
+    __rt_ctx->load_module("/clojure.core", module::origin::latest).expect_ok();
     __rt_ctx->compile_module(opts.target_ns).expect_ok();
   }
 

--- a/compiler+runtime/src/cpp/main.cpp
+++ b/compiler+runtime/src/cpp/main.cpp
@@ -101,7 +101,7 @@ namespace jank
     using namespace jank;
     using namespace jank::runtime;
 
-    __rt_ctx->load_module("/clojure.core", module::origin::latest).expect_ok();
+    //__rt_ctx->load_module("/clojure.core", module::origin::latest).expect_ok();
     __rt_ctx->compile_module(opts.target_ns).expect_ok();
   }
 

--- a/compiler+runtime/test/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/test/cpp/jank/read/lex.cpp
@@ -634,12 +634,12 @@ namespace jank::read::lex
         native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_results({
-                error{  0,  3,          "invalid number: chars 'g' are invalid for radix 16" },
-                error{  4,  8,          "invalid number: chars '-' are invalid for radix 16" },
-                error{  9, 14,          "invalid number: chars '.' are invalid for radix 16" },
-                error{ 15, 21,          "invalid number: chars '-' are invalid for radix 16" },
+                error{  0,  3,       "invalid number: chars 'g' are invalid for radix 16" },
+                error{  4,  8,       "invalid number: chars '-' are invalid for radix 16" },
+                error{  9, 14,       "invalid number: chars '.' are invalid for radix 16" },
+                error{ 15, 21,       "invalid number: chars '-' are invalid for radix 16" },
                 error{ 22, 24, "unexpected end of radix 16 number, expecting more digits" },
-                error{ 25, 27,          "invalid number: chars 'x' are invalid for radix 10" }
+                error{ 25, 27,       "invalid number: chars 'x' are invalid for radix 10" }
         }));
       }
 
@@ -718,10 +718,10 @@ namespace jank::read::lex
         native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_results({
-                error{  0,  3,        "invalid number: chars '3' are invalid for radix 2" },
-                error{  4,  8,       "invalid number: chars 'z' are invalid for radix 35" },
-                error{  9, 14,        "invalid number: chars 'e' are invalid for radix 8" },
-                error{ 15, 22,       "invalid number: chars '-' are invalid for radix 19" },
+                error{  0,  3,     "invalid number: chars '3' are invalid for radix 2" },
+                error{  4,  8,    "invalid number: chars 'z' are invalid for radix 35" },
+                error{  9, 14,     "invalid number: chars 'e' are invalid for radix 8" },
+                error{ 15, 22,    "invalid number: chars '-' are invalid for radix 19" },
                 error{ 23, 25, "unexpected end of radix number, expecting more digits" },
                 error{ 26, 29, "unexpected end of radix number, expecting more digits" }
         }));

--- a/compiler+runtime/test/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/test/cpp/jank/read/lex.cpp
@@ -115,7 +115,7 @@ namespace jank::read::lex
       SUBCASE("Empty")
       {
         processor p{ ";" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 1, token_kind::comment, ""sv }
@@ -125,7 +125,7 @@ namespace jank::read::lex
       SUBCASE("Empty multi-line")
       {
         processor p{ ";\n;" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 1, token_kind::comment, ""sv },
@@ -136,7 +136,7 @@ namespace jank::read::lex
       SUBCASE("Non-empty")
       {
         processor p{ "; Hello hello" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 12, token_kind::comment, " Hello hello"sv }
@@ -146,7 +146,7 @@ namespace jank::read::lex
       SUBCASE("Multiple on same line")
       {
         processor p{ "; Hello hello ; \"hi hi\"" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 22, token_kind::comment, " Hello hello ; \"hi hi\""sv }
@@ -156,7 +156,7 @@ namespace jank::read::lex
       SUBCASE("Multiple ; in a row")
       {
         processor p{ ";;; Hello hello 12" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 17, token_kind::comment, " Hello hello 12"sv }
@@ -166,7 +166,7 @@ namespace jank::read::lex
       SUBCASE("Expressions before")
       {
         processor p{ "1 2 ; meow" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 1, token_kind::integer,       1ll },
@@ -178,7 +178,7 @@ namespace jank::read::lex
       SUBCASE("Expressions before and after")
       {
         processor p{ "1 ; meow\n2" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 1, token_kind::integer,       1ll },
@@ -193,7 +193,7 @@ namespace jank::read::lex
       SUBCASE("Empty")
       {
         processor p{ "()" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0,  token_kind::open_paren },
@@ -204,7 +204,7 @@ namespace jank::read::lex
       SUBCASE("Nested")
       {
         processor p{ "(())" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0,  token_kind::open_paren },
@@ -219,7 +219,7 @@ namespace jank::read::lex
         SUBCASE("Open")
         {
           processor p{ "(" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
                   { 0, token_kind::open_paren }
@@ -229,7 +229,7 @@ namespace jank::read::lex
         SUBCASE("Closed")
         {
           processor p{ ")" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
                   { 0, token_kind::close_paren }
@@ -243,7 +243,7 @@ namespace jank::read::lex
       SUBCASE("Empty")
       {
         processor p{ "[]" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0,  token_kind::open_square_bracket },
@@ -254,7 +254,7 @@ namespace jank::read::lex
       SUBCASE("Nested")
       {
         processor p{ "[[]]" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0,  token_kind::open_square_bracket },
@@ -267,7 +267,7 @@ namespace jank::read::lex
       SUBCASE("Mixed")
       {
         processor p{ "[(foo [1 2]) 2]" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, token_kind::open_square_bracket },
@@ -288,7 +288,7 @@ namespace jank::read::lex
         SUBCASE("Open")
         {
           processor p{ "[" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
                   { 0, token_kind::open_square_bracket }
@@ -298,7 +298,7 @@ namespace jank::read::lex
         SUBCASE("Closed")
         {
           processor p{ "]" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
                   { 0, token_kind::close_square_bracket }
@@ -312,7 +312,7 @@ namespace jank::read::lex
       SUBCASE("Full match")
       {
         processor p{ "nil" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 3, token_kind::nil }
@@ -322,7 +322,7 @@ namespace jank::read::lex
       SUBCASE("Partial match, prefix")
       {
         processor p{ "nili" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 4, token_kind::symbol, "nili"sv }
@@ -332,7 +332,7 @@ namespace jank::read::lex
       SUBCASE("Partial match, suffix")
       {
         processor p{ "onil" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 4, token_kind::symbol, "onil"sv }
@@ -345,7 +345,7 @@ namespace jank::read::lex
       SUBCASE("Full match")
       {
         processor p{ "true false" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 4, token_kind::boolean,  true },
@@ -356,7 +356,7 @@ namespace jank::read::lex
       SUBCASE("Partial match, prefix")
       {
         processor p{ "true- falsey" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 5, token_kind::symbol,  "true-"sv },
@@ -367,7 +367,7 @@ namespace jank::read::lex
       SUBCASE("Partial match, suffix")
       {
         processor p{ "sotrue ffalse" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 6, token_kind::symbol, "sotrue"sv },
@@ -380,7 +380,7 @@ namespace jank::read::lex
       SUBCASE("Success - x/x")
       {
         processor p{ "4/5" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 3, token_kind::ratio, { .numerator = 4, .denominator = 5 } }
@@ -389,7 +389,7 @@ namespace jank::read::lex
       SUBCASE("Success - -x/x")
       {
         processor p{ "-4/5" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 4, token_kind::ratio, { .numerator = -4, .denominator = 5 } }
@@ -398,7 +398,7 @@ namespace jank::read::lex
       SUBCASE("Success - -x/-x")
       {
         processor p{ "-4/-5" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 5, token_kind::ratio, { .numerator = -4, .denominator = -5 } }
@@ -407,31 +407,29 @@ namespace jank::read::lex
       SUBCASE("Failures - x//x")
       {
         processor p{ "4//5" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(
-          tokens
-          == make_results({ { error(0, 4, "invalid ratio: expecting an integer denominator") } }));
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens == make_results({ { error(2, 2, "invalid symbol") } }));
       }
       SUBCASE("Failures - x/x/x")
       {
         processor p{ "4/5/4" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_results({ { error(0, 3, "invalid ratio: expecting an integer denominator") },
-                                { error(3, 3, "invalid symbol") } }));
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(
+          tokens
+          == make_results({ { error(2, 3, "invalid ratio") }, { error(3, 3, "invalid symbol") } }));
       }
       SUBCASE("Failures - x/x/x/x")
       {
         processor p{ "4/5/4/5/6/7/7" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_results({ { error(0, 3, "invalid ratio: expecting an integer denominator") },
-                                { error(3, 3, "invalid symbol") } }));
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(
+          tokens
+          == make_results({ { error(2, 3, "invalid ratio") }, { error(3, 3, "invalid symbol") } }));
       }
       SUBCASE("Failures - x.x/x")
       {
         processor p{ "4.4/5" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(
           tokens
           == make_results({ { error(0, 3, "invalid ratio") }, { error(3, 3, "invalid symbol") } }));
@@ -439,10 +437,30 @@ namespace jank::read::lex
       SUBCASE("Failures - x/x.x")
       {
         processor p{ "4/5.9" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(
           tokens
           == make_results({ { error(0, 5, "invalid ratio: expecting an integer denominator") } }));
+      }
+      SUBCASE("Failures - xex/x")
+      {
+        processor p{ "4e1/5" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error{ 0, 3,  "invalid ratio" },
+                error{ 3, 3, "invalid symbol" }
+        }));
+      }
+      SUBCASE("Failures - x/xex")
+      {
+        processor p{ "4/5e9" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error{ 2, 3, "invalid ratio: ratio cannot have scientific notation" },
+                token{ 3, 2, token_kind::symbol, "e9"sv }
+        }));
       }
     }
     TEST_CASE("Integer")
@@ -450,7 +468,7 @@ namespace jank::read::lex
       SUBCASE("Positive single-char")
       {
         processor p{ "0" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, token_kind::integer, 0ll }
@@ -460,17 +478,332 @@ namespace jank::read::lex
       SUBCASE("Positive multi-char")
       {
         processor p{ "1234" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 4, token_kind::integer, 1234ll }
         }));
       }
 
+      SUBCASE("Positive multiple numbers")
+      {
+        processor p{ "0 1234" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 1, token_kind::integer,    0ll },
+                { 2, 4, token_kind::integer, 1234ll },
+        }));
+      }
+
+      SUBCASE("Octal number")
+      {
+        processor p{ "034 -034 08.9 07e1" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                {  0, 3, token_kind::integer,  28ll },
+                {  4, 4, token_kind::integer, -28ll },
+                {  9, 4,    token_kind::real,   8.9 },
+                { 14, 4,    token_kind::real,  70.0 },
+        }));
+      }
+
+      SUBCASE("Invalid octal number")
+      {
+        processor p{ "08 0a -08" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error{ 0, 2, "invalid number: char 8 are invalid for radix 8" },
+                error{ 3, 5, "invalid number: char a are invalid for radix 8" },
+                error{ 6, 9, "invalid number: char 8 are invalid for radix 8" },
+        }));
+      }
+
+      SUBCASE("Octal numbers with invalid padding")
+      {
+        processor p{ "000123 0123 034 00" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                {  0, 6, token_kind::integer, 83ll },
+                {  7, 4, token_kind::integer, 83ll },
+                { 12, 3, token_kind::integer, 28ll },
+                { 16, 2, token_kind::integer,  0ll }
+        }));
+      }
+
+      SUBCASE("Edge case: Invalid mixed radix")
+      {
+        processor p{ "123abc 0x12g 8r8 16rx.2" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error{ 0, 6, "invalid number: char abc are invalid for radix 10" },
+                error{ 7, 12, "invalid number: char g are invalid for radix 16" },
+                error{ 13, 16, "invalid number: char 8 are invalid for radix 8" },
+                error{ 17, 21, "arbitrary radix number can only be an integer" },
+                error{ 21, 21, "unexpected character: ." },
+                error{ 22, 22, "expected whitespace before next token" },
+                token{ 22, 1, token_kind::integer, 2ll },
+        }));
+      }
+
+      SUBCASE("Arbitrary radix edge cases")
+      {
+        /* exceeds 64-bit integer max */
+        processor p{ "36r0123456789abcdefghijklmnopqrstuvwxyz" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 39, token_kind::integer, 9223372036854775807ll }
+        }));
+
+        processor p2{ "2r1111111111111111111111111111111111111111111" };
+        native_vector<result<token, error>> const tokens2(p2.begin(), p2.end());
+        CHECK(tokens2
+              == make_tokens({
+                { 0, 45, token_kind::integer, 8796093022207ll }
+        }));
+      }
+
+      SUBCASE("Invalid arbitrary radix edge cases")
+      {
+        processor p{ "37r1234" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error{ 0, 7, "invalid number: radix 37 is out of range" }
+        }));
+
+        processor p2{ "1r2" };
+        native_vector<result<token, error>> const tokens2(p2.begin(), p2.end());
+        CHECK(tokens2
+              == make_results({
+                error{ 0, 3, "invalid number: radix 1 is out of range" }
+        }));
+      }
+
+      SUBCASE("Mixed valid and invalid numbers")
+      {
+        processor p{ "123 0x1g 8r7 -12 10r1z 16rff" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                token{ 0, 3, token_kind::integer, 123ll },
+                error{ 4, 8, "invalid number: char g are invalid for radix 16" },
+                token{ 9, 3, token_kind::integer, 7ll },
+                token{ 13, 3, token_kind::integer, -12ll },
+                error{ 17, 22, "invalid number: char z are invalid for radix 10" },
+                token{ 23, 5, token_kind::integer, 255ll }
+        }));
+      }
+
+      SUBCASE("Negative numbers with arbitrary radix")
+      {
+        processor p{ "-2r11 -8r77 -16rff" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                {  0, 5, token_kind::integer,   -3ll },
+                {  6, 5, token_kind::integer,  -63ll },
+                { 12, 6, token_kind::integer, -255ll }
+        }));
+      }
+
+      SUBCASE("Hex numbers")
+      {
+        processor p{ "0x34 0Xab 0x12ab 123 0Xef43 -0x1a 0x0" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                {  0, 4, token_kind::integer,    52ll },
+                {  5, 4, token_kind::integer,   171ll },
+                { 10, 6, token_kind::integer,  4779ll },
+                { 17, 3, token_kind::integer,   123ll },
+                { 21, 6, token_kind::integer, 61251ll },
+                { 28, 5, token_kind::integer,   -26ll },
+                { 34, 3, token_kind::integer,     0ll },
+        }));
+      }
+
+      SUBCASE("Invalid hex numbers")
+      {
+        processor p{ "0xg 0x-2 0x8.4 0x3e-5 0x 1x" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error{  0,  3,          "invalid number: char g are invalid for radix 16" },
+                error{  4,  8,          "invalid number: char - are invalid for radix 16" },
+                error{  9, 14,          "invalid number: char . are invalid for radix 16" },
+                error{ 15, 21,          "invalid number: char - are invalid for radix 16" },
+                error{ 22, 24, "unexpected end of radix 16 number, expecting more digits" },
+                error{ 25, 27,          "invalid number: char x are invalid for radix 10" }
+        }));
+      }
+
+      SUBCASE("Invalid hex - 1x1")
+      {
+        processor p{ "1x1" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error{ 0, 3, "invalid number: char x are invalid for radix 10" },
+        }));
+      }
+
+      SUBCASE("Invalid hex - 2.0x1")
+      {
+        processor p{ "2.0x1" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                token{ 0, 3, token_kind::real, 2.0 },
+                error{ 3, 3, "expected whitespace before next token" },
+                token{ 3, 2, token_kind::symbol, "x1"sv },
+        }));
+      }
+
+      SUBCASE("Invalid hex - 0xx1")
+      {
+        processor p{ "0xx1" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error{ 0, 4, "invalid number: char x are invalid for radix 16" },
+        }));
+      }
+
+      SUBCASE("Invalid hex - 0x1x")
+      {
+        processor p{ "0x1x" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error{ 0, 4, "invalid number: char x are invalid for radix 16" },
+        }));
+      }
+
+      SUBCASE("Invalid hex - 0x.0")
+      {
+        processor p{ "0x.0" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error{ 0, 4, "invalid number: char . are invalid for radix 16" },
+        }));
+      }
+
+      SUBCASE("Valid arbitrary radix")
+      {
+        processor p{ "2r11 36rz 8R71 19rghi -4r32 16r3e 16r3e4 -32r3e4" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                token{  0, 4, token_kind::integer,     3ll },
+                token{  5, 4, token_kind::integer,    35ll },
+                token{ 10, 4, token_kind::integer,    57ll },
+                token{ 15, 6, token_kind::integer,  6117ll },
+                token{ 22, 5, token_kind::integer,   -14ll },
+                token{ 28, 5, token_kind::integer,    62ll },
+                token{ 34, 6, token_kind::integer,   996ll },
+                token{ 41, 7, token_kind::integer, -3524ll },
+        }));
+      }
+
+      SUBCASE("Invalid arbitrary radix")
+      {
+        processor p{ "2r3 35rz 8re71 19r-ghi 2r 16r" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error{  0,  3,        "invalid number: char 3 are invalid for radix 2" },
+                error{  4,  8,       "invalid number: char z are invalid for radix 35" },
+                error{  9, 14,        "invalid number: char e are invalid for radix 8" },
+                error{ 15, 22,       "invalid number: char - are invalid for radix 19" },
+                error{ 23, 25, "unexpected end of radix number, expecting more digits" },
+                error{ 26, 29, "unexpected end of radix number, expecting more digits" }
+        }));
+      }
+
+      SUBCASE("Invalid arbitrary radix - 0r0")
+      {
+        processor p{ "0r0" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error{ 0, 3, "invalid number: radix 0 is out of range" },
+        }));
+      }
+
+      SUBCASE("Invalid arbitrary radix - 1r1")
+      {
+        processor p{ "1r1" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error{ 0, 3, "invalid number: radix 1 is out of range" },
+        }));
+      }
+
+      SUBCASE("Invalid arbitrary radix - 2048r0")
+      {
+        processor p{ "2048r0" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error{ 0, 6, "invalid number: radix 2048 is out of range" },
+        }));
+      }
+
+      SUBCASE("Invalid arbitrary radix - 2.0r1")
+      {
+        processor p{ "2.0r1" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error{ 0, 3, "invalid number: arbitrary radix numbers can only be integers" },
+                token{ 3, 2, token_kind::symbol, "r1"sv },
+        }));
+      }
+
+      SUBCASE("Invalid arbitrary radix - 2rr1")
+      {
+        processor p{ "2rr1" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error{ 0, 4, "invalid number: char r are invalid for radix 2" },
+        }));
+      }
+
+      SUBCASE("Invalid arbitrary radix - 2r1r")
+      {
+        processor p{ "2r1r" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error{ 0, 4, "invalid number: char r are invalid for radix 2" },
+        }));
+      }
+
+      SUBCASE("Invalid arbitrary radix - 2r.0")
+      {
+        processor p{ "2r.0" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error{ 0, 2, "arbitrary radix number can only be an integer" },
+                error{ 2, 2, "unexpected character: ." },
+                token{ 3, 1, token_kind::integer, 0ll }
+        }));
+      }
+
       SUBCASE("Negative single-char")
       {
         processor p{ "-1" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 2, token_kind::integer, -1ll }
@@ -480,7 +813,7 @@ namespace jank::read::lex
       SUBCASE("Negative multi-char")
       {
         processor p{ "-1234" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 5, token_kind::integer, -1234ll }
@@ -492,19 +825,17 @@ namespace jank::read::lex
         SUBCASE("Required")
         {
           processor p{ "1234abc" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_results({
-                  token{ 0, 4, token_kind::integer, 1234ll },
-                  error{ 4, "expected whitespace before next token" },
-                  token{ 4, 3, token_kind::symbol, "abc"sv },
+                  error{ 0, 7, "invalid number: char abc are invalid for radix 10" },
           }));
         }
 
         SUBCASE("Not required")
         {
           processor p{ "(1234)" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_results({
                   token{ 0, token_kind::open_paren },
@@ -520,7 +851,7 @@ namespace jank::read::lex
       SUBCASE("Positive 0.")
       {
         processor p{ "0." };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 2, token_kind::real, 0.0 }
@@ -530,7 +861,7 @@ namespace jank::read::lex
       SUBCASE("Positive 0.0")
       {
         processor p{ "0.0" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 3, token_kind::real, 0.0 }
@@ -540,7 +871,7 @@ namespace jank::read::lex
       SUBCASE("Negative 1.")
       {
         processor p{ "-1." };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 3, token_kind::real, -1.0 }
@@ -550,7 +881,7 @@ namespace jank::read::lex
       SUBCASE("Negative 1.5")
       {
         processor p{ "-1.5" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 4, token_kind::real, -1.5 }
@@ -560,7 +891,7 @@ namespace jank::read::lex
       SUBCASE("Negative multi-char")
       {
         processor p{ "-1234.1234" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 10, token_kind::real, -1234.1234 }
@@ -570,7 +901,7 @@ namespace jank::read::lex
       SUBCASE("Positive no leading digit")
       {
         processor p{ ".0" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_results({
                 error{ 0, "unexpected character: ." },
@@ -581,7 +912,7 @@ namespace jank::read::lex
       SUBCASE("Negative no leading digit")
       {
         processor p{ "-.0" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_results({
                 error{ 0, 1, "invalid number" },
@@ -594,17 +925,16 @@ namespace jank::read::lex
       {
         {
           processor p{ "0.0." };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_results({
                   error{ 0, 3, "invalid number" },
                   error{ 3, "unexpected character: ." },
           }));
         }
-
         {
           processor p{ "0..0" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_results({
                   error{ 0, 2, "invalid number" },
@@ -614,7 +944,7 @@ namespace jank::read::lex
         }
         {
           processor p{ "0.0.0" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_results({
                   error{ 0, 3, "invalid number" },
@@ -629,7 +959,7 @@ namespace jank::read::lex
         SUBCASE("Required")
         {
           processor p{ "12.34abc" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_results({
                   token{ 0, 5, token_kind::real, 12.34 },
@@ -641,7 +971,7 @@ namespace jank::read::lex
         SUBCASE("Not required")
         {
           processor p{ "(12.34)" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_results({
                   token{ 0, token_kind::open_paren },
@@ -656,7 +986,7 @@ namespace jank::read::lex
         SUBCASE("Valid")
         {
           processor p{ "1e3 -1e2 2.E-3 22.3e-8 -12E+18\\a" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_results({
                   token{  0, 3,      token_kind::real,   1000.0 },
@@ -671,7 +1001,7 @@ namespace jank::read::lex
         SUBCASE("Missing exponent")
         {
           processor p{ "1e 23E-1 12e- -0.2e" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_results({
                   error{ 0, 2, "unexpected end of real, expecting exponent" },
@@ -684,7 +1014,7 @@ namespace jank::read::lex
         SUBCASE("Signs after exponent found")
         {
           processor p{ "12.3 -1e3- 2.3E+" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_results({
                   token{ 0, 4, token_kind::real, 12.3 },
@@ -698,7 +1028,7 @@ namespace jank::read::lex
         SUBCASE("Extra dots")
         {
           processor p{ "1e3. 12.3 -1e4.3" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_results({
                   error{ 0, 3, "invalid number" },
@@ -714,7 +1044,7 @@ namespace jank::read::lex
         SUBCASE("Extra characters in exponent")
         {
           processor p{ "2.ee4 -1e4E3 1.eFoo 3E5fOo" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_results({
                   error{ 0, 3, "invalid number" },
@@ -725,9 +1055,7 @@ namespace jank::read::lex
                   error{ 13, 16, "unexpected end of real, expecting exponent" },
                   error{ 16, "expected whitespace before next token" },
                   token{ 16, 3, token_kind::symbol, "Foo"sv },
-                  token{ 20, 3, token_kind::real, 300000.0 },
-                  error{ 23, "expected whitespace before next token" },
-                  token{ 23, 3, token_kind::symbol, "fOo"sv },
+                  error{ 20, 26, "invalid number: char fOo are invalid for radix 10" },
           }));
         }
       }
@@ -738,7 +1066,7 @@ namespace jank::read::lex
       SUBCASE("Whitespace after \\")
       {
         processor p{ R"(\ )" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_results({ { error(0, "Expecting a valid character literal after \\") } }));
       }
@@ -746,7 +1074,7 @@ namespace jank::read::lex
       SUBCASE("Dangling \\")
       {
         processor p{ R"(\)" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_results({ { error(0, "Expecting a valid character literal after \\") } }));
       }
@@ -754,7 +1082,7 @@ namespace jank::read::lex
       SUBCASE("Alphabetic")
       {
         processor p{ R"(\a)" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 2, token_kind::character, "\\a"sv }
@@ -764,7 +1092,7 @@ namespace jank::read::lex
       SUBCASE("Numeric")
       {
         processor p{ R"(\1)" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 2, token_kind::character, "\\1"sv }
@@ -774,7 +1102,7 @@ namespace jank::read::lex
       SUBCASE("Multiple characters after \\")
       {
         processor p{ R"(\11)" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 3, token_kind::character, "\\11"sv }
@@ -784,7 +1112,7 @@ namespace jank::read::lex
       SUBCASE("Valid lexed character with symbol")
       {
         processor p{ R"(\1:)" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_results({
                 token{ 0, 3, token_kind::character, "\\1:"sv },
@@ -794,7 +1122,7 @@ namespace jank::read::lex
       SUBCASE("Valid consecutive characters")
       {
         processor p{ R"(\1 \newline\' \\)" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 {  0, 2, token_kind::character,       "\\1"sv },
@@ -807,7 +1135,7 @@ namespace jank::read::lex
       SUBCASE("Character followed by a backticked keyword")
       {
         processor p{ R"(\a`:kw)" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_results({
                 token{ 0, 2, token_kind::character, "\\a"sv },
@@ -822,7 +1150,7 @@ namespace jank::read::lex
       SUBCASE("Single-char")
       {
         processor p{ "a" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, token_kind::symbol, "a"sv }
@@ -832,7 +1160,7 @@ namespace jank::read::lex
       SUBCASE("Multi-char")
       {
         processor p{ "abc" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 3, token_kind::symbol, "abc"sv }
@@ -842,7 +1170,7 @@ namespace jank::read::lex
       SUBCASE("Single slash")
       {
         processor p{ "/" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, token_kind::symbol, "/"sv }
@@ -852,7 +1180,7 @@ namespace jank::read::lex
       SUBCASE("Multi slash")
       {
         processor p{ "//" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_results({
                 error{ 0, "invalid symbol" },
@@ -862,7 +1190,7 @@ namespace jank::read::lex
       SUBCASE("Starting with a slash")
       {
         processor p{ "/foo" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_results({
                 error{ 0, "invalid symbol" },
@@ -872,7 +1200,7 @@ namespace jank::read::lex
       SUBCASE("With numbers")
       {
         processor p{ "abc123" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 6, token_kind::symbol, "abc123"sv }
@@ -882,7 +1210,7 @@ namespace jank::read::lex
       SUBCASE("With other symbols")
       {
         processor p{ "abc_.123/-foo+?=!&<>#%" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 22, token_kind::symbol, "abc_.123/-foo+?=!&<>#%"sv }
@@ -892,7 +1220,7 @@ namespace jank::read::lex
       SUBCASE("Only -")
       {
         processor p{ "-" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, token_kind::symbol, "-"sv }
@@ -902,7 +1230,7 @@ namespace jank::read::lex
       SUBCASE("Starting with -")
       {
         processor p{ "-main" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 5, token_kind::symbol, "-main"sv }
@@ -912,7 +1240,7 @@ namespace jank::read::lex
       SUBCASE("Quoted")
       {
         processor p{ "'foo" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, token_kind::single_quote },
@@ -926,7 +1254,7 @@ namespace jank::read::lex
       SUBCASE("Single-char")
       {
         processor p{ ":a" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 2, token_kind::keyword, "a"sv }
@@ -936,7 +1264,7 @@ namespace jank::read::lex
       SUBCASE("Multi-char")
       {
         processor p{ ":abc" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 4, token_kind::keyword, "abc"sv }
@@ -946,7 +1274,7 @@ namespace jank::read::lex
       SUBCASE("Whitespace after :")
       {
         processor p{ ": " };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_results({
                 error{ 0, "invalid keyword: expected non-whitespace character after :" }
@@ -956,7 +1284,7 @@ namespace jank::read::lex
       SUBCASE("Single slash")
       {
         processor p{ ":/" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 2, token_kind::keyword, "/"sv }
@@ -966,7 +1294,7 @@ namespace jank::read::lex
       SUBCASE("Multi slash")
       {
         processor p{ "://" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_results({
                 error{ 0, "invalid keyword: starts with /" },
@@ -976,7 +1304,7 @@ namespace jank::read::lex
       SUBCASE("Starting with a slash")
       {
         processor p{ ":/foo" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_results({
                 error{ 0, "invalid keyword: starts with /" },
@@ -986,7 +1314,7 @@ namespace jank::read::lex
       SUBCASE("With numbers")
       {
         processor p{ ":abc123" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 7, token_kind::keyword, "abc123"sv }
@@ -996,7 +1324,7 @@ namespace jank::read::lex
       SUBCASE("With other symbols")
       {
         processor p{ ":abc_.123/-foo+?=!&<>" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 21, token_kind::keyword, "abc_.123/-foo+?=!&<>"sv }
@@ -1006,7 +1334,7 @@ namespace jank::read::lex
       SUBCASE("Auto-resolved unqualified")
       {
         processor p{ "::foo-bar" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 9, token_kind::keyword, ":foo-bar"sv }
@@ -1016,7 +1344,7 @@ namespace jank::read::lex
       SUBCASE("Auto-resolved qualified")
       {
         processor p{ "::foo/bar" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 9, token_kind::keyword, ":foo/bar"sv }
@@ -1026,7 +1354,7 @@ namespace jank::read::lex
       SUBCASE("Too many starting colons")
       {
         processor p{ ":::foo" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_results({
                 error{ 0, "invalid keyword: incorrect number of :" },
@@ -1036,7 +1364,7 @@ namespace jank::read::lex
       SUBCASE("Way too many starting colons")
       {
         processor p{ "::::foo" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_results({
                 error{ 0, "invalid keyword: incorrect number of :" },
@@ -1049,7 +1377,7 @@ namespace jank::read::lex
       SUBCASE("Empty")
       {
         processor p{ "\"\"" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 2, token_kind::string, ""sv }
@@ -1058,7 +1386,7 @@ namespace jank::read::lex
       SUBCASE("Single-char")
       {
         processor p{ "\"a\"" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 3, token_kind::string, "a"sv }
@@ -1068,7 +1396,7 @@ namespace jank::read::lex
       SUBCASE("Multi-char")
       {
         processor p{ "\"abc\"" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 5, token_kind::string, "abc"sv }
@@ -1078,7 +1406,7 @@ namespace jank::read::lex
       SUBCASE("With numbers")
       {
         processor p{ "\"123\"" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 5, token_kind::string, "123"sv }
@@ -1088,7 +1416,7 @@ namespace jank::read::lex
       SUBCASE("With other symbols")
       {
         processor p{ "\"and then() there was abc_123/-foo?!&<>\"" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 40, token_kind::string, "and then() there was abc_123/-foo?!&<>"sv }
@@ -1098,7 +1426,7 @@ namespace jank::read::lex
       SUBCASE("With line breaks")
       {
         processor p{ "\"foo\nbar\nspam\t\"" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 15, token_kind::string, "foo\nbar\nspam\t"sv }
@@ -1108,14 +1436,14 @@ namespace jank::read::lex
       SUBCASE("With escapes")
       {
         processor p{ R"("foo\"\nbar\nspam\t\r")" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 22, token_kind::escaped_string, "foo\\\"\\nbar\\nspam\\t\\r"sv }
         }));
 
         processor q{ R"("\??\' \\ a\a b\b f\f v\v")" };
-        native_vector<result<token, error>> tokens2(q.begin(), q.end());
+        native_vector<result<token, error>> const tokens2(q.begin(), q.end());
         CHECK(tokens2
               == make_tokens({
                 { 0, 26, token_kind::escaped_string, "\\\?\?\\' \\\\ a\\a b\\b f\\f v\\v"sv }
@@ -1125,7 +1453,7 @@ namespace jank::read::lex
       SUBCASE("Unterminated")
       {
         processor p{ "\"meow" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_results({
                 error{ 0, "unterminated string" },
@@ -1138,7 +1466,7 @@ namespace jank::read::lex
       SUBCASE("Empty")
       {
         processor p{ "^" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 1, token_kind::meta_hint }
@@ -1148,7 +1476,7 @@ namespace jank::read::lex
       SUBCASE("With line breaks")
       {
         processor p{ "^\n:foo" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 1, token_kind::meta_hint },
@@ -1162,7 +1490,7 @@ namespace jank::read::lex
       SUBCASE("Empty")
       {
         processor p{ "#" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 1, token_kind::reader_macro }
@@ -1174,7 +1502,7 @@ namespace jank::read::lex
         SUBCASE("Empty")
         {
           processor p{ "#_" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
                   { 0, 2, token_kind::reader_macro_comment }
@@ -1184,7 +1512,7 @@ namespace jank::read::lex
         SUBCASE("No whitespace after")
         {
           processor p{ "#_[]" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
                   { 0, 2, token_kind::reader_macro_comment },
@@ -1199,7 +1527,7 @@ namespace jank::read::lex
         SUBCASE("Empty")
         {
           processor p{ "#?" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
                   { 0, 2, token_kind::reader_macro_conditional }
@@ -1209,7 +1537,7 @@ namespace jank::read::lex
         SUBCASE("With following list")
         {
           processor p{ "#?()" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
                   { 0, 2, token_kind::reader_macro_conditional },
@@ -1224,7 +1552,7 @@ namespace jank::read::lex
         SUBCASE("Empty")
         {
           processor p{ "#{}" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
                   { 0, 1,        token_kind::reader_macro },
@@ -1238,7 +1566,7 @@ namespace jank::read::lex
         SUBCASE("With line breaks")
         {
           processor p{ "#\n{}" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
                   { 0, 1,        token_kind::reader_macro },
@@ -1254,7 +1582,7 @@ namespace jank::read::lex
       SUBCASE("Empty")
       {
         processor p{ "`" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 1, token_kind::syntax_quote }
@@ -1264,7 +1592,7 @@ namespace jank::read::lex
       SUBCASE("With line breaks")
       {
         processor p{ "`\n:foo" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 1, token_kind::syntax_quote },
@@ -1277,7 +1605,7 @@ namespace jank::read::lex
         SUBCASE("Empty")
         {
           processor p{ "~" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
                   { 0, 1, token_kind::unquote }
@@ -1287,7 +1615,7 @@ namespace jank::read::lex
         SUBCASE("With line breaks")
         {
           processor p{ "~\n:foo" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
                   { 0, 1, token_kind::unquote },
@@ -1301,7 +1629,7 @@ namespace jank::read::lex
         SUBCASE("Empty")
         {
           processor p{ "~@" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
                   { 0, 2, token_kind::unquote_splice }
@@ -1311,7 +1639,7 @@ namespace jank::read::lex
         SUBCASE("With line breaks before")
         {
           processor p{ "~\n@:foo" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
                   { 0, 1, token_kind::unquote },
@@ -1323,7 +1651,7 @@ namespace jank::read::lex
         SUBCASE("With line breaks after")
         {
           processor p{ "~@\n:foo" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
                   { 0, 2, token_kind::unquote_splice },
@@ -1340,7 +1668,7 @@ namespace jank::read::lex
         SUBCASE("Single character")
         {
           processor p{ "👍" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
                   { 0, 4, token_kind::symbol, "👍"sv }
@@ -1349,7 +1677,7 @@ namespace jank::read::lex
         SUBCASE("Multiple characters")
         {
           processor p{ "😎👍" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
                   { 0, 8, token_kind::symbol, "😎👍"sv }
@@ -1358,7 +1686,7 @@ namespace jank::read::lex
         SUBCASE("Symbol with mixed characters inside")
         {
           processor p{ "one-🍺-please!" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
                   { 0, 16, token_kind::symbol, "one-🍺-please!"sv }
@@ -1367,7 +1695,7 @@ namespace jank::read::lex
         SUBCASE("Qualified Symbol")
         {
           processor p{ "🐝/🥀" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
                   { 0, 9, token_kind::symbol, "🐝/🥀"sv }
@@ -1379,7 +1707,7 @@ namespace jank::read::lex
         SUBCASE("Single character")
         {
           processor p{ ":🍙" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
                   { 0, 5, token_kind::keyword, "🍙"sv },
@@ -1388,7 +1716,7 @@ namespace jank::read::lex
         SUBCASE("Multiple characters keyword")
         {
           processor p{ ":🥩🍗" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
                   { 0, 9, token_kind::keyword, "🥩🍗"sv }
@@ -1397,7 +1725,7 @@ namespace jank::read::lex
         SUBCASE("Keyword with mixed characters inside")
         {
           processor p{ ":w🍪w" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
                   { 0, 7, token_kind::keyword, "w🍪w"sv }
@@ -1406,7 +1734,7 @@ namespace jank::read::lex
         SUBCASE("Qualified Keyword")
         {
           processor p{ ":🐝/🥀" };
-          native_vector<result<token, error>> tokens(p.begin(), p.end());
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
                   { 0, 10, token_kind::keyword, "🐝/🥀"sv }
@@ -1416,7 +1744,7 @@ namespace jank::read::lex
       SUBCASE("8-wide character")
       {
         processor p{ "🇪🇺" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 8, token_kind::symbol, "🇪🇺"sv }
@@ -1425,7 +1753,7 @@ namespace jank::read::lex
       SUBCASE("Non-Latin Characters")
       {
         processor p{ "ありがとう" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 15, token_kind::symbol, "ありがとう"sv }
@@ -1434,7 +1762,7 @@ namespace jank::read::lex
       SUBCASE("Non-Latin Characters")
       {
         processor p{ ":ありがとう" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 16, token_kind::keyword, "ありがとう"sv }
@@ -1443,7 +1771,7 @@ namespace jank::read::lex
       SUBCASE("Whitespace Characters")
       {
         processor p{ ":  " };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
                 { 0, 7, token_kind::keyword, "  "sv }
@@ -1454,7 +1782,7 @@ namespace jank::read::lex
       SUBCASE("Malformed Text")
       {
         processor p{ "\xC0\x80" };
-        native_vector<result<token, error>> tokens(p.begin(), p.end());
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_results({
                 error({ 0, "Unfinished Character" }),

--- a/compiler+runtime/test/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/test/cpp/jank/read/lex.cpp
@@ -556,8 +556,8 @@ namespace jank::read::lex
         processor p{ "36r0123456789abcdefghijklmnopqrstuvwxyz" };
         native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
-              == make_tokens({
-                { 0, 39, token_kind::integer, 9223372036854775807ll }
+              == make_results({
+                error{ 0, 39, "number out of range" }
         }));
 
         processor p2{ "2r1111111111111111111111111111111111111111111" };

--- a/compiler+runtime/test/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/test/cpp/jank/read/lex.cpp
@@ -515,9 +515,9 @@ namespace jank::read::lex
         native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_results({
-                error{ 0, 2, "invalid number: char 8 are invalid for radix 8" },
-                error{ 3, 5, "invalid number: char a are invalid for radix 8" },
-                error{ 6, 9, "invalid number: char 8 are invalid for radix 8" },
+                error{ 0, 2, "invalid number: chars '8' are invalid for radix 8" },
+                error{ 3, 5, "invalid number: chars 'a' are invalid for radix 8" },
+                error{ 6, 9, "invalid number: chars '8' are invalid for radix 8" },
         }));
       }
 
@@ -540,9 +540,9 @@ namespace jank::read::lex
         native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_results({
-                error{ 0, 6, "invalid number: char abc are invalid for radix 10" },
-                error{ 7, 12, "invalid number: char g are invalid for radix 16" },
-                error{ 13, 16, "invalid number: char 8 are invalid for radix 8" },
+                error{ 0, 6, "invalid number: chars 'abc' are invalid for radix 10" },
+                error{ 7, 12, "invalid number: chars 'g' are invalid for radix 16" },
+                error{ 13, 16, "invalid number: chars '8' are invalid for radix 8" },
                 error{ 17, 21, "arbitrary radix number can only be an integer" },
                 error{ 21, 21, "unexpected character: ." },
                 error{ 22, 22, "expected whitespace before next token" },
@@ -592,10 +592,10 @@ namespace jank::read::lex
         CHECK(tokens
               == make_results({
                 token{ 0, 3, token_kind::integer, 123ll },
-                error{ 4, 8, "invalid number: char g are invalid for radix 16" },
+                error{ 4, 8, "invalid number: chars 'g' are invalid for radix 16" },
                 token{ 9, 3, token_kind::integer, 7ll },
                 token{ 13, 3, token_kind::integer, -12ll },
-                error{ 17, 22, "invalid number: char z are invalid for radix 10" },
+                error{ 17, 22, "invalid number: chars 'z' are invalid for radix 10" },
                 token{ 23, 5, token_kind::integer, 255ll }
         }));
       }
@@ -634,12 +634,12 @@ namespace jank::read::lex
         native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_results({
-                error{  0,  3,          "invalid number: char g are invalid for radix 16" },
-                error{  4,  8,          "invalid number: char - are invalid for radix 16" },
-                error{  9, 14,          "invalid number: char . are invalid for radix 16" },
-                error{ 15, 21,          "invalid number: char - are invalid for radix 16" },
+                error{  0,  3,          "invalid number: chars 'g' are invalid for radix 16" },
+                error{  4,  8,          "invalid number: chars '-' are invalid for radix 16" },
+                error{  9, 14,          "invalid number: chars '.' are invalid for radix 16" },
+                error{ 15, 21,          "invalid number: chars '-' are invalid for radix 16" },
                 error{ 22, 24, "unexpected end of radix 16 number, expecting more digits" },
-                error{ 25, 27,          "invalid number: char x are invalid for radix 10" }
+                error{ 25, 27,          "invalid number: chars 'x' are invalid for radix 10" }
         }));
       }
 
@@ -649,7 +649,7 @@ namespace jank::read::lex
         native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_results({
-                error{ 0, 3, "invalid number: char x are invalid for radix 10" },
+                error{ 0, 3, "invalid number: chars 'x' are invalid for radix 10" },
         }));
       }
 
@@ -671,7 +671,7 @@ namespace jank::read::lex
         native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_results({
-                error{ 0, 4, "invalid number: char x are invalid for radix 16" },
+                error{ 0, 4, "invalid number: chars 'x' are invalid for radix 16" },
         }));
       }
 
@@ -681,7 +681,7 @@ namespace jank::read::lex
         native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_results({
-                error{ 0, 4, "invalid number: char x are invalid for radix 16" },
+                error{ 0, 4, "invalid number: chars 'x' are invalid for radix 16" },
         }));
       }
 
@@ -691,7 +691,7 @@ namespace jank::read::lex
         native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_results({
-                error{ 0, 4, "invalid number: char . are invalid for radix 16" },
+                error{ 0, 4, "invalid number: chars '.' are invalid for radix 16" },
         }));
       }
 
@@ -718,10 +718,10 @@ namespace jank::read::lex
         native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_results({
-                error{  0,  3,        "invalid number: char 3 are invalid for radix 2" },
-                error{  4,  8,       "invalid number: char z are invalid for radix 35" },
-                error{  9, 14,        "invalid number: char e are invalid for radix 8" },
-                error{ 15, 22,       "invalid number: char - are invalid for radix 19" },
+                error{  0,  3,        "invalid number: chars '3' are invalid for radix 2" },
+                error{  4,  8,       "invalid number: chars 'z' are invalid for radix 35" },
+                error{  9, 14,        "invalid number: chars 'e' are invalid for radix 8" },
+                error{ 15, 22,       "invalid number: chars '-' are invalid for radix 19" },
                 error{ 23, 25, "unexpected end of radix number, expecting more digits" },
                 error{ 26, 29, "unexpected end of radix number, expecting more digits" }
         }));
@@ -774,7 +774,7 @@ namespace jank::read::lex
         native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_results({
-                error{ 0, 4, "invalid number: char r are invalid for radix 2" },
+                error{ 0, 4, "invalid number: chars 'r' are invalid for radix 2" },
         }));
       }
 
@@ -784,7 +784,7 @@ namespace jank::read::lex
         native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_results({
-                error{ 0, 4, "invalid number: char r are invalid for radix 2" },
+                error{ 0, 4, "invalid number: chars 'r' are invalid for radix 2" },
         }));
       }
 
@@ -828,7 +828,7 @@ namespace jank::read::lex
           native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_results({
-                  error{ 0, 7, "invalid number: char abc are invalid for radix 10" },
+                  error{ 0, 7, "invalid number: chars 'abc' are invalid for radix 10" },
           }));
         }
 
@@ -1055,7 +1055,7 @@ namespace jank::read::lex
                   error{ 13, 16, "unexpected end of real, expecting exponent" },
                   error{ 16, "expected whitespace before next token" },
                   token{ 16, 3, token_kind::symbol, "Foo"sv },
-                  error{ 20, 26, "invalid number: char fOo are invalid for radix 10" },
+                  error{ 20, 26, "invalid number: chars 'fOo' are invalid for radix 10" },
           }));
         }
       }


### PR DESCRIPTION
code is a bit ugly but should work:

```clojure
❯ build/jank repl
Bottom of clojure.core
clojure.core=> 071
57
clojure.core=> -071
-57
clojure.core=> 08
Read error (0 - 2): invalid number: char 8 are invalid for radix 8
clojure.core=> 08.9
8.9
clojure.core=> 08e2
800
clojure.core=> 0-7.1
0
clojure.core=> 0xabc
2748
clojure.core=> 0Xabc
2748
clojure.core=> -0xef
-239
clojure.core=> 0xg
Read error (0 - 3): invalid number: char g are invalid for radix 16
clojure.core=> 0x-a
Read error (0 - 4): invalid number: char - are invalid for radix 16
clojure.core=> 2r011110
30
clojure.core=> 8r71
57
clojure.core=> -8r71
-57
clojure.core=> 1r0
Read error (0 - 3): invalid number: radix 1 is out of range
clojure.core=> -36razxyu
-18473142
clojure.core=> -30razxyu
Read error (0 - 9): invalid number: char zxyu are invalid for radix 30
clojure.core=> 37rzb
Read error (0 - 5): invalid number: radix 37 is out of range
clojure.core=> 36r4.5
Read error (0 - 6): invalid number: char . are invalid for radix 36
clojure.core=> 36r-4.5
Read error (0 - 7): invalid number: char -. are invalid for radix 36
clojure.core=> 3e-4
0.0003
clojure.core=> 16r3e4
996
clojure.core=>  36r3e4
4396
clojure.core=> 3e2/3
Read error (0 - 3): invalid ratio
clojure.core=> 7r3e4
Read error (0 - 5): invalid number: char e are invalid for radix 7
clojure.core=>  0xe
14
clojure.core=> 16re3
227
clojure.core=> 16r3e
62
clojure.core=> 0x3e
62
clojure.core=>  0x3e3
995
clojure.core=> 16r3e3
995
```