### PR TITLE
Fix clang tidy errors

### DIFF
--- a/compiler+runtime/src/cpp/jank/c_api.cpp
+++ b/compiler+runtime/src/cpp/jank/c_api.cpp
@@ -394,7 +394,7 @@ extern "C"
   jank_object_ptr jank_list_create(uint64_t const size, ...)
   {
     /* NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg) */
-    va_list args;
+    va_list args{};
     va_start(args, size);
 
     native_vector<object_ptr> v;
@@ -414,7 +414,7 @@ extern "C"
   jank_object_ptr jank_vector_create(uint64_t const size, ...)
   {
     /* NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg) */
-    va_list args;
+    va_list args{};
     va_start(args, size);
 
     obj::transient_vector trans;
@@ -433,7 +433,7 @@ extern "C"
   jank_object_ptr jank_map_create(uint64_t const pairs, ...)
   {
     /* NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg) */
-    va_list args;
+    va_list args{};
     va_start(args, pairs);
 
     /* TODO: Could optimize to build an array map, if it's small enough. */
@@ -454,7 +454,7 @@ extern "C"
   jank_object_ptr jank_set_create(uint64_t const size, ...)
   {
     /* NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg) */
-    va_list args;
+    va_list args{};
     va_start(args, size);
 
     obj::transient_hash_set trans;

--- a/compiler+runtime/src/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/src/cpp/jank/read/lex.cpp
@@ -264,6 +264,18 @@ namespace jank::read
       return none;
     }
 
+    static int cast_char32_t_as_int(char32_t const c)
+    {
+      if(c > static_cast<char32_t>(INT_MAX))
+      {
+        throw std::runtime_error("Value out of range for wint_t");
+      }
+
+      // Perform the safe conversion
+      auto const safe_char = static_cast<int>(c);
+      return safe_char;
+    }
+
     static result<codepoint, error>
     convert_to_codepoint(native_persistent_string_view const sv, size_t const pos)
     {
@@ -313,7 +325,7 @@ namespace jank::read
 
     static native_bool is_symbol_char(char32_t const c)
     {
-      return !std::iswspace(c) && !is_special_char(c)
+      return !std::iswspace(cast_char32_t_as_int(c)) && !is_special_char(c)
         && (std::iswalnum(static_cast<wint_t>(c)) != 0 || c == '_' || c == '-' || c == '/'
             || c == '?' || c == '!' || c == '+' || c == '*' || c == '=' || c == '.' || c == '&'
             || c == '<' || c == '>' || c == '#' || c == '%' || is_utf8_char(c));
@@ -377,7 +389,7 @@ namespace jank::read
             auto const ch(peek());
             pos++;
 
-            if(ch.is_err() || std::iswspace(ch.expect_ok().character))
+            if(ch.is_err() || std::iswspace(cast_char32_t_as_int(ch.expect_ok().character)))
             {
               return err(error{ token_start, "Expecting a valid character literal after \\" });
             }
@@ -514,7 +526,7 @@ namespace jank::read
                 return err(
                   error{ token_start, pos, "invalid ratio: expecting an integer denominator" });
               }
-              else if(std::iswdigit(c) == 0)
+              else if(std::iswdigit(cast_char32_t_as_int(c)) == 0)
               {
                 if(expecting_exponent)
                 {
@@ -631,7 +643,7 @@ namespace jank::read
 
             auto const oc(peek());
             auto const c(oc.expect_ok().character);
-            if(oc.is_err() || std::iswspace(c))
+            if(oc.is_err() || std::iswspace(cast_char32_t_as_int(c)))
             {
               ++pos;
               return err(


### PR DESCRIPTION
```
❯ bin/compile
[1/103] Building CXX object CMakeFiles/jank_lib.dir/src/cpp/jank/util/scope_exit.cpp.o
FAILED: CMakeFiles/jank_lib.dir/src/cpp/jank/util/scope_exit.cpp.o
/opt/homebrew/bin/cmake -E __run_co_compile --tidy="/Users/personal/jank/compiler+runtime/build/llvm-install/usr/local/bin/clang-tidy;--use-color;--extra-arg-before=--driver-mode=g++" --source=/Users/personal/jank/compiler+runtime/src/cpp/jank/util/scope_exit.cpp -- /Users/personal/jank/compiler+runtime/build/llvm-install/usr/local/bin/clang++ -DBOOST_ATOMIC_DYN_LINK -DBOOST_ATOMIC_NO_LIB -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_FILESYSTEM_NO_LIB -DBOOST_SYSTEM_DYN_LINK -DBOOST_SYSTEM_NO_LIB -DFMT_SHARED -D__STDC_CONSTANT_MACROS -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/Users/personal/jank/compiler+runtime/build -I/Users/personal/jank/compiler+runtime -I/Users/personal/jank/compiler+runtime/include/cpp -isystem /Users/personal/jank/compiler+runtime/build/llvm-install/usr/local/include -isystem /Users/personal/jank/compiler+runtime/third-party/nanobench/include -isystem /Users/personal/jank/compiler+runtime/third-party/folly -isystem /Users/personal/jank/compiler+runtime/third-party/bpptree/include -isystem /Users/personal/jank/compiler+runtime/third-party/bdwgc/include -isystem /Users/personal/jank/compiler+runtime/third-party/immer -isystem /Users/personal/jank/compiler+runtime/third-party/magic_enum/include/magic_enum -isystem /Users/personal/jank/compiler+runtime/third-party/cli11/include -isystem /Users/personal/jank/compiler+runtime/third-party/fmt/include -isystem /Users/personal/jank/compiler+runtime/third-party/libzippp/src -isystem /opt/homebrew/include -isystem /opt/homebrew/Cellar/openssl@3/3.4.0/include -fPIC -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -g -std=gnu++20 -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk -fcolor-diagnostics -std=gnu++20 -DIMMER_HAS_LIBGC=1 -DIMMER_TAGGED_NODE=0 -DHAVE_CXX14=1 -DFMT_HEADER_ONLY=1 -I/opt/homebrew/include -Werror -DJANK_DEBUG -Wall -Wextra -Wpedantic -Wfloat-equal -Wuninitialized -Wswitch-enum -Wnon-virtual-dtor -Wold-style-cast -Wno-gnu-case-range -Wno-gnu-conditional-omitted-operand -Wno-implicit-fallthrough -Wno-covered-switch-default -Wno-invalid-offsetof -fno-common -frtti -fexceptions -O0 -DJANK_VERSION=\"0.1-8ec44a71f37acd3d4af9823632178e12925ab7dd\" "-DJANK_JIT_FLAGS=\"-std=gnu++20 -DIMMER_HAS_LIBGC=1 -DIMMER_TAGGED_NODE=0 -DHAVE_CXX14=1 -DFMT_HEADER_ONLY=1 -I/opt/homebrew/include -Werror -DJANK_DEBUG -w\"" -DJANK_CLANG_PREFIX=\"/Users/personal/jank/compiler+runtime/build/llvm-install/usr/local\" -MD -MT CMakeFiles/jank_lib.dir/src/cpp/jank/util/scope_exit.cpp.o -MF CMakeFiles/jank_lib.dir/src/cpp/jank/util/scope_exit.cpp.o.d -o CMakeFiles/jank_lib.dir/src/cpp/jank/util/scope_exit.cpp.o -c /Users/personal/jank/compiler+runtime/src/cpp/jank/util/scope_exit.cpp
/Users/personal/jank/compiler+runtime/src/cpp/jank/util/scope_exit.cpp:15:15: error: an exception may be thrown in function '~scope_exit' which should not throw exceptions [bugprone-exception-escape,-warnings-as-errors]
   15 |   scope_exit::~scope_exit()
      |               ^
7536 warnings generated.
Suppressed 7537 warnings (7535 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
1 warning treated as error
[8/103] Building CXX object CMakeFiles/jank_lib.dir/src/cpp/jank/read/lex.cpp.o
FAILED: CMakeFiles/jank_lib.dir/src/cpp/jank/read/lex.cpp.o
/opt/homebrew/bin/cmake -E __run_co_compile --tidy="/Users/personal/jank/compiler+runtime/build/llvm-install/usr/local/bin/clang-tidy;--use-color;--extra-arg-before=--driver-mode=g++" --source=/Users/personal/jank/compiler+runtime/src/cpp/jank/read/lex.cpp -- /Users/personal/jank/compiler+runtime/build/llvm-install/usr/local/bin/clang++ -DBOOST_ATOMIC_DYN_LINK -DBOOST_ATOMIC_NO_LIB -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_FILESYSTEM_NO_LIB -DBOOST_SYSTEM_DYN_LINK -DBOOST_SYSTEM_NO_LIB -DFMT_SHARED -D__STDC_CONSTANT_MACROS -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/Users/personal/jank/compiler+runtime/build -I/Users/personal/jank/compiler+runtime -I/Users/personal/jank/compiler+runtime/include/cpp -isystem /Users/personal/jank/compiler+runtime/build/llvm-install/usr/local/include -isystem /Users/personal/jank/compiler+runtime/third-party/nanobench/include -isystem /Users/personal/jank/compiler+runtime/third-party/folly -isystem /Users/personal/jank/compiler+runtime/third-party/bpptree/include -isystem /Users/personal/jank/compiler+runtime/third-party/bdwgc/include -isystem /Users/personal/jank/compiler+runtime/third-party/immer -isystem /Users/personal/jank/compiler+runtime/third-party/magic_enum/include/magic_enum -isystem /Users/personal/jank/compiler+runtime/third-party/cli11/include -isystem /Users/personal/jank/compiler+runtime/third-party/fmt/include -isystem /Users/personal/jank/compiler+runtime/third-party/libzippp/src -isystem /opt/homebrew/include -isystem /opt/homebrew/Cellar/openssl@3/3.4.0/include -fPIC -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -g -std=gnu++20 -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk -fcolor-diagnostics -std=gnu++20 -DIMMER_HAS_LIBGC=1 -DIMMER_TAGGED_NODE=0 -DHAVE_CXX14=1 -DFMT_HEADER_ONLY=1 -I/opt/homebrew/include -Werror -DJANK_DEBUG -Wall -Wextra -Wpedantic -Wfloat-equal -Wuninitialized -Wswitch-enum -Wnon-virtual-dtor -Wold-style-cast -Wno-gnu-case-range -Wno-gnu-conditional-omitted-operand -Wno-implicit-fallthrough -Wno-covered-switch-default -Wno-invalid-offsetof -fno-common -frtti -fexceptions -O0 -DJANK_VERSION=\"0.1-8ec44a71f37acd3d4af9823632178e12925ab7dd\" "-DJANK_JIT_FLAGS=\"-std=gnu++20 -DIMMER_HAS_LIBGC=1 -DIMMER_TAGGED_NODE=0 -DHAVE_CXX14=1 -DFMT_HEADER_ONLY=1 -I/opt/homebrew/include -Werror -DJANK_DEBUG -w\"" -DJANK_CLANG_PREFIX=\"/Users/personal/jank/compiler+runtime/build/llvm-install/usr/local\" -MD -MT CMakeFiles/jank_lib.dir/src/cpp/jank/read/lex.cpp.o -MF CMakeFiles/jank_lib.dir/src/cpp/jank/read/lex.cpp.o.d -o CMakeFiles/jank_lib.dir/src/cpp/jank/read/lex.cpp.o -c /Users/personal/jank/compiler+runtime/src/cpp/jank/read/lex.cpp
/Users/personal/jank/compiler+runtime/src/cpp/jank/read/lex.cpp:318:29: error: narrowing conversion from 'char32_t' to signed type 'wint_t' (aka 'int') is implementation-defined [bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions,-warnings-as-errors]
  318 |       return !std::iswspace(c) && !is_special_char(c)
      |                             ^
/Users/personal/jank/compiler+runtime/src/cpp/jank/read/lex.cpp:382:45: error: narrowing conversion from 'char32_t' to signed type 'wint_t' (aka 'int') is implementation-defined [bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions,-warnings-as-errors]
  382 |             if(ch.is_err() || std::iswspace(ch.expect_ok().character))
      |                                             ^
/Users/personal/jank/compiler+runtime/src/cpp/jank/read/lex.cpp:519:37: error: narrowing conversion from 'char32_t' to signed type 'wint_t' (aka 'int') is implementation-defined [bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions,-warnings-as-errors]
  519 |               else if(std::iswdigit(c) == 0)
      |                                     ^
/Users/personal/jank/compiler+runtime/src/cpp/jank/read/lex.cpp:636:45: error: narrowing conversion from 'char32_t' to signed type 'wint_t' (aka 'int') is implementation-defined [bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions,-warnings-as-errors]
  636 |             if(oc.is_err() || std::iswspace(c))
      |                                             ^
20056 warnings generated.
Suppressed 20057 warnings (20048 in non-user code, 9 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
4 warnings treated as errors
[10/103] Building CXX object CMakeFiles/jank_lib.dir/src/cpp/jank/c_api.cpp.o
FAILED: CMakeFiles/jank_lib.dir/src/cpp/jank/c_api.cpp.o
/opt/homebrew/bin/cmake -E __run_co_compile --tidy="/Users/personal/jank/compiler+runtime/build/llvm-install/usr/local/bin/clang-tidy;--use-color;--extra-arg-before=--driver-mode=g++" --source=/Users/personal/jank/compiler+runtime/src/cpp/jank/c_api.cpp -- /Users/personal/jank/compiler+runtime/build/llvm-install/usr/local/bin/clang++ -DBOOST_ATOMIC_DYN_LINK -DBOOST_ATOMIC_NO_LIB -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_FILESYSTEM_NO_LIB -DBOOST_SYSTEM_DYN_LINK -DBOOST_SYSTEM_NO_LIB -DFMT_SHARED -D__STDC_CONSTANT_MACROS -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/Users/personal/jank/compiler+runtime/build -I/Users/personal/jank/compiler+runtime -I/Users/personal/jank/compiler+runtime/include/cpp -isystem /Users/personal/jank/compiler+runtime/build/llvm-install/usr/local/include -isystem /Users/personal/jank/compiler+runtime/third-party/nanobench/include -isystem /Users/personal/jank/compiler+runtime/third-party/folly -isystem /Users/personal/jank/compiler+runtime/third-party/bpptree/include -isystem /Users/personal/jank/compiler+runtime/third-party/bdwgc/include -isystem /Users/personal/jank/compiler+runtime/third-party/immer -isystem /Users/personal/jank/compiler+runtime/third-party/magic_enum/include/magic_enum -isystem /Users/personal/jank/compiler+runtime/third-party/cli11/include -isystem /Users/personal/jank/compiler+runtime/third-party/fmt/include -isystem /Users/personal/jank/compiler+runtime/third-party/libzippp/src -isystem /opt/homebrew/include -isystem /opt/homebrew/Cellar/openssl@3/3.4.0/include -fPIC -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -g -std=gnu++20 -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk -fcolor-diagnostics -std=gnu++20 -DIMMER_HAS_LIBGC=1 -DIMMER_TAGGED_NODE=0 -DHAVE_CXX14=1 -DFMT_HEADER_ONLY=1 -I/opt/homebrew/include -Werror -DJANK_DEBUG -Wall -Wextra -Wpedantic -Wfloat-equal -Wuninitialized -Wswitch-enum -Wnon-virtual-dtor -Wold-style-cast -Wno-gnu-case-range -Wno-gnu-conditional-omitted-operand -Wno-implicit-fallthrough -Wno-covered-switch-default -Wno-invalid-offsetof -fno-common -frtti -fexceptions -O0 -DJANK_VERSION=\"0.1-8ec44a71f37acd3d4af9823632178e12925ab7dd\" "-DJANK_JIT_FLAGS=\"-std=gnu++20 -DIMMER_HAS_LIBGC=1 -DIMMER_TAGGED_NODE=0 -DHAVE_CXX14=1 -DFMT_HEADER_ONLY=1 -I/opt/homebrew/include -Werror -DJANK_DEBUG -w\"" -DJANK_CLANG_PREFIX=\"/Users/personal/jank/compiler+runtime/build/llvm-install/usr/local\" -MD -MT CMakeFiles/jank_lib.dir/src/cpp/jank/c_api.cpp.o -MF CMakeFiles/jank_lib.dir/src/cpp/jank/c_api.cpp.o.d -o CMakeFiles/jank_lib.dir/src/cpp/jank/c_api.cpp.o -c /Users/personal/jank/compiler+runtime/src/cpp/jank/c_api.cpp
/Users/personal/jank/compiler+runtime/src/cpp/jank/c_api.cpp:397:13: error: variable 'args' is not initialized [cppcoreguidelines-init-variables,-warnings-as-errors]
  397 |     va_list args;
      |             ^
      |                  = nullptr
/Users/personal/jank/compiler+runtime/src/cpp/jank/c_api.cpp:417:13: error: variable 'args' is not initialized [cppcoreguidelines-init-variables,-warnings-as-errors]
  417 |     va_list args;
      |             ^
      |                  = nullptr
/Users/personal/jank/compiler+runtime/src/cpp/jank/c_api.cpp:436:13: error: variable 'args' is not initialized [cppcoreguidelines-init-variables,-warnings-as-errors]
  436 |     va_list args;
      |             ^
      |                  = nullptr
/Users/personal/jank/compiler+runtime/src/cpp/jank/c_api.cpp:457:13: error: variable 'args' is not initialized [cppcoreguidelines-init-variables,-warnings-as-errors]
  457 |     va_list args;
      |             ^
      |                  = nullptr
32148 warnings generated.
Suppressed 32182 warnings (32144 in non-user code, 38 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
4 warnings treated as errors
[12/103] Building CXX object CMakeFiles/jank_lib.dir/src/cpp/jank/read/parse.cpp.o
ninja: build stopped: subcommand failed.
```