### PR TITLE
Improve compile times by 25%

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -34,6 +34,7 @@ misc-definitions-in-headers,\
 -bugprone-easily-swappable-parameters,\
 -bugprone-reserved-identifier,\
 -bugprone-multi-level-implicit-pointer-conversion,\
+-bugprone-crtp-constructor-accessibility,\
 -readability-redundant-member-init,\
 -readability-implicit-bool-conversion,\
 -readability-magic-numbers,\

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,9 +16,6 @@
 [submodule "compiler+runtime/third-party/immer"]
 	path = compiler+runtime/third-party/immer
 	url = https://github.com/jank-lang/immer.git
-[submodule "compiler+runtime/third-party/magic_enum"]
-	path = compiler+runtime/third-party/magic_enum
-	url = https://github.com/jank-lang/magic_enum.git
 [submodule "compiler+runtime/third-party/cli11"]
 	path = compiler+runtime/third-party/cli11
 	url = https://github.com/jank-lang/CLI11.git

--- a/compiler+runtime/CMakeLists.txt
+++ b/compiler+runtime/CMakeLists.txt
@@ -151,6 +151,7 @@ add_library(
   src/cpp/jank/util/scope_exit.cpp
   src/cpp/jank/util/escape.cpp
   src/cpp/jank/util/clang_format.cpp
+  src/cpp/jank/util/string_builder.cpp
   src/cpp/jank/profile/time.cpp
   src/cpp/jank/read/lex.cpp
   src/cpp/jank/read/parse.cpp
@@ -426,6 +427,7 @@ if(jank_tests)
     jank_test_exe
     test/cpp/main.cpp
     test/cpp/jank/native_persistent_string.cpp
+    test/cpp/jank/util/string_builder.cpp
     test/cpp/jank/read/lex.cpp
     test/cpp/jank/read/parse.cpp
     test/cpp/jank/analyze/box.cpp

--- a/compiler+runtime/CMakeLists.txt
+++ b/compiler+runtime/CMakeLists.txt
@@ -68,7 +68,7 @@ set(
   -fno-common
   -fno-rtti
   -fexceptions
-  -ftime-trace
+  #-ftime-trace
   $<$<CONFIG:Debug>:-O0>
   $<$<CONFIG:Release>:-O2>
 )

--- a/compiler+runtime/CMakeLists.txt
+++ b/compiler+runtime/CMakeLists.txt
@@ -79,13 +79,10 @@ set(
   -w
 )
 
-# TODO: Remove FMT_HEADER_ONLY once the extern template Clang bug is fixed.
 set(
   jank_common_compiler_flags
   -std=gnu++20
   -DIMMER_HAS_LIBGC=1 -DIMMER_TAGGED_NODE=0 -DHAVE_CXX14=1
-  -DFMT_HEADER_ONLY=1
-  #-DLIBASSERT_USE_MAGIC_ENUM=1
   #-DLIBASSERT_USE_FMT=1
   #-DLIBASSERT_STATIC_DEFINE=1
   #-stdlib=libc++

--- a/compiler+runtime/CMakeLists.txt
+++ b/compiler+runtime/CMakeLists.txt
@@ -197,6 +197,7 @@ add_library(
   src/cpp/jank/runtime/obj/persistent_string_sequence.cpp
   src/cpp/jank/runtime/obj/cons.cpp
   src/cpp/jank/runtime/obj/range.cpp
+  src/cpp/jank/runtime/obj/integer_range.cpp
   src/cpp/jank/runtime/obj/repeat.cpp
   src/cpp/jank/runtime/obj/ratio.cpp
   src/cpp/jank/runtime/obj/iterator.cpp

--- a/compiler+runtime/CMakeLists.txt
+++ b/compiler+runtime/CMakeLists.txt
@@ -206,6 +206,7 @@ add_library(
   src/cpp/jank/runtime/obj/chunk_buffer.cpp
   src/cpp/jank/runtime/obj/array_chunk.cpp
   src/cpp/jank/runtime/obj/chunked_cons.cpp
+  src/cpp/jank/runtime/obj/detail/iterator_sequence.cpp
   src/cpp/jank/runtime/obj/native_array_sequence.cpp
   src/cpp/jank/runtime/obj/native_vector_sequence.cpp
   src/cpp/jank/runtime/obj/atom.cpp

--- a/compiler+runtime/CMakeLists.txt
+++ b/compiler+runtime/CMakeLists.txt
@@ -188,6 +188,8 @@ add_library(
   src/cpp/jank/runtime/obj/transient_hash_map.cpp
   src/cpp/jank/runtime/obj/persistent_sorted_map.cpp
   src/cpp/jank/runtime/obj/transient_sorted_map.cpp
+  src/cpp/jank/runtime/obj/detail/base_persistent_map.cpp
+  src/cpp/jank/runtime/obj/detail/base_persistent_map_sequence.cpp
   src/cpp/jank/runtime/obj/transient_vector.cpp
   src/cpp/jank/runtime/obj/persistent_hash_set.cpp
   src/cpp/jank/runtime/obj/transient_hash_set.cpp

--- a/compiler+runtime/CMakeLists.txt
+++ b/compiler+runtime/CMakeLists.txt
@@ -68,6 +68,7 @@ set(
   -fno-common
   -frtti
   -fexceptions
+  -ftime-trace
   $<$<CONFIG:Debug>:-O0>
   $<$<CONFIG:Release>:-O2>
 )

--- a/compiler+runtime/CMakeLists.txt
+++ b/compiler+runtime/CMakeLists.txt
@@ -66,7 +66,7 @@ set(
   -Wno-covered-switch-default
   -Wno-invalid-offsetof
   -fno-common
-  -frtti
+  -fno-rtti
   -fexceptions
   -ftime-trace
   $<$<CONFIG:Debug>:-O0>

--- a/compiler+runtime/include/cpp/jank/analyze/expr/call.hpp
+++ b/compiler+runtime/include/cpp/jank/analyze/expr/call.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <jank/runtime/obj/persistent_list.hpp>
 #include <jank/analyze/expression_base.hpp>
 
 namespace jank::analyze::expr

--- a/compiler+runtime/include/cpp/jank/analyze/expr/def.hpp
+++ b/compiler+runtime/include/cpp/jank/analyze/expr/def.hpp
@@ -1,10 +1,9 @@
 #pragma once
 
-#include <jank/runtime/obj/symbol.hpp>
+#include <jank/detail/to_runtime_data.hpp>
 #include <jank/analyze/local_frame.hpp>
 #include <jank/analyze/expression_base.hpp>
 #include <jank/option.hpp>
-#include <jank/detail/to_runtime_data.hpp>
 
 namespace jank::analyze::expr
 {

--- a/compiler+runtime/include/cpp/jank/analyze/expr/function.hpp
+++ b/compiler+runtime/include/cpp/jank/analyze/expr/function.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <jank/runtime/obj/symbol.hpp>
 #include <jank/analyze/local_frame.hpp>
 #include <jank/analyze/expr/do.hpp>
 #include <jank/analyze/expression_base.hpp>

--- a/compiler+runtime/include/cpp/jank/analyze/expr/let.hpp
+++ b/compiler+runtime/include/cpp/jank/analyze/expr/let.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <jank/runtime/obj/symbol.hpp>
 #include <jank/analyze/expr/do.hpp>
 #include <jank/analyze/local_frame.hpp>
 #include <jank/analyze/expression_base.hpp>

--- a/compiler+runtime/include/cpp/jank/analyze/expr/local_reference.hpp
+++ b/compiler+runtime/include/cpp/jank/analyze/expr/local_reference.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <jank/runtime/obj/symbol.hpp>
 #include <jank/analyze/expression_base.hpp>
 #include <jank/detail/to_runtime_data.hpp>
 

--- a/compiler+runtime/include/cpp/jank/analyze/expr/named_recursion.hpp
+++ b/compiler+runtime/include/cpp/jank/analyze/expr/named_recursion.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <jank/runtime/obj/persistent_list.hpp>
 #include <jank/analyze/expression_base.hpp>
 #include <jank/analyze/expr/recursion_reference.hpp>
 

--- a/compiler+runtime/include/cpp/jank/analyze/expr/recur.hpp
+++ b/compiler+runtime/include/cpp/jank/analyze/expr/recur.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <memory>
-
-#include <jank/runtime/obj/persistent_list.hpp>
 #include <jank/analyze/expression_base.hpp>
 
 namespace jank::analyze::expr

--- a/compiler+runtime/include/cpp/jank/analyze/expr/set.hpp
+++ b/compiler+runtime/include/cpp/jank/analyze/expr/set.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <jank/analyze/expression_base.hpp>
-#include <jank/runtime/obj/persistent_hash_set.hpp>
 
 namespace jank::analyze::expr
 {

--- a/compiler+runtime/include/cpp/jank/analyze/expression_base.hpp
+++ b/compiler+runtime/include/cpp/jank/analyze/expression_base.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <magic_enum.hpp>
-
 #include <jank/detail/to_runtime_data.hpp>
 #include <jank/runtime/core/make_box.hpp>
 #include <jank/runtime/core/seq.hpp>
@@ -19,13 +17,26 @@ namespace jank::analyze
     tail
   };
 
+  constexpr char const *expression_position_str(expression_position const pos)
+  {
+    switch(pos)
+    {
+      case expression_position::value:
+        return "value";
+      case expression_position::statement:
+        return "statement";
+      case expression_position::tail:
+        return "tail";
+    }
+  }
+
   /* Common base class for every expression. */
   struct expression_base : gc
   {
     object_ptr to_runtime_data() const
     {
       return obj::persistent_array_map::create_unique(make_box("position"),
-                                                      make_box(magic_enum::enum_name(position)),
+                                                      make_box(expression_position_str(position)),
                                                       make_box("needs_box"),
                                                       make_box(needs_box));
     }

--- a/compiler+runtime/include/cpp/jank/analyze/expression_base.hpp
+++ b/compiler+runtime/include/cpp/jank/analyze/expression_base.hpp
@@ -2,10 +2,11 @@
 
 #include <magic_enum.hpp>
 
+#include <jank/detail/to_runtime_data.hpp>
 #include <jank/runtime/core/make_box.hpp>
+#include <jank/runtime/core/seq.hpp>
 #include <jank/runtime/obj/persistent_array_map.hpp>
 #include <jank/analyze/local_frame.hpp>
-#include <jank/detail/to_runtime_data.hpp>
 
 namespace jank::analyze
 {

--- a/compiler+runtime/include/cpp/jank/analyze/local_frame.hpp
+++ b/compiler+runtime/include/cpp/jank/analyze/local_frame.hpp
@@ -1,11 +1,16 @@
 #pragma once
 
-#include <jank/runtime/obj/symbol.hpp>
 #include <jank/option.hpp>
+#include <jank/runtime/object.hpp>
 
 namespace jank::runtime
 {
   struct context;
+
+  namespace obj
+  {
+    using symbol_ptr = native_box<struct symbol>;
+  }
 }
 
 namespace jank::analyze

--- a/compiler+runtime/include/cpp/jank/analyze/local_frame.hpp
+++ b/compiler+runtime/include/cpp/jank/analyze/local_frame.hpp
@@ -65,6 +65,25 @@ namespace jank::analyze
       finally
     };
 
+    static constexpr char const *frame_type_str(frame_type const type)
+    {
+      switch(type)
+      {
+        case frame_type::root:
+          return "root";
+        case frame_type::fn:
+          return "fn";
+        case frame_type::let:
+          return "let";
+        case frame_type::try_:
+          return "try_";
+        case frame_type::catch_:
+          return "catch_";
+        case frame_type::finally:
+          return "finally";
+      }
+    }
+
     static constexpr native_bool pointer_free{ false };
 
     local_frame() = delete;

--- a/compiler+runtime/include/cpp/jank/analyze/processor.hpp
+++ b/compiler+runtime/include/cpp/jank/analyze/processor.hpp
@@ -3,10 +3,6 @@
 #include <functional>
 
 #include <jank/read/parse.hpp>
-#include <jank/runtime/obj/symbol.hpp>
-#include <jank/runtime/obj/persistent_list.hpp>
-#include <jank/runtime/obj/persistent_vector.hpp>
-#include <jank/runtime/obj/persistent_array_map.hpp>
 #include <jank/runtime/var.hpp>
 #include <jank/analyze/local_frame.hpp>
 #include <jank/analyze/expression.hpp>
@@ -15,6 +11,14 @@
 namespace jank::runtime
 {
   struct context;
+
+  namespace obj
+  {
+    using symbol_ptr = native_box<struct symbol>;
+    using persistent_list_ptr = native_box<struct persistent_list>;
+    using persistent_vector_ptr = native_box<struct persistent_vector>;
+    using persistent_array_map_ptr = native_box<struct persistent_array_map>;
+  }
 }
 
 namespace jank::analyze

--- a/compiler+runtime/include/cpp/jank/codegen/llvm_processor.hpp
+++ b/compiler+runtime/include/cpp/jank/codegen/llvm_processor.hpp
@@ -7,9 +7,13 @@
 #include <llvm/Analysis/LoopAnalysisManager.h>
 #include <llvm/Analysis/CGSCCPassManager.h>
 
-#include <jank/runtime/obj/keyword.hpp>
 #include <jank/analyze/expression.hpp>
 #include <jank/analyze/processor.hpp>
+
+namespace jank::runtime::obj
+{
+  using keyword_ptr = native_box<struct keyword>;
+}
 
 namespace jank::codegen
 {

--- a/compiler+runtime/include/cpp/jank/detail/to_runtime_data.hpp
+++ b/compiler+runtime/include/cpp/jank/detail/to_runtime_data.hpp
@@ -3,6 +3,8 @@
 #include <boost/filesystem/path.hpp>
 
 #include <jank/runtime/object.hpp>
+#include <jank/runtime/obj/symbol.hpp>
+#include <jank/runtime/obj/persistent_array_map.hpp>
 #include <jank/runtime/core/make_box.hpp>
 
 namespace jank::detail

--- a/compiler+runtime/include/cpp/jank/detail/to_runtime_data.hpp
+++ b/compiler+runtime/include/cpp/jank/detail/to_runtime_data.hpp
@@ -31,7 +31,8 @@ namespace jank::detail
   template <typename T>
   object_ptr to_runtime_data(native_box<T> const &d)
   {
-    return make_box(fmt::format("box({})", reinterpret_cast<void const *>(d.data)));
+    util::string_builder sb;
+    return make_box(sb("box(")(reinterpret_cast<void const *>(d.data))(")").release());
   }
 
   inline object_ptr to_runtime_data(native_persistent_string const &d)

--- a/compiler+runtime/include/cpp/jank/native_persistent_string.hpp
+++ b/compiler+runtime/include/cpp/jank/native_persistent_string.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <bit>
-#include <fmt/format.h>
 
 #include <jank/type.hpp>
 
@@ -925,18 +924,6 @@ namespace jank
     return os << static_cast<native_persistent_string_view>(s);
   }
 }
-
-template <>
-struct fmt::formatter<jank::native_persistent_string> : private formatter<fmt::string_view>
-{
-  using formatter<fmt::string_view>::parse;
-
-  template <typename Context>
-  auto format(jank::native_persistent_string const &s, Context &ctx) const
-  {
-    return formatter<fmt::string_view>::format({ s.data(), s.size() }, ctx);
-  }
-};
 
 namespace std
 {

--- a/compiler+runtime/include/cpp/jank/native_persistent_string.hpp
+++ b/compiler+runtime/include/cpp/jank/native_persistent_string.hpp
@@ -11,6 +11,11 @@ namespace jank
     uint32_t integer(native_hash const input);
   }
 
+  namespace util
+  {
+    struct string_builder;
+  }
+
   /* This is a not-completely-standard replacement for std::string, with a few goals in mind:
    *
    * 1. Be as fast, or faster, than `std::string` and `folly::fbstring`
@@ -60,6 +65,8 @@ namespace jank
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
     static constexpr size_type npos{ std::numeric_limits<size_type>::max() };
+
+    friend struct util::string_builder;
 
     constexpr native_persistent_string() noexcept
     {

--- a/compiler+runtime/include/cpp/jank/native_persistent_string/fmt.hpp
+++ b/compiler+runtime/include/cpp/jank/native_persistent_string/fmt.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <fmt/base.h>
+
+#include <jank/native_persistent_string.hpp>
+
+template <>
+struct fmt::formatter<jank::native_persistent_string> : private formatter<fmt::string_view>
+{
+  using formatter<fmt::string_view>::parse;
+
+  template <typename Context>
+  auto format(jank::native_persistent_string const &s, Context &ctx) const
+  {
+    return formatter<fmt::string_view>::format({ s.data(), s.size() }, ctx);
+  }
+};

--- a/compiler+runtime/include/cpp/jank/option.hpp
+++ b/compiler+runtime/include/cpp/jank/option.hpp
@@ -3,9 +3,6 @@
 #include <cassert>
 #include <utility> // move, forward
 #include <type_traits>
-#include <ostream>
-
-#include <fmt/ostream.h>
 
 #include <jank/type.hpp>
 
@@ -268,22 +265,4 @@ namespace jank
   }
 
   constexpr inline none_t none = none_t{};
-
-  template <typename T>
-  std::ostream &operator<<(std::ostream &os, option<T> const &o)
-  {
-    if(o.is_none())
-    {
-      return os << "none";
-    }
-    return os << "some(" << o.unwrap() << ")";
-  }
-}
-
-namespace fmt
-{
-  template <typename T>
-  struct formatter<jank::option<T>> : fmt::ostream_formatter
-  {
-  };
 }

--- a/compiler+runtime/include/cpp/jank/option/fmt.hpp
+++ b/compiler+runtime/include/cpp/jank/option/fmt.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <ostream>
+
+#include <fmt/ostream.h>
+
+#include <jank/option.hpp>
+
+namespace jank
+{
+  template <typename T>
+  std::ostream &operator<<(std::ostream &os, option<T> const &o)
+  {
+    if(o.is_none())
+    {
+      return os << "none";
+    }
+    return os << "some(" << o.unwrap() << ")";
+  }
+}
+
+namespace fmt
+{
+  template <typename T>
+  struct formatter<jank::option<T>> : fmt::ostream_formatter
+  {
+  };
+}

--- a/compiler+runtime/include/cpp/jank/read/lex.hpp
+++ b/compiler+runtime/include/cpp/jank/read/lex.hpp
@@ -49,6 +49,69 @@ namespace jank::read::lex
     eof,
   };
 
+  constexpr char const *token_kind_str(token_kind const kind)
+  {
+    switch(kind)
+    {
+      case token_kind::open_paren:
+        return "open_paren";
+      case token_kind::close_paren:
+        return "close_paren";
+      case token_kind::open_square_bracket:
+        return "open_square_bracket";
+      case token_kind::close_square_bracket:
+        return "close_square_bracket";
+      case token_kind::open_curly_bracket:
+        return "open_curly_bracket";
+      case token_kind::close_curly_bracket:
+        return "close_curly_bracket";
+      case token_kind::single_quote:
+        return "single_quote";
+      case token_kind::meta_hint:
+        return "meta_hint";
+      case token_kind::reader_macro:
+        return "reader_macro";
+      case token_kind::reader_macro_comment:
+        return "reader_macro_comment";
+      case token_kind::reader_macro_conditional:
+        return "reader_macro_conditional";
+      case token_kind::reader_macro_conditional_splice:
+        return "reader_macro_conditional_splice";
+      case token_kind::syntax_quote:
+        return "syntax_quote";
+      case token_kind::unquote:
+        return "unquote";
+      case token_kind::unquote_splice:
+        return "unquote_splice";
+      case token_kind::deref:
+        return "deref";
+      case token_kind::comment:
+        return "comment";
+      case token_kind::nil:
+        return "nil";
+      case token_kind::boolean:
+        return "boolean";
+      case token_kind::character:
+        return "character";
+      case token_kind::symbol:
+        return "symbol";
+      case token_kind::keyword:
+        return "keyword";
+      case token_kind::integer:
+        return "integer";
+      case token_kind::real:
+        return "real";
+      case token_kind::ratio:
+        return "ratio";
+      case token_kind::string:
+        return "string";
+      case token_kind::escaped_string:
+        return "escaped_string";
+      case token_kind::eof:
+        return "eof";
+    }
+  }
+
   struct ratio
   {
     native_integer numerator{};

--- a/compiler+runtime/include/cpp/jank/runtime/behavior/callable.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/behavior/callable.hpp
@@ -9,8 +9,7 @@ namespace jank::runtime
 
   namespace obj
   {
-    using persistent_list = static_object<object_type::persistent_list>;
-    using persistent_list_ptr = native_box<persistent_list>;
+    using persistent_list_ptr = native_box<struct persistent_list>;
   }
 
   constexpr size_t const max_params{ 10 };

--- a/compiler+runtime/include/cpp/jank/runtime/behavior/number_like.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/behavior/number_like.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <jank/runtime/obj/number.hpp>
+#include <jank/type.hpp>
 
 namespace jank::runtime::behavior
 {

--- a/compiler+runtime/include/cpp/jank/runtime/context.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/context.hpp
@@ -9,7 +9,6 @@
 #include <jank/runtime/module/loader.hpp>
 #include <jank/runtime/ns.hpp>
 #include <jank/runtime/var.hpp>
-#include <jank/runtime/obj/keyword.hpp>
 #include <jank/jit/processor.hpp>
 #include <jank/util/cli.hpp>
 
@@ -28,6 +27,11 @@ namespace jank
 
 namespace jank::runtime
 {
+  namespace obj
+  {
+    using keyword_ptr = native_box<struct keyword>;
+  }
+
   /* This is a singleton, as much as I fought it for actual years. Trying to have multiple
    * contexts is limited firstly by there being a single, global JIT compilation context
    * and process in which global memory exists. Secondly, by the fact that interned keywords

--- a/compiler+runtime/include/cpp/jank/runtime/convert/into.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/convert/into.hpp
@@ -4,6 +4,7 @@
 #include <jank/runtime/object.hpp>
 #include <jank/runtime/detail/type.hpp>
 #include <jank/runtime/obj/nil.hpp>
+#include <jank/runtime/obj/persistent_vector.hpp>
 #include <jank/runtime/core/make_box.hpp>
 
 namespace jank::runtime
@@ -114,7 +115,7 @@ namespace jank::runtime
   {
     static object_ptr call(V<Input> const &o)
     {
-      detail::native_transient_vector trans;
+      runtime::detail::native_transient_vector trans;
       for(auto const &e : o)
       {
         trans.push_back(convert<Input, object_ptr>::call(e));

--- a/compiler+runtime/include/cpp/jank/runtime/core/make_box.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core/make_box.hpp
@@ -11,18 +11,6 @@
 
 namespace jank::runtime
 {
-  namespace obj
-  {
-    using nil = static_object<object_type::nil>;
-    using boolean = static_object<object_type::boolean>;
-    using integer = static_object<object_type::integer>;
-    using real = static_object<object_type::real>;
-    using persistent_string = static_object<object_type::persistent_string>;
-    using persistent_list = static_object<object_type::persistent_list>;
-    using symbol = static_object<object_type::symbol>;
-    using character = static_object<object_type::character>;
-  }
-
   /* TODO: Constexpr these. */
   [[gnu::always_inline, gnu::flatten, gnu::hot]]
   inline auto make_box(std::nullptr_t const &)

--- a/compiler+runtime/include/cpp/jank/runtime/core/math.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core/math.hpp
@@ -1,10 +1,16 @@
 #pragma once
 
-#include <jank/runtime/obj/number.hpp>
-#include <jank/runtime/obj/ratio.hpp>
+#include <jank/runtime/object.hpp>
 
 namespace jank::runtime
 {
+  namespace obj
+  {
+    using integer_ptr = native_box<struct integer>;
+    using real_ptr = native_box<struct real>;
+    using ratio_ptr = native_box<struct ratio>;
+  }
+
   object_ptr add(object_ptr l, object_ptr r);
   object_ptr add(obj::integer_ptr l, object_ptr r);
   object_ptr add(object_ptr l, obj::integer_ptr r);

--- a/compiler+runtime/include/cpp/jank/runtime/core/seq.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core/seq.hpp
@@ -7,11 +7,8 @@ namespace jank::runtime
 {
   namespace obj
   {
-    using persistent_list = static_object<object_type::persistent_list>;
-    using persistent_list_ptr = native_box<persistent_list>;
-
-    using persistent_vector = static_object<object_type::persistent_vector>;
-    using persistent_vector_ptr = native_box<persistent_vector>;
+    using persistent_list_ptr = native_box<struct persistent_list>;
+    using persistent_vector_ptr = native_box<struct persistent_vector>;
   }
 
   template <typename T>

--- a/compiler+runtime/include/cpp/jank/runtime/core/to_string.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core/to_string.hpp
@@ -6,24 +6,23 @@
 namespace jank::runtime
 {
   native_persistent_string to_string(object const *o);
-  void to_string(char ch, fmt::memory_buffer &buff);
-  void to_string(object_ptr o, fmt::memory_buffer &buff);
+  void to_string(char ch, util::string_builder &buff);
+  void to_string(object_ptr o, util::string_builder &buff);
 
   native_persistent_string to_code_string(object const *o);
-  void to_code_string(char ch, fmt::memory_buffer &buff);
-  void to_code_string(object_ptr o, fmt::memory_buffer &buff);
+  void to_code_string(char ch, util::string_builder &buff);
+  void to_code_string(object_ptr o, util::string_builder &buff);
 
   template <typename It>
   void to_string(It const &begin,
                  It const &end,
                  native_persistent_string_view const open,
                  char const close,
-                 fmt::memory_buffer &buff)
+                 util::string_builder &buff)
   {
-    auto inserter(std::back_inserter(buff));
     for(auto const c : open)
     {
-      inserter = c;
+      buff(c);
     }
     for(auto i(begin); i != end; ++i)
     {
@@ -31,44 +30,43 @@ namespace jank::runtime
       auto n(i);
       if(++n != end)
       {
-        inserter = ' ';
+        buff(' ');
       }
     }
-    inserter = close;
+    buff(close);
   }
 
   template <typename T>
   requires behavior::sequenceable<T>
-  void to_string(native_box<T> const s, fmt::memory_buffer &buff)
+  void to_string(native_box<T> const s, util::string_builder &buff)
   {
-    auto inserter(std::back_inserter(buff));
     if(!s)
     {
-      fmt::format_to(inserter, "()");
+      buff("()");
       return;
     }
 
-    fmt::format_to(inserter, "(");
+    buff('(');
     native_bool needs_space{};
     for(auto i(s->fresh_seq()); i != nullptr; i = i->next_in_place())
     {
       if(needs_space)
       {
-        fmt::format_to(inserter, " ");
+        buff(' ');
       }
       runtime::to_string(i->first(), buff);
       needs_space = true;
     }
-    fmt::format_to(inserter, ")");
+    buff(')');
   }
 
   template <typename T>
   requires behavior::sequenceable<T>
   native_persistent_string to_string(native_box<T> const s)
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     runtime::to_string(s, buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
   template <typename It>
@@ -76,12 +74,11 @@ namespace jank::runtime
                       It const &end,
                       native_persistent_string_view const open,
                       char const close,
-                      fmt::memory_buffer &buff)
+                      util::string_builder &buff)
   {
-    auto inserter(std::back_inserter(buff));
     for(auto const c : open)
     {
-      inserter = c;
+      buff(c);
     }
     for(auto i(begin); i != end; ++i)
     {
@@ -89,43 +86,42 @@ namespace jank::runtime
       auto n(i);
       if(++n != end)
       {
-        inserter = ' ';
+        buff(' ');
       }
     }
-    inserter = close;
+    buff(close);
   }
 
   template <typename T>
   requires behavior::sequenceable<T>
-  void to_code_string(native_box<T> const s, fmt::memory_buffer &buff)
+  void to_code_string(native_box<T> const s, util::string_builder &buff)
   {
-    auto inserter(std::back_inserter(buff));
     if(!s)
     {
-      fmt::format_to(inserter, "()");
+      buff("()");
       return;
     }
 
-    fmt::format_to(inserter, "(");
+    buff('(');
     native_bool needs_space{};
     for(auto i(s->fresh_seq()); i != nullptr; i = i->next_in_place())
     {
       if(needs_space)
       {
-        fmt::format_to(inserter, " ");
+        buff(' ');
       }
       runtime::to_code_string(i->first(), buff);
       needs_space = true;
     }
-    fmt::format_to(inserter, ")");
+    buff(')');
   }
 
   template <typename T>
   requires behavior::sequenceable<T>
   native_persistent_string to_code_string(native_box<T> const s)
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     runtime::to_code_string(s, buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/native_box.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/native_box.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <fmt/ostream.h>
-
 #include <jank/runtime/object.hpp>
 
 namespace jank::runtime
@@ -318,12 +316,4 @@ namespace jank::runtime
   {
     return os << "box(" << o.data << ")";
   }
-}
-
-namespace fmt
-{
-  template <typename T>
-  struct formatter<jank::runtime::native_box<T>> : fmt::ostream_formatter
-  {
-  };
 }

--- a/compiler+runtime/include/cpp/jank/runtime/native_box.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/native_box.hpp
@@ -120,20 +120,23 @@ namespace jank::runtime
     {
     }
 
-    template <object_type T>
-    native_box(static_object<T> * const typed_data)
+    template <typename T>
+    requires behavior::object_like<T>
+    native_box(T * const typed_data)
       : data{ &typed_data->base }
     {
     }
 
-    template <object_type T>
-    native_box(static_object<T> const * const typed_data)
+    template <typename T>
+    requires behavior::object_like<T>
+    native_box(T const * const typed_data)
       : data{ typed_data ? const_cast<object *>(&typed_data->base) : nullptr }
     {
     }
 
-    template <object_type T>
-    native_box(native_box<static_object<T>> const typed_data)
+    template <typename T>
+    requires behavior::object_like<T>
+    native_box(native_box<T> const typed_data)
       : data{ typed_data ? &typed_data->base : nullptr }
     {
     }
@@ -165,14 +168,16 @@ namespace jank::runtime
       return data == rhs.data;
     }
 
-    template <object_type T>
-    native_bool operator==(static_object<T> const &rhs) const
+    template <typename T>
+    requires behavior::object_like<T>
+    native_bool operator==(T const &rhs) const
     {
       return data == &rhs->base;
     }
 
-    template <object_type T>
-    native_bool operator==(native_box<static_object<T>> const &rhs) const
+    template <typename T>
+    requires behavior::object_like<T>
+    native_bool operator==(native_box<T> const &rhs) const
     {
       return data == &rhs->base;
     }
@@ -187,14 +192,16 @@ namespace jank::runtime
       return data != rhs.data;
     }
 
-    template <object_type T>
-    native_bool operator!=(static_object<T> const &rhs) const
+    template <typename T>
+    requires behavior::object_like<T>
+    native_bool operator!=(T const &rhs) const
     {
       return data != &rhs->base;
     }
 
-    template <object_type T>
-    native_bool operator!=(native_box<static_object<T>> const &rhs) const
+    template <typename T>
+    requires behavior::object_like<T>
+    native_bool operator!=(native_box<T> const &rhs) const
     {
       return data != &rhs->base;
     }

--- a/compiler+runtime/include/cpp/jank/runtime/native_box/fmt.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/native_box/fmt.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <fmt/ostream.h>
+
+#include <jank/runtime/native_box.hpp>
+
+namespace fmt
+{
+  template <typename T>
+  struct formatter<jank::runtime::native_box<T>> : fmt::ostream_formatter
+  {
+  };
+}

--- a/compiler+runtime/include/cpp/jank/runtime/ns.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/ns.hpp
@@ -13,20 +13,21 @@ namespace jank::runtime
 {
   struct context;
 
-  template <>
-  struct static_object<object_type::ns> : gc
+  using ns_ptr = native_box<struct ns>;
+
+  struct ns : gc
   {
+    static constexpr object_type obj_type{ object_type::ns };
     static constexpr native_bool pointer_free{ false };
 
-    static_object() = delete;
-    static_object(obj::symbol_ptr const &name, context &c);
+    ns() = delete;
+    ns(obj::symbol_ptr const &name, context &c);
 
     var_ptr intern_var(native_persistent_string_view const &);
     var_ptr intern_var(obj::symbol_ptr const &);
     option<var_ptr> find_var(obj::symbol_ptr const &);
 
-    result<void, native_persistent_string>
-    add_alias(obj::symbol_ptr const &sym, native_box<static_object> const &ns);
+    result<void, native_persistent_string> add_alias(obj::symbol_ptr const &sym, ns_ptr const &ns);
     option<ns_ptr> find_alias(obj::symbol_ptr const &sym) const;
 
     result<void, native_persistent_string> refer(obj::symbol_ptr const sym, var_ptr const var);
@@ -40,9 +41,9 @@ namespace jank::runtime
     void to_string(fmt::memory_buffer &buff) const;
     native_hash to_hash() const;
 
-    native_bool operator==(static_object const &rhs) const;
+    native_bool operator==(ns const &rhs) const;
 
-    native_box<static_object> clone(context &rt_ctx) const;
+    ns_ptr clone(context &rt_ctx) const;
 
     object base{ object_type::ns };
     obj::symbol_ptr name{};
@@ -51,7 +52,4 @@ namespace jank::runtime
     folly::Synchronized<obj::persistent_hash_map_ptr> aliases;
     context &rt_ctx;
   };
-
-  using ns = static_object<object_type::ns>;
-  using ns_ptr = native_box<ns>;
 }

--- a/compiler+runtime/include/cpp/jank/runtime/ns.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/ns.hpp
@@ -1,17 +1,17 @@
 #pragma once
 
-#include <functional>
-#include <unordered_map>
-#include <mutex>
-
 #include <folly/Synchronized.h>
 
-#include <jank/runtime/obj/symbol.hpp>
 #include <jank/runtime/var.hpp>
 
 namespace jank::runtime
 {
   struct context;
+
+  namespace obj
+  {
+    using symbol_ptr = native_box<struct symbol>;
+  }
 
   using ns_ptr = native_box<struct ns>;
 

--- a/compiler+runtime/include/cpp/jank/runtime/ns.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/ns.hpp
@@ -38,7 +38,7 @@ namespace jank::runtime
     native_bool equal(object const &) const;
     native_persistent_string to_string() const;
     native_persistent_string to_code_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_hash to_hash() const;
 
     native_bool operator==(ns const &rhs) const;

--- a/compiler+runtime/include/cpp/jank/runtime/ns.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/ns.hpp
@@ -45,7 +45,7 @@ namespace jank::runtime
 
     ns_ptr clone(context &rt_ctx) const;
 
-    object base{ object_type::ns };
+    object base{ obj_type };
     obj::symbol_ptr name{};
     /* TODO: Benchmark the use of atomics here. That's what Clojure uses. */
     folly::Synchronized<obj::persistent_hash_map_ptr> vars;

--- a/compiler+runtime/include/cpp/jank/runtime/obj/array_chunk.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/array_chunk.hpp
@@ -30,7 +30,7 @@ namespace jank::runtime::obj
     object_ptr nth(object_ptr index) const;
     object_ptr nth(object_ptr index, object_ptr fallback) const;
 
-    object base{ object_type::array_chunk };
+    object base{ obj_type };
     native_vector<object_ptr> buffer;
     size_t offset{};
   };

--- a/compiler+runtime/include/cpp/jank/runtime/obj/array_chunk.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/array_chunk.hpp
@@ -2,17 +2,19 @@
 
 #include <jank/runtime/object.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  template <>
-  struct static_object<object_type::array_chunk> : gc
+  using array_chunk_ptr = native_box<struct array_chunk>;
+
+  struct array_chunk : gc
   {
+    static constexpr object_type obj_type{ object_type::array_chunk };
     static constexpr native_bool pointer_free{ false };
 
-    static_object() = default;
-    static_object(native_vector<object_ptr> const &buffer);
-    static_object(native_vector<object_ptr> const &buffer, size_t offset);
-    static_object(native_vector<object_ptr> &&buffer, size_t offset);
+    array_chunk() = default;
+    array_chunk(native_vector<object_ptr> const &buffer);
+    array_chunk(native_vector<object_ptr> const &buffer, size_t offset);
+    array_chunk(native_vector<object_ptr> &&buffer, size_t offset);
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -22,8 +24,8 @@ namespace jank::runtime
     native_hash to_hash() const;
 
     /* behavior::chunk_like */
-    native_box<static_object> chunk_next() const;
-    native_box<static_object> chunk_next_in_place();
+    array_chunk_ptr chunk_next() const;
+    array_chunk_ptr chunk_next_in_place();
     size_t count() const;
     object_ptr nth(object_ptr index) const;
     object_ptr nth(object_ptr index, object_ptr fallback) const;
@@ -32,10 +34,4 @@ namespace jank::runtime
     native_vector<object_ptr> buffer;
     size_t offset{};
   };
-
-  namespace obj
-  {
-    using array_chunk = static_object<object_type::array_chunk>;
-    using array_chunk_ptr = native_box<array_chunk>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/array_chunk.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/array_chunk.hpp
@@ -19,7 +19,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/atom.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/atom.hpp
@@ -3,15 +3,17 @@
 #include <jank/runtime/object.hpp>
 #include <jank/runtime/obj/persistent_vector.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  template <>
-  struct static_object<object_type::atom> : gc
+  using atom_ptr = native_box<struct atom>;
+
+  struct atom : gc
   {
+    static constexpr object_type obj_type{ object_type::atom };
     static constexpr native_bool pointer_free{ false };
 
-    static_object() = default;
-    static_object(object_ptr o);
+    atom() = default;
+    atom(object_ptr o);
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -46,10 +48,4 @@ namespace jank::runtime
     object base{ object_type::atom };
     std::atomic<object *> val{};
   };
-
-  namespace obj
-  {
-    using atom = static_object<object_type::atom>;
-    using atom_ptr = native_box<atom>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/atom.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/atom.hpp
@@ -18,7 +18,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/atom.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/atom.hpp
@@ -44,7 +44,7 @@ namespace jank::runtime::obj
 
     object_ptr compare_and_set(object_ptr old_val, object_ptr new_val);
 
-    object base{ object_type::atom };
+    object base{ obj_type };
     std::atomic<object *> val{};
   };
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/atom.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/atom.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <jank/runtime/object.hpp>
-#include <jank/runtime/obj/persistent_vector.hpp>
 
 namespace jank::runtime::obj
 {
   using atom_ptr = native_box<struct atom>;
+  using persistent_vector_ptr = native_box<struct persistent_vector>;
 
   struct atom : gc
   {
@@ -28,7 +28,7 @@ namespace jank::runtime::obj
     /* Replaces the old value with the specified value. Returns the new value. */
     object_ptr reset(object_ptr o);
     /* Same as reset, but returns a vector of the old value and the new value. */
-    obj::persistent_vector_ptr reset_vals(object_ptr o);
+    persistent_vector_ptr reset_vals(object_ptr o);
 
     /* Atomically updates the value of the atom with the specified fn. Returns the new value. */
     object_ptr swap(object_ptr fn);
@@ -37,11 +37,10 @@ namespace jank::runtime::obj
     object_ptr swap(object_ptr fn, object_ptr a1, object_ptr a2, object_ptr rest);
 
     /* Same as swap, but returns a vector of the old value and the new value. */
-    obj::persistent_vector_ptr swap_vals(object_ptr fn);
-    obj::persistent_vector_ptr swap_vals(object_ptr fn, object_ptr a1);
-    obj::persistent_vector_ptr swap_vals(object_ptr fn, object_ptr a1, object_ptr a2);
-    obj::persistent_vector_ptr
-    swap_vals(object_ptr fn, object_ptr a1, object_ptr a2, object_ptr rest);
+    persistent_vector_ptr swap_vals(object_ptr fn);
+    persistent_vector_ptr swap_vals(object_ptr fn, object_ptr a1);
+    persistent_vector_ptr swap_vals(object_ptr fn, object_ptr a1, object_ptr a2);
+    persistent_vector_ptr swap_vals(object_ptr fn, object_ptr a1, object_ptr a2, object_ptr rest);
 
     object_ptr compare_and_set(object_ptr old_val, object_ptr new_val);
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/character.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/character.hpp
@@ -20,7 +20,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/character.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/character.hpp
@@ -24,7 +24,7 @@ namespace jank::runtime::obj
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;
 
-    object base{ object_type::character };
+    object base{ obj_type };
     /* Holds the raw form of the character bytes. Supports Unicode. */
     native_persistent_string data;
   };

--- a/compiler+runtime/include/cpp/jank/runtime/obj/character.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/character.hpp
@@ -2,18 +2,20 @@
 
 #include <jank/runtime/object.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  template <>
-  struct static_object<object_type::character> : gc
+  using character_ptr = native_box<struct character>;
+
+  struct character : gc
   {
+    static constexpr object_type obj_type{ object_type::character };
     static constexpr native_bool pointer_free{ false };
 
-    static_object() = default;
-    static_object(static_object &&) = default;
-    static_object(static_object const &) = default;
-    static_object(native_persistent_string const &);
-    static_object(char);
+    character() = default;
+    character(character &&) noexcept = default;
+    character(character const &) = default;
+    character(native_persistent_string const &);
+    character(char);
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -23,14 +25,7 @@ namespace jank::runtime
     native_hash to_hash() const;
 
     object base{ object_type::character };
-
-    /* Holds the literal form of the character as it's written eg. "\\tab" */
+    /* Holds the raw form of the character bytes. Supports Unicode. */
     native_persistent_string data;
   };
-
-  namespace obj
-  {
-    using character = static_object<object_type::character>;
-    using character_ptr = native_box<character>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/chunk_buffer.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/chunk_buffer.hpp
@@ -2,22 +2,19 @@
 
 #include <jank/runtime/object.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  namespace obj
-  {
-    using array_chunk = static_object<object_type::array_chunk>;
-    using array_chunk_ptr = native_box<array_chunk>;
-  }
+  using array_chunk_ptr = native_box<struct array_chunk>;
+  using chunk_buffer_ptr = native_box<struct chunk_buffer>;
 
-  template <>
-  struct static_object<object_type::chunk_buffer> : gc
+  struct chunk_buffer : gc
   {
+    static constexpr object_type obj_type{ object_type::chunk_buffer };
     static constexpr native_bool pointer_free{ false };
 
-    static_object() = default;
-    static_object(size_t capacity);
-    static_object(object_ptr capacity);
+    chunk_buffer() = default;
+    chunk_buffer(size_t capacity);
+    chunk_buffer(object_ptr capacity);
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -36,10 +33,4 @@ namespace jank::runtime
     native_vector<object_ptr> buffer;
     size_t capacity{};
   };
-
-  namespace obj
-  {
-    using chunk_buffer = static_object<object_type::chunk_buffer>;
-    using chunk_buffer_ptr = native_box<chunk_buffer>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/chunk_buffer.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/chunk_buffer.hpp
@@ -29,7 +29,7 @@ namespace jank::runtime::obj
     void append(object_ptr o);
     obj::array_chunk_ptr chunk();
 
-    object base{ object_type::chunk_buffer };
+    object base{ obj_type };
     native_vector<object_ptr> buffer;
     size_t capacity{};
   };

--- a/compiler+runtime/include/cpp/jank/runtime/obj/chunk_buffer.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/chunk_buffer.hpp
@@ -19,7 +19,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/chunked_cons.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/chunked_cons.hpp
@@ -22,7 +22,7 @@ namespace jank::runtime::obj
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_string() const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;

--- a/compiler+runtime/include/cpp/jank/runtime/obj/chunked_cons.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/chunked_cons.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <jank/runtime/object.hpp>
-#include <jank/runtime/obj/cons.hpp>
 #include <jank/option.hpp>
 
 namespace jank::runtime::obj
 {
+  using cons_ptr = native_box<struct cons>;
   using chunked_cons_ptr = native_box<struct chunked_cons>;
 
   struct chunked_cons : gc

--- a/compiler+runtime/include/cpp/jank/runtime/obj/chunked_cons.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/chunked_cons.hpp
@@ -4,19 +4,21 @@
 #include <jank/runtime/obj/cons.hpp>
 #include <jank/option.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  template <>
-  struct static_object<object_type::chunked_cons> : gc
+  using chunked_cons_ptr = native_box<struct chunked_cons>;
+
+  struct chunked_cons : gc
   {
+    static constexpr object_type obj_type{ object_type::chunked_cons };
     static constexpr native_bool pointer_free{ false };
     static constexpr native_bool is_sequential{ true };
 
-    static_object() = default;
-    static_object(static_object &&) = default;
-    static_object(static_object const &) = default;
-    static_object(object_ptr head, object_ptr tail);
-    static_object(object_ptr meta, object_ptr head, object_ptr tail);
+    chunked_cons() = default;
+    chunked_cons(chunked_cons &&) noexcept = default;
+    chunked_cons(chunked_cons const &) = default;
+    chunked_cons(object_ptr head, object_ptr tail);
+    chunked_cons(object_ptr meta, object_ptr head, object_ptr tail);
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -26,11 +28,11 @@ namespace jank::runtime
     native_hash to_hash() const;
 
     /* behavior::metadatable */
-    native_box<static_object> with_meta(object_ptr m) const;
+    chunked_cons_ptr with_meta(object_ptr m) const;
 
     /* behavior::seqable */
-    native_box<static_object> seq() const;
-    native_box<static_object> fresh_seq() const;
+    chunked_cons_ptr seq() const;
+    chunked_cons_ptr fresh_seq() const;
 
     /* behavior::sequenceable */
     object_ptr first() const;
@@ -38,7 +40,7 @@ namespace jank::runtime
     obj::cons_ptr conj(object_ptr head) const;
 
     /* behavior::sequenceable_in_place */
-    native_box<static_object> next_in_place();
+    chunked_cons_ptr next_in_place();
 
     /* behavior::chunkable */
     object_ptr chunked_first() const;
@@ -49,10 +51,4 @@ namespace jank::runtime
     object_ptr tail{};
     option<object_ptr> meta;
   };
-
-  namespace obj
-  {
-    using chunked_cons = static_object<object_type::chunked_cons>;
-    using chunked_cons_ptr = native_box<chunked_cons>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/chunked_cons.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/chunked_cons.hpp
@@ -46,7 +46,7 @@ namespace jank::runtime::obj
     object_ptr chunked_first() const;
     object_ptr chunked_next() const;
 
-    object base{ object_type::chunked_cons };
+    object base{ obj_type };
     object_ptr head{};
     object_ptr tail{};
     option<object_ptr> meta;

--- a/compiler+runtime/include/cpp/jank/runtime/obj/cons.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/cons.hpp
@@ -21,7 +21,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/cons.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/cons.hpp
@@ -3,18 +3,20 @@
 #include <jank/runtime/object.hpp>
 #include <jank/option.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  template <>
-  struct static_object<object_type::cons> : gc
+  using cons_ptr = native_box<struct cons>;
+
+  struct cons : gc
   {
+    static constexpr object_type obj_type{ object_type::cons };
     static constexpr native_bool pointer_free{ false };
     static constexpr native_bool is_sequential{ true };
 
-    static_object() = default;
-    static_object(static_object &&) = default;
-    static_object(static_object const &) = default;
-    static_object(object_ptr const head, object_ptr const tail);
+    cons() = default;
+    cons(cons &&) noexcept = default;
+    cons(cons const &) = default;
+    cons(object_ptr const head, object_ptr const tail);
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -24,21 +26,21 @@ namespace jank::runtime
     native_hash to_hash() const;
 
     /* behavior::metadatable */
-    native_box<static_object> with_meta(object_ptr m) const;
+    cons_ptr with_meta(object_ptr m) const;
 
     /* behavior::seqable */
-    native_box<static_object> seq() const;
-    native_box<static_object> fresh_seq() const;
+    cons_ptr seq() const;
+    cons_ptr fresh_seq() const;
 
     /* behavior::sequenceable */
     object_ptr first() const;
     object_ptr next() const;
 
     /* behavior::sequenceable_in_place */
-    native_box<static_object> next_in_place();
+    cons_ptr next_in_place();
 
     /* behavior::conjable */
-    native_box<static_object> conj(object_ptr head) const;
+    cons_ptr conj(object_ptr head) const;
 
     object base{ object_type::cons };
     object_ptr head{};
@@ -46,10 +48,4 @@ namespace jank::runtime
     mutable native_hash hash{};
     option<object_ptr> meta;
   };
-
-  namespace obj
-  {
-    using cons = static_object<object_type::cons>;
-    using cons_ptr = native_box<cons>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/cons.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/cons.hpp
@@ -42,7 +42,7 @@ namespace jank::runtime::obj
     /* behavior::conjable */
     cons_ptr conj(object_ptr head) const;
 
-    object base{ object_type::cons };
+    object base{ obj_type };
     object_ptr head{};
     object_ptr tail{};
     mutable native_hash hash{};

--- a/compiler+runtime/include/cpp/jank/runtime/obj/delay.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/delay.hpp
@@ -2,15 +2,17 @@
 
 #include <jank/runtime/object.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  template <>
-  struct static_object<object_type::delay> : gc
+  using delay_ptr = native_box<struct delay>;
+
+  struct delay : gc
   {
+    static constexpr object_type obj_type{ object_type::delay };
     static constexpr native_bool pointer_free{ false };
 
-    static_object() = default;
-    static_object(object_ptr fn);
+    delay() = default;
+    delay(object_ptr fn);
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -28,10 +30,4 @@ namespace jank::runtime
     object_ptr error{};
     std::mutex mutex;
   };
-
-  namespace obj
-  {
-    using delay = static_object<object_type::delay>;
-    using delay_ptr = native_box<delay>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/delay.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/delay.hpp
@@ -17,7 +17,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/delay.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/delay.hpp
@@ -24,7 +24,7 @@ namespace jank::runtime::obj
     /* behavior::derefable */
     object_ptr deref();
 
-    object base{ object_type::delay };
+    object base{ obj_type };
     object_ptr val{};
     object_ptr fn{};
     object_ptr error{};

--- a/compiler+runtime/include/cpp/jank/runtime/obj/detail/base_persistent_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/detail/base_persistent_map.hpp
@@ -21,12 +21,12 @@ namespace jank::runtime::obj::detail
 {
   /* Array maps and hash maps share a lot of common code, so we have a common base.
    * No virtual fns are used, so this structure won't survive release optimizations. */
-  template <object_type OT, object_type ST, typename V>
+  template <typename PT, typename ST, typename V>
   struct base_persistent_map : gc
   {
+    using parent_type = PT;
+    using sequence_type = ST;
     using value_type = V;
-    using parent_type = static_object<OT>;
-    using sequence_type = static_object<ST>;
 
     static constexpr native_bool pointer_free{ false };
     static constexpr native_bool is_map_like{ true };
@@ -179,7 +179,7 @@ namespace jank::runtime::obj::detail
       return ret;
     }
 
-    object base{ OT };
+    object base{ PT::obj_type };
     option<object_ptr> meta;
     mutable native_hash hash{};
   };

--- a/compiler+runtime/include/cpp/jank/runtime/obj/detail/base_persistent_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/detail/base_persistent_map.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
 #include <jank/runtime/object.hpp>
-#include <jank/runtime/behavior/associatively_readable.hpp>
-#include <jank/runtime/behavior/map_like.hpp>
+#include <jank/option.hpp>
 
 namespace jank::runtime
 {
@@ -24,160 +23,34 @@ namespace jank::runtime::obj::detail
   template <typename PT, typename ST, typename V>
   struct base_persistent_map : gc
   {
-    using parent_type = PT;
-    using sequence_type = ST;
-    using value_type = V;
-
     static constexpr native_bool pointer_free{ false };
     static constexpr native_bool is_map_like{ true };
+
+    using value_type = V;
 
     base_persistent_map() = default;
 
     /* behavior::object_like */
-    native_bool equal(object const &o) const
-    {
-      if(&o == &base)
-      {
-        return true;
-      }
-
-      return visit_map_like(
-        [&](auto const typed_o) -> native_bool {
-          if(typed_o->count() != count())
-          {
-            return false;
-          }
-
-          for(auto const &entry : static_cast<parent_type const *>(this)->data)
-          {
-            auto const found(typed_o->contains(entry.first));
-
-            if(!found || !runtime::equal(entry.second, typed_o->get(entry.first)))
-            {
-              return false;
-            }
-          }
-
-          return true;
-        },
-        []() { return false; },
-        &o);
-    }
-
+    native_bool equal(object const &o) const;
     static void to_string_impl(typename V::const_iterator const &begin,
                                typename V::const_iterator const &end,
                                fmt::memory_buffer &buff,
-                               native_bool const to_code)
-    {
-      auto inserter(std::back_inserter(buff));
-      inserter = '{';
-      for(auto i(begin); i != end; ++i)
-      {
-        auto const pair(*i);
-        if(to_code)
-        {
-          runtime::to_code_string(pair.first, buff);
-        }
-        else
-        {
-          runtime::to_string(pair.first, buff);
-        }
-        inserter = ' ';
+                               native_bool const to_code);
+    void to_string(fmt::memory_buffer &buff) const;
 
-        if(to_code)
-        {
-          runtime::to_code_string(pair.second, buff);
-        }
-        else
-        {
-          runtime::to_string(pair.second, buff);
-        }
-        auto n(i);
-        if(++n != end)
-        {
-          inserter = ',';
-          inserter = ' ';
-        }
-      }
-      inserter = '}';
-    }
-
-    void to_string(fmt::memory_buffer &buff) const
-    {
-      to_string_impl(static_cast<parent_type const *>(this)->data.begin(),
-                     static_cast<parent_type const *>(this)->data.end(),
-                     buff,
-                     false);
-    }
-
-    native_persistent_string to_string() const
-    {
-      fmt::memory_buffer buff;
-      to_string_impl(static_cast<parent_type const *>(this)->data.begin(),
-                     static_cast<parent_type const *>(this)->data.end(),
-                     buff,
-                     false);
-      return native_persistent_string{ buff.data(), buff.size() };
-    }
-
-    native_persistent_string to_code_string() const
-    {
-      fmt::memory_buffer buff;
-      to_string_impl(static_cast<parent_type const *>(this)->data.begin(),
-                     static_cast<parent_type const *>(this)->data.end(),
-                     buff,
-                     true);
-      return native_persistent_string{ buff.data(), buff.size() };
-    }
-
-    native_hash to_hash() const
-    {
-      if(hash)
-      {
-        return hash;
-      }
-
-      return hash = hash::unordered(static_cast<parent_type const *>(this)->data.begin(),
-                                    static_cast<parent_type const *>(this)->data.end());
-    }
+    native_persistent_string to_string() const;
+    native_persistent_string to_code_string() const;
+    native_hash to_hash() const;
 
     /* behavior::seqable */
-    native_box<sequence_type> seq() const
-    {
-      if(static_cast<parent_type const *>(this)->data.empty())
-      {
-        return nullptr;
-      }
-      return make_box<sequence_type>(static_cast<parent_type const *>(this),
-                                     static_cast<parent_type const *>(this)->data.begin(),
-                                     static_cast<parent_type const *>(this)->data.end());
-    }
-
-    native_box<sequence_type> fresh_seq() const
-    {
-      if(static_cast<parent_type const *>(this)->data.empty())
-      {
-        return nullptr;
-      }
-      return make_box<sequence_type>(static_cast<parent_type const *>(this),
-                                     static_cast<parent_type const *>(this)->data.begin(),
-                                     static_cast<parent_type const *>(this)->data.end());
-    }
+    native_box<ST> seq() const;
+    native_box<ST> fresh_seq() const;
 
     /* behavior::countable */
-    size_t count() const
-    {
-      return static_cast<parent_type const *>(this)->data.size();
-    }
+    size_t count() const;
 
     /* behavior::metadatable */
-    native_box<parent_type> with_meta(object_ptr const m) const
-    {
-      auto const meta(behavior::detail::validate_meta(m));
-      auto ret(make_box<parent_type>(static_cast<parent_type const *>(this)->data));
-      ret->meta = meta;
-      return ret;
-    }
+    native_box<PT> with_meta(object_ptr const m) const;
 
     object base{ PT::obj_type };
     option<object_ptr> meta;

--- a/compiler+runtime/include/cpp/jank/runtime/obj/detail/base_persistent_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/detail/base_persistent_map.hpp
@@ -7,8 +7,8 @@ namespace jank::runtime
 {
   native_bool is_map(object_ptr o);
   native_bool equal(object_ptr l, object_ptr r);
-  void to_string(object_ptr o, fmt::memory_buffer &buff);
-  void to_code_string(object_ptr o, fmt::memory_buffer &buff);
+  void to_string(object_ptr o, util::string_builder &buff);
+  void to_code_string(object_ptr o, util::string_builder &buff);
 
   namespace behavior::detail
   {
@@ -34,9 +34,9 @@ namespace jank::runtime::obj::detail
     native_bool equal(object const &o) const;
     static void to_string_impl(typename V::const_iterator const &begin,
                                typename V::const_iterator const &end,
-                               fmt::memory_buffer &buff,
+                               util::string_builder &buff,
                                native_bool const to_code);
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
 
     native_persistent_string to_string() const;
     native_persistent_string to_code_string() const;

--- a/compiler+runtime/include/cpp/jank/runtime/obj/detail/base_persistent_map_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/detail/base_persistent_map_sequence.hpp
@@ -5,8 +5,8 @@
 
 namespace jank::runtime
 {
-  void to_string(object_ptr o, fmt::memory_buffer &buff);
-  void to_code_string(object_ptr o, fmt::memory_buffer &buff);
+  void to_string(object_ptr o, util::string_builder &buff);
+  void to_code_string(object_ptr o, util::string_builder &buff);
 
   namespace obj
   {
@@ -29,8 +29,8 @@ namespace jank::runtime::obj::detail
 
     /* behavior::object_like */
     native_bool equal(object const &o) const;
-    void to_string_impl(fmt::memory_buffer &buff, native_bool const to_code) const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string_impl(util::string_builder &buff, native_bool const to_code) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_string() const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;

--- a/compiler+runtime/include/cpp/jank/runtime/obj/detail/base_persistent_map_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/detail/base_persistent_map_sequence.hpp
@@ -7,6 +7,11 @@ namespace jank::runtime
 {
   void to_string(object_ptr o, fmt::memory_buffer &buff);
   void to_code_string(object_ptr o, fmt::memory_buffer &buff);
+
+  namespace obj
+  {
+    using cons_ptr = native_box<struct cons>;
+  }
 }
 
 namespace jank::runtime::obj::detail

--- a/compiler+runtime/include/cpp/jank/runtime/obj/detail/base_persistent_map_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/detail/base_persistent_map_sequence.hpp
@@ -11,13 +11,13 @@ namespace jank::runtime
 
 namespace jank::runtime::obj::detail
 {
-  template <object_type OT, typename It>
+  template <typename PT, typename It>
   struct base_persistent_map_sequence : gc
   {
     static constexpr native_bool pointer_free{ false };
     static constexpr native_bool is_sequential{ true };
 
-    using parent_type = static_object<OT>;
+    using parent_type = PT;
     using iterator_type = It;
 
     base_persistent_map_sequence() = default;
@@ -166,7 +166,7 @@ namespace jank::runtime::obj::detail
       return make_box<obj::cons>(head, static_cast<parent_type *>(this));
     }
 
-    object base{ OT };
+    object base{ PT::obj_type };
     object_ptr coll{};
     iterator_type begin{}, end{};
   };

--- a/compiler+runtime/include/cpp/jank/runtime/obj/detail/base_persistent_map_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/detail/base_persistent_map_sequence.hpp
@@ -16,163 +16,44 @@ namespace jank::runtime
 
 namespace jank::runtime::obj::detail
 {
-  template <typename PT, typename It>
+  template <typename PT, typename IT>
   struct base_persistent_map_sequence : gc
   {
     static constexpr native_bool pointer_free{ false };
     static constexpr native_bool is_sequential{ true };
 
-    using parent_type = PT;
-    using iterator_type = It;
-
     base_persistent_map_sequence() = default;
     base_persistent_map_sequence(base_persistent_map_sequence &&) = default;
     base_persistent_map_sequence(base_persistent_map_sequence const &) = default;
-
-    base_persistent_map_sequence(object_ptr c, iterator_type const &b, iterator_type const &e)
-      : coll{ c }
-      , begin{ b }
-      , end{ e }
-    {
-      assert(begin != end);
-    }
+    base_persistent_map_sequence(object_ptr const c, IT const &b, IT const &e);
 
     /* behavior::object_like */
-    native_bool equal(object const &o) const
-    {
-      return visit_seqable(
-        [this](auto const typed_o) {
-          auto seq(typed_o->fresh_seq());
-          for(auto it(fresh_seq()); it != nullptr;
-              it = it->next_in_place(), seq = seq->next_in_place())
-          {
-            if(seq == nullptr || !runtime::equal(it, seq->first()))
-            {
-              return false;
-            }
-          }
-          return true;
-        },
-        []() { return false; },
-        &o);
-    }
-
-    void to_string_impl(fmt::memory_buffer &buff, native_bool const to_code) const
-    {
-      auto inserter(std::back_inserter(buff));
-      fmt::format_to(inserter, "(");
-      for(auto i(begin); i != end; ++i)
-      {
-        fmt::format_to(inserter, "[");
-        if(to_code)
-        {
-          runtime::to_code_string((*i).first, buff);
-        }
-        else
-        {
-          runtime::to_string((*i).first, buff);
-        }
-        fmt::format_to(inserter, " ");
-        if(to_code)
-        {
-          runtime::to_code_string((*i).second, buff);
-        }
-        else
-        {
-          runtime::to_string((*i).second, buff);
-        }
-        fmt::format_to(inserter, "]");
-        auto n(i);
-        if(++n != end)
-        {
-          fmt::format_to(inserter, " ");
-        }
-      }
-      fmt::format_to(inserter, ")");
-    }
-
-    void to_string(fmt::memory_buffer &buff) const
-    {
-      return to_string_impl(buff, false);
-    }
-
-    native_persistent_string to_string() const
-    {
-      fmt::memory_buffer buff;
-      to_string_impl(buff, false);
-      return native_persistent_string{ buff.data(), buff.size() };
-    }
-
-    native_persistent_string to_code_string() const
-    {
-      fmt::memory_buffer buff;
-      to_string_impl(buff, true);
-      return native_persistent_string{ buff.data(), buff.size() };
-    }
-
-    native_hash to_hash() const
-    {
-      return hash::unordered(&static_cast<parent_type const *>(this)->base);
-    }
+    native_bool equal(object const &o) const;
+    void to_string_impl(fmt::memory_buffer &buff, native_bool const to_code) const;
+    void to_string(fmt::memory_buffer &buff) const;
+    native_persistent_string to_string() const;
+    native_persistent_string to_code_string() const;
+    native_hash to_hash() const;
 
     /* behavior::countable */
-    size_t count() const
-    {
-      return std::distance(begin, end);
-    }
+    size_t count() const;
 
     /* behavior::seqable */
-    native_box<parent_type> seq()
-    {
-      return static_cast<parent_type *>(this);
-    }
-
-    native_box<parent_type> fresh_seq() const
-    {
-      return make_box<parent_type>(coll, begin, end);
-    }
+    native_box<PT> seq();
+    native_box<PT> fresh_seq() const;
 
     /* behavior::sequenceable */
-    obj::persistent_vector_ptr first() const
-    {
-      auto const pair(*begin);
-      return make_box<obj::persistent_vector>(
-        runtime::detail::native_persistent_vector{ pair.first, pair.second });
-    }
-
-    native_box<parent_type> next() const
-    {
-      auto n(begin);
-      ++n;
-
-      if(n == end)
-      {
-        return nullptr;
-      }
-
-      return make_box<parent_type>(coll, n, end);
-    }
+    obj::persistent_vector_ptr first() const;
+    native_box<PT> next() const;
 
     /* behavior::sequenceable_in_place */
-    native_box<parent_type> next_in_place()
-    {
-      ++begin;
+    native_box<PT> next_in_place();
 
-      if(begin == end)
-      {
-        return nullptr;
-      }
-
-      return static_cast<parent_type *>(this);
-    }
-
-    obj::cons_ptr conj(object_ptr const head)
-    {
-      return make_box<obj::cons>(head, static_cast<parent_type *>(this));
-    }
+    /* behavior::conjable */
+    obj::cons_ptr conj(object_ptr const head);
 
     object base{ PT::obj_type };
     object_ptr coll{};
-    iterator_type begin{}, end{};
+    IT begin{}, end{};
   };
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/detail/iterator_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/detail/iterator_sequence.hpp
@@ -1,13 +1,10 @@
 #pragma once
 
 #include <jank/runtime/object.hpp>
-#include <jank/runtime/obj/cons.hpp>
-#include <jank/runtime/core/seq.hpp>
-#include <jank/runtime/core/to_string.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  native_bool equal(object_ptr l, object_ptr r);
+  using cons_ptr = native_box<struct cons>;
 }
 
 namespace jank::runtime::obj::detail
@@ -19,114 +16,32 @@ namespace jank::runtime::obj::detail
     iterator_sequence() = default;
 
     /* NOLINTNEXTLINE(bugprone-crtp-constructor-accessibility) */
-    iterator_sequence(object_ptr const &c, It const &b, It const &e, size_t const s)
-      : coll{ c }
-      , begin{ b }
-      , end{ e }
-      , size{ s }
-    {
-      if(begin == end)
-      {
-        throw std::runtime_error{ "iterator_sequence for empty sequence" };
-      }
-    }
+    iterator_sequence(object_ptr const &c, It const &b, It const &e, size_t const s);
 
     /* behavior::object_like */
-    native_bool equal(object const &o) const
-    {
-      return visit_seqable(
-        [this](auto const typed_o) {
-          auto seq(typed_o->fresh_seq());
-          for(auto it(begin); it != end; ++it, seq = seq->next_in_place())
-          {
-            if(seq == nullptr || !runtime::equal(*it, seq->first()))
-            {
-              return false;
-            }
-          }
-          return true;
-        },
-        []() { return false; },
-        &o);
-    }
-
-    void to_string(fmt::memory_buffer &buff) const
-    {
-      runtime::to_string(begin, end, "(", ')', buff);
-    }
-
-    native_persistent_string to_string() const
-    {
-      fmt::memory_buffer buff;
-      runtime::to_string(begin, end, "(", ')', buff);
-      return native_persistent_string{ buff.data(), buff.size() };
-    }
-
-    native_persistent_string to_code_string() const
-    {
-      fmt::memory_buffer buff;
-      runtime::to_code_string(begin, end, "(", ')', buff);
-      return native_persistent_string{ buff.data(), buff.size() };
-    }
-
-    native_hash to_hash() const
-    {
-      return hash::ordered(begin, end);
-    }
+    native_bool equal(object const &o) const;
+    void to_string(fmt::memory_buffer &buff) const;
+    native_persistent_string to_string() const;
+    native_persistent_string to_code_string() const;
+    native_hash to_hash() const;
 
     /* behavior::seqable */
-    native_box<Derived> seq()
-    {
-      return static_cast<Derived *>(this);
-    }
-
-    native_box<Derived> fresh_seq() const
-    {
-      return make_box<Derived>(coll, begin, end, size);
-    }
+    native_box<Derived> seq();
+    native_box<Derived> fresh_seq() const;
 
     /* behavior::countable */
-    size_t count() const
-    {
-      return size;
-    }
+    size_t count() const;
 
     /* behavior::sequenceable */
-    object_ptr first() const
-    {
-      return *begin;
-    }
+    object_ptr first() const;
 
-    native_box<Derived> next() const
-    {
-      auto n(begin);
-      ++n;
-
-      if(n == end)
-      {
-        return nullptr;
-      }
-
-      return make_box<Derived>(coll, n, end, size);
-    }
+    native_box<Derived> next() const;
 
     /* behavior::sequenceable_in_place */
-    native_box<Derived> next_in_place()
-    {
-      ++begin;
+    native_box<Derived> next_in_place();
 
-      if(begin == end)
-      {
-        return nullptr;
-      }
-
-      return static_cast<Derived *>(this);
-    }
-
-    obj::cons_ptr conj(object_ptr const head)
-    {
-      return make_box<obj::cons>(head, static_cast<Derived *>(this));
-    }
+    /* behavior::conjable */
+    obj::cons_ptr conj(object_ptr const head);
 
     object_ptr coll{};
     /* Not default constructible. */

--- a/compiler+runtime/include/cpp/jank/runtime/obj/detail/iterator_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/detail/iterator_sequence.hpp
@@ -20,7 +20,7 @@ namespace jank::runtime::obj::detail
 
     /* behavior::object_like */
     native_bool equal(object const &o) const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_string() const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;

--- a/compiler+runtime/include/cpp/jank/runtime/obj/integer_range.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/integer_range.hpp
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <jank/runtime/object.hpp>
+#include <jank/option.hpp>
+
+namespace jank::runtime::obj
+{
+  using integer_ptr = native_box<struct integer>;
+  using cons_ptr = native_box<struct cons>;
+  using integer_range_ptr = native_box<struct integer_range>;
+
+  /* An integer range from X to Y, exclusive, incrementing by S. */
+  /* For non-integer values, use the range object */
+  struct integer_range
+  {
+    static constexpr object_type obj_type{ object_type::integer_range };
+    static constexpr native_bool pointer_free{ false };
+    static constexpr native_bool is_sequential{ true };
+
+    using bounds_check_t = native_bool (*)(integer_ptr, integer_ptr);
+
+    integer_range() = default;
+    integer_range(integer_range &&) noexcept = default;
+    integer_range(integer_range const &) = default;
+    integer_range(integer_ptr end);
+    integer_range(integer_ptr start, obj::integer_ptr end);
+    integer_range(integer_ptr start, obj::integer_ptr end, obj::integer_ptr step);
+    integer_range(integer_ptr start,
+                  integer_ptr end,
+                  integer_ptr step,
+                  bounds_check_t bounds_check);
+    //integer_range(integer_ptr start,
+    //              integer_ptr end,
+    //              integer_ptr step,
+    //              bounds_check_t bounds_check,
+    //              array_chunk_ptr chunk,
+    //              integer_range_ptr chunk_next);
+
+    static object_ptr create(integer_ptr end);
+    static object_ptr create(integer_ptr start, obj::integer_ptr end);
+    static object_ptr create(integer_ptr start, obj::integer_ptr end, obj::integer_ptr step);
+
+    /* behavior::object_like */
+    native_bool equal(object const &) const;
+    native_persistent_string to_string() const;
+    void to_string(util::string_builder &buff) const;
+    native_persistent_string to_code_string() const;
+    native_hash to_hash() const;
+
+    /* behavior::seqable */
+    integer_range_ptr seq() const;
+    integer_range_ptr fresh_seq() const;
+
+    /* behavior::sequenceable */
+    integer_ptr first() const;
+    integer_range_ptr next() const;
+
+    /* behavior::sequenceable_in_place */
+    integer_range_ptr next_in_place();
+
+    /* TODO: behavior::chunkable */
+    /* array_chunk_ptr chunked_first() const; */
+    /* integer_range_ptr chunked_next() const; */
+    /* void force_chunk() const; */
+
+    /* behavior::conjable */
+    cons_ptr conj(object_ptr head) const;
+
+    /* behavior::metadatable */
+    integer_range_ptr with_meta(object_ptr m) const;
+
+    /* behavior::countable */
+    size_t count() const;
+
+    object base{ object_type::integer_range };
+    integer_ptr start{};
+    integer_ptr end{};
+    integer_ptr step{};
+    bounds_check_t bounds_check{};
+
+    /* TODO: behavior::chunkable */
+    /* mutable array_chunk_ptr chunk{}; */
+    /* mutable integer_range_ptr chunk_next{}; */
+    /* mutable integer_range_ptr cached_next{}; */
+    option<object_ptr> meta{};
+  };
+}

--- a/compiler+runtime/include/cpp/jank/runtime/obj/iterator.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/iterator.hpp
@@ -39,7 +39,7 @@ namespace jank::runtime::obj
     /* behavior::sequenceable_in_place */
     iterator_ptr next_in_place();
 
-    object base{ object_type::iterator };
+    object base{ obj_type };
     /* TODO: Support chunking. */
     object_ptr fn{};
     object_ptr current{};

--- a/compiler+runtime/include/cpp/jank/runtime/obj/iterator.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/iterator.hpp
@@ -23,7 +23,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string();
-    void to_string(fmt::memory_buffer &buff);
+    void to_string(util::string_builder &buff);
     native_persistent_string to_code_string();
     native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/iterator.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/iterator.hpp
@@ -3,25 +3,22 @@
 #include <jank/runtime/object.hpp>
 #include <jank/runtime/behavior/seqable.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  namespace obj
-  {
-    using cons = static_object<object_type::cons>;
-    using cons_ptr = native_box<cons>;
-  }
+  using cons_ptr = native_box<struct cons>;
+  using iterator_ptr = native_box<struct iterator>;
 
   /* TODO: Rename to iterator_sequence. */
-  template <>
-  struct static_object<object_type::iterator> : gc
+  struct iterator : gc
   {
+    static constexpr object_type obj_type{ object_type::iterator };
     static constexpr native_bool pointer_free{ false };
     static constexpr native_bool is_sequential{ true };
 
-    static_object() = default;
-    static_object(static_object &&) = default;
-    static_object(static_object const &) = default;
-    static_object(object_ptr const fn, object_ptr const start);
+    iterator() = default;
+    iterator(iterator &&) noexcept = default;
+    iterator(iterator const &) = default;
+    iterator(object_ptr const fn, object_ptr const start);
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -31,28 +28,22 @@ namespace jank::runtime
     native_hash to_hash() const;
 
     /* behavior::seqable */
-    native_box<static_object> seq();
-    native_box<static_object> fresh_seq() const;
+    iterator_ptr seq();
+    iterator_ptr fresh_seq() const;
 
     /* behavior::sequenceable */
     object_ptr first() const;
-    native_box<static_object> next() const;
+    iterator_ptr next() const;
     obj::cons_ptr conj(object_ptr head) const;
 
     /* behavior::sequenceable_in_place */
-    native_box<static_object> next_in_place();
+    iterator_ptr next_in_place();
 
     object base{ object_type::iterator };
     /* TODO: Support chunking. */
     object_ptr fn{};
     object_ptr current{};
     object_ptr previous{};
-    mutable native_box<static_object> cached_next{};
+    mutable iterator_ptr cached_next{};
   };
-
-  namespace obj
-  {
-    using iterator = static_object<object_type::iterator>;
-    using iterator_ptr = native_box<iterator>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/jit_closure.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/jit_closure.hpp
@@ -73,7 +73,7 @@ namespace jank::runtime::obj
 
     object_ptr this_object_ptr() final;
 
-    object base{ object_type::jit_closure };
+    object base{ obj_type };
     void *context{};
     object *(*arity_0)(void *){};
     object *(*arity_1)(void *, object *){};

--- a/compiler+runtime/include/cpp/jank/runtime/obj/jit_closure.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/jit_closure.hpp
@@ -3,20 +3,22 @@
 #include <jank/runtime/object.hpp>
 #include <jank/runtime/behavior/callable.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  template <>
-  struct static_object<object_type::jit_closure>
+  using jit_closure_ptr = native_box<struct jit_closure>;
+
+  struct jit_closure
     : gc
     , behavior::callable
   {
+    static constexpr object_type obj_type{ object_type::jit_closure };
     static constexpr native_bool pointer_free{ false };
 
-    static_object() = default;
-    static_object(static_object &&) = default;
-    static_object(static_object const &) = default;
-    static_object(arity_flag_t arity_flags, void *context);
-    static_object(object_ptr meta);
+    jit_closure() = default;
+    jit_closure(jit_closure &&) noexcept = default;
+    jit_closure(jit_closure const &) = default;
+    jit_closure(arity_flag_t arity_flags, void *context);
+    jit_closure(object_ptr meta);
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -26,7 +28,7 @@ namespace jank::runtime
     native_hash to_hash() const;
 
     /* behavior::metadatable */
-    native_box<static_object> with_meta(object_ptr m);
+    jit_closure_ptr with_meta(object_ptr m);
 
     /* behavior::callable */
     object_ptr call() final;
@@ -115,10 +117,4 @@ namespace jank::runtime
     option<object_ptr> meta;
     arity_flag_t arity_flags{};
   };
-
-  namespace obj
-  {
-    using jit_closure = static_object<object_type::jit_closure>;
-    using jit_closure_ptr = native_box<jit_closure>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/jit_closure.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/jit_closure.hpp
@@ -23,7 +23,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string();
-    void to_string(fmt::memory_buffer &buff);
+    void to_string(util::string_builder &buff);
     native_persistent_string to_code_string();
     native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/jit_function.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/jit_function.hpp
@@ -72,7 +72,7 @@ namespace jank::runtime::obj
     arity_flag_t get_arity_flags() const final;
     object_ptr this_object_ptr() final;
 
-    object base{ object_type::jit_function };
+    object base{ obj_type };
     object *(*arity_0)(){};
     object *(*arity_1)(object *){};
     object *(*arity_2)(object *, object *){};

--- a/compiler+runtime/include/cpp/jank/runtime/obj/jit_function.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/jit_function.hpp
@@ -3,20 +3,22 @@
 #include <jank/runtime/object.hpp>
 #include <jank/runtime/behavior/callable.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  template <>
-  struct static_object<object_type::jit_function>
+  using jit_function_ptr = native_box<struct jit_function>;
+
+  struct jit_function
     : gc
     , behavior::callable
   {
+    static constexpr object_type obj_type{ object_type::jit_function };
     static constexpr native_bool pointer_free{ false };
 
-    static_object() = default;
-    static_object(static_object &&) = default;
-    static_object(static_object const &) = default;
-    static_object(arity_flag_t arity_flags);
-    static_object(object_ptr meta);
+    jit_function() = default;
+    jit_function(jit_function &&) noexcept = default;
+    jit_function(jit_function const &) = default;
+    jit_function(arity_flag_t arity_flags);
+    jit_function(object_ptr meta);
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -26,7 +28,7 @@ namespace jank::runtime
     native_hash to_hash() const;
 
     /* behavior::metadatable */
-    native_box<static_object> with_meta(object_ptr m);
+    jit_function_ptr with_meta(object_ptr m);
 
     /* behavior::callable */
     object_ptr call() final;
@@ -103,10 +105,4 @@ namespace jank::runtime
     option<object_ptr> meta;
     arity_flag_t arity_flags{};
   };
-
-  namespace obj
-  {
-    using jit_function = static_object<object_type::jit_function>;
-    using jit_function_ptr = native_box<jit_function>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/jit_function.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/jit_function.hpp
@@ -23,7 +23,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string();
-    void to_string(fmt::memory_buffer &buff);
+    void to_string(util::string_builder &buff);
     native_persistent_string to_code_string();
     native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/keyword.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/keyword.hpp
@@ -48,7 +48,7 @@ namespace jank::runtime::obj
 
     native_bool operator==(keyword const &rhs) const;
 
-    object base{ object_type::keyword };
+    object base{ obj_type };
     symbol_ptr sym;
   };
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/keyword.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/keyword.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
 #include <jank/runtime/object.hpp>
-#include <jank/runtime/obj/symbol.hpp>
 #include <jank/runtime/detail/type.hpp>
 
 namespace jank::runtime::obj
 {
   using persistent_array_map_ptr = native_box<struct persistent_array_map>;
+  using symbol_ptr = native_box<struct symbol>;
   using keyword_ptr = native_box<struct keyword>;
 
   /* The correct way to create a keyword for normal use is through interning via the RT context. */
@@ -49,8 +49,7 @@ namespace jank::runtime::obj
     native_bool operator==(keyword const &rhs) const;
 
     object base{ object_type::keyword };
-    /* TODO: Box this. */
-    obj::symbol sym;
+    symbol_ptr sym;
   };
 }
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/keyword.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/keyword.hpp
@@ -4,29 +4,26 @@
 #include <jank/runtime/obj/symbol.hpp>
 #include <jank/runtime/detail/type.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  namespace obj
-  {
-    using persistent_array_map = static_object<object_type::persistent_array_map>;
-    using persistent_array_map_ptr = native_box<persistent_array_map>;
-  }
+  using persistent_array_map_ptr = native_box<struct persistent_array_map>;
+  using keyword_ptr = native_box<struct keyword>;
 
   /* The correct way to create a keyword for normal use is through interning via the RT context. */
-  template <>
-  struct static_object<object_type::keyword> : gc
+  struct keyword : gc
   {
+    static constexpr object_type obj_type{ object_type::keyword };
     static constexpr native_bool pointer_free{ false };
     /* Clojure uses this. No idea. https://github.com/clojure/clojure/blob/master/src/jvm/clojure/lang/Keyword.java */
     static constexpr size_t hash_magic{ 0x9e3779b9 };
 
-    static_object() = default;
-    static_object(static_object &&) = default;
-    static_object(static_object const &) = default;
-    static_object(detail::must_be_interned, native_persistent_string_view const &s);
-    static_object(detail::must_be_interned,
-                  native_persistent_string_view const &ns,
-                  native_persistent_string_view const &n);
+    keyword() = default;
+    keyword(keyword &&) noexcept = default;
+    keyword(keyword const &) = default;
+    keyword(runtime::detail::must_be_interned, native_persistent_string_view const &s);
+    keyword(runtime::detail::must_be_interned,
+            native_persistent_string_view const &ns,
+            native_persistent_string_view const &n);
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -39,7 +36,7 @@ namespace jank::runtime
     native_integer compare(object const &) const;
 
     /* behavior::comparable extended */
-    native_integer compare(static_object const &) const;
+    native_integer compare(keyword const &) const;
 
     /* behavior::nameable */
     native_persistent_string const &get_name() const;
@@ -49,18 +46,12 @@ namespace jank::runtime
     object_ptr call(object_ptr);
     object_ptr call(object_ptr, object_ptr);
 
-    native_bool operator==(static_object const &rhs) const;
+    native_bool operator==(keyword const &rhs) const;
 
     object base{ object_type::keyword };
     /* TODO: Box this. */
     obj::symbol sym;
   };
-
-  namespace obj
-  {
-    using keyword = static_object<object_type::keyword>;
-    using keyword_ptr = native_box<keyword>;
-  }
 }
 
 namespace std

--- a/compiler+runtime/include/cpp/jank/runtime/obj/keyword.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/keyword.hpp
@@ -28,7 +28,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/lazy_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/lazy_sequence.hpp
@@ -25,7 +25,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/lazy_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/lazy_sequence.hpp
@@ -4,26 +4,23 @@
 #include <jank/runtime/behavior/seqable.hpp>
 #include <jank/option.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  namespace obj
-  {
-    using cons = static_object<object_type::cons>;
-    using cons_ptr = native_box<cons>;
-  }
+  using cons_ptr = native_box<struct cons>;
+  using lazy_sequence_ptr = native_box<struct lazy_sequence>;
 
   /* TODO: IPending analog, to implement `realized?`. */
-  template <>
-  struct static_object<object_type::lazy_sequence> : gc
+  struct lazy_sequence : gc
   {
+    static constexpr object_type obj_type{ object_type::lazy_sequence };
     static constexpr native_bool pointer_free{ false };
     static constexpr native_bool is_sequential{ true };
 
-    static_object() = default;
-    static_object(static_object &&) = default;
-    static_object(static_object const &) = default;
-    static_object(object_ptr fn);
-    static_object(object_ptr fn, object_ptr sequence);
+    lazy_sequence() = default;
+    lazy_sequence(lazy_sequence &&) noexcept = default;
+    lazy_sequence(lazy_sequence const &) = default;
+    lazy_sequence(object_ptr fn);
+    lazy_sequence(object_ptr fn, object_ptr sequence);
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -33,19 +30,19 @@ namespace jank::runtime
     native_hash to_hash() const;
 
     /* behavior::seqable */
-    native_box<static_object> seq() const;
-    native_box<static_object> fresh_seq() const;
+    lazy_sequence_ptr seq() const;
+    lazy_sequence_ptr fresh_seq() const;
 
     /* behavior::sequenceable */
     object_ptr first() const;
-    native_box<static_object> next() const;
+    lazy_sequence_ptr next() const;
     obj::cons_ptr conj(object_ptr head) const;
 
     /* behavior::sequenceable_in_place */
-    native_box<static_object> next_in_place();
+    lazy_sequence_ptr next_in_place();
 
     /* behavior::metadatable */
-    native_box<static_object> with_meta(object_ptr m) const;
+    lazy_sequence_ptr with_meta(object_ptr m) const;
 
   private:
     object_ptr resolve_fn() const;
@@ -59,10 +56,4 @@ namespace jank::runtime
     mutable object_ptr sequence{};
     option<object_ptr> meta;
   };
-
-  namespace obj
-  {
-    using lazy_sequence = static_object<object_type::lazy_sequence>;
-    using lazy_sequence_ptr = native_box<lazy_sequence>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/lazy_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/lazy_sequence.hpp
@@ -50,7 +50,7 @@ namespace jank::runtime::obj
 
   public:
     /* TODO: Synchronize. */
-    object base{ object_type::lazy_sequence };
+    object base{ obj_type };
     mutable object_ptr fn{};
     mutable object_ptr fn_result{};
     mutable object_ptr sequence{};

--- a/compiler+runtime/include/cpp/jank/runtime/obj/multi_function.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/multi_function.hpp
@@ -7,17 +7,19 @@
 #include <jank/runtime/obj/persistent_hash_map.hpp>
 #include <jank/runtime/behavior/callable.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  template <>
-  struct static_object<object_type::multi_function>
+  using multi_function_ptr = native_box<struct multi_function>;
+
+  struct multi_function
     : gc
     , behavior::callable
   {
+    static constexpr object_type obj_type{ object_type::multi_function };
     static constexpr native_bool pointer_free{ false };
 
-    static_object() = default;
-    static_object(object_ptr name, object_ptr dispatch, object_ptr default_, object_ptr hierarchy);
+    multi_function() = default;
+    multi_function(object_ptr name, object_ptr dispatch, object_ptr default_, object_ptr hierarchy);
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -67,11 +69,11 @@ namespace jank::runtime
                     object_ptr) override;
     object_ptr this_object_ptr() final;
 
-    native_box<static_object> reset();
+    multi_function_ptr reset();
     obj::persistent_hash_map_ptr reset_cache();
-    native_box<static_object> add_method(object_ptr dispatch_val, object_ptr method);
-    native_box<static_object> remove_method(object_ptr dispatch_val);
-    native_box<static_object> prefer_method(object_ptr x, object_ptr y);
+    multi_function_ptr add_method(object_ptr dispatch_val, object_ptr method);
+    multi_function_ptr remove_method(object_ptr dispatch_val);
+    multi_function_ptr prefer_method(object_ptr x, object_ptr y);
     native_bool is_preferred(object_ptr hierarchy, object_ptr x, object_ptr y) const;
 
     static native_bool is_a(object_ptr hierarchy, object_ptr x, object_ptr y);
@@ -92,10 +94,4 @@ namespace jank::runtime
     obj::symbol_ptr name{};
     std::recursive_mutex data_lock;
   };
-
-  namespace obj
-  {
-    using multi_function = static_object<object_type::multi_function>;
-    using multi_function_ptr = native_box<multi_function>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/multi_function.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/multi_function.hpp
@@ -3,12 +3,12 @@
 #include <mutex>
 
 #include <jank/runtime/object.hpp>
-#include <jank/runtime/obj/symbol.hpp>
-#include <jank/runtime/obj/persistent_hash_map.hpp>
 #include <jank/runtime/behavior/callable.hpp>
 
 namespace jank::runtime::obj
 {
+  using symbol_ptr = native_box<struct symbol>;
+  using persistent_hash_map_ptr = native_box<struct persistent_hash_map>;
   using multi_function_ptr = native_box<struct multi_function>;
 
   struct multi_function
@@ -70,7 +70,7 @@ namespace jank::runtime::obj
     object_ptr this_object_ptr() final;
 
     multi_function_ptr reset();
-    obj::persistent_hash_map_ptr reset_cache();
+    persistent_hash_map_ptr reset_cache();
     multi_function_ptr add_method(object_ptr dispatch_val, object_ptr method);
     multi_function_ptr remove_method(object_ptr dispatch_val);
     multi_function_ptr prefer_method(object_ptr x, object_ptr y);
@@ -88,10 +88,10 @@ namespace jank::runtime::obj
     object_ptr default_dispatch_value{};
     object_ptr hierarchy{};
     mutable object_ptr cached_hierarchy{};
-    obj::persistent_hash_map_ptr method_table{};
-    mutable obj::persistent_hash_map_ptr method_cache{};
-    obj::persistent_hash_map_ptr prefer_table{};
-    obj::symbol_ptr name{};
+    persistent_hash_map_ptr method_table{};
+    mutable persistent_hash_map_ptr method_cache{};
+    persistent_hash_map_ptr prefer_table{};
+    symbol_ptr name{};
     std::recursive_mutex data_lock;
   };
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/multi_function.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/multi_function.hpp
@@ -24,7 +24,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string();
-    void to_string(fmt::memory_buffer &buff);
+    void to_string(util::string_builder &buff);
     native_persistent_string to_code_string();
     native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/multi_function.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/multi_function.hpp
@@ -83,7 +83,7 @@ namespace jank::runtime::obj
     object_ptr get_method(object_ptr dispatch_val);
     object_ptr find_and_cache_best_method(object_ptr dispatch_val);
 
-    object base{ object_type::multi_function };
+    object base{ obj_type };
     object_ptr dispatch{};
     object_ptr default_dispatch_value{};
     object_ptr hierarchy{};

--- a/compiler+runtime/include/cpp/jank/runtime/obj/native_array_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/native_array_sequence.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <jank/runtime/object.hpp>
-#include <jank/runtime/obj/cons.hpp>
 
 namespace jank::runtime::obj
 {
   using native_array_sequence_ptr = native_box<struct native_array_sequence>;
+  using cons_ptr = native_box<struct cons>;
 
   struct native_array_sequence : gc
   {

--- a/compiler+runtime/include/cpp/jank/runtime/obj/native_array_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/native_array_sequence.hpp
@@ -28,7 +28,7 @@ namespace jank::runtime::obj
 
     /* behavior::object_like */
     native_bool equal(object const &o) const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_string() const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;

--- a/compiler+runtime/include/cpp/jank/runtime/obj/native_array_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/native_array_sequence.hpp
@@ -3,22 +3,24 @@
 #include <jank/runtime/object.hpp>
 #include <jank/runtime/obj/cons.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  template <>
-  struct static_object<object_type::native_array_sequence> : gc
+  using native_array_sequence_ptr = native_box<struct native_array_sequence>;
+
+  struct native_array_sequence : gc
   {
+    static constexpr object_type obj_type{ object_type::native_array_sequence };
     static constexpr native_bool pointer_free{ false };
     static constexpr native_bool is_sequential{ true };
 
-    static_object() = delete;
-    static_object(static_object &&) = default;
-    static_object(static_object const &) = default;
-    static_object(object_ptr * const arr, size_t const size);
-    static_object(object_ptr * const arr, size_t const index, size_t const size);
+    native_array_sequence() = delete;
+    native_array_sequence(native_array_sequence &&) noexcept = default;
+    native_array_sequence(native_array_sequence const &) = default;
+    native_array_sequence(object_ptr * const arr, size_t const size);
+    native_array_sequence(object_ptr * const arr, size_t const index, size_t const size);
 
     template <typename... Args>
-    static_object(object_ptr const first, Args const... rest)
+    native_array_sequence(object_ptr const first, Args const... rest)
       : arr{ make_array_box<object_ptr>(first, rest...) }
       , size{ sizeof...(Args) + 1 }
     {
@@ -32,29 +34,23 @@ namespace jank::runtime
     native_hash to_hash() const;
 
     /* behavior::seqable */
-    native_box<static_object> seq();
-    native_box<static_object> fresh_seq();
+    native_array_sequence_ptr seq();
+    native_array_sequence_ptr fresh_seq();
 
     /* behavior::countable */
     size_t count() const;
 
     /* behavior::sequence */
     object_ptr first() const;
-    native_box<static_object> next() const;
+    native_array_sequence_ptr next() const;
     obj::cons_ptr conj(object_ptr head);
 
     /* behavior::sequenceable_in_place */
-    native_box<static_object> next_in_place();
+    native_array_sequence_ptr next_in_place();
 
     object base{ object_type::native_array_sequence };
     object_ptr *arr{};
     size_t index{};
     size_t size{};
   };
-
-  namespace obj
-  {
-    using native_array_sequence = static_object<object_type::native_array_sequence>;
-    using native_array_sequence_ptr = native_box<native_array_sequence>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/native_array_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/native_array_sequence.hpp
@@ -48,7 +48,7 @@ namespace jank::runtime::obj
     /* behavior::sequenceable_in_place */
     native_array_sequence_ptr next_in_place();
 
-    object base{ object_type::native_array_sequence };
+    object base{ obj_type };
     object_ptr *arr{};
     size_t index{};
     size_t size{};

--- a/compiler+runtime/include/cpp/jank/runtime/obj/native_function_wrapper.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/native_function_wrapper.hpp
@@ -60,79 +60,79 @@ namespace jank::runtime
     }
   };
 
-  template <>
-  struct static_object<object_type::native_function_wrapper>
-    : gc
-    , behavior::callable
-  {
-    static constexpr native_bool pointer_free{ false };
-
-    static_object() = default;
-    static_object(static_object &&) = default;
-    static_object(static_object const &) = default;
-    static_object(obj::detail::function_type &&d);
-    static_object(obj::detail::function_type const &d);
-
-    /* behavior::object_like */
-    native_bool equal(object const &) const;
-    native_persistent_string to_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
-    native_persistent_string to_code_string() const;
-    native_hash to_hash() const;
-
-    /* behavior::callable */
-    object_ptr call() final;
-    object_ptr call(object_ptr) final;
-    object_ptr call(object_ptr, object_ptr) final;
-    object_ptr call(object_ptr, object_ptr, object_ptr) final;
-    object_ptr call(object_ptr, object_ptr, object_ptr, object_ptr) final;
-    object_ptr call(object_ptr, object_ptr, object_ptr, object_ptr, object_ptr) final;
-    object_ptr call(object_ptr, object_ptr, object_ptr, object_ptr, object_ptr, object_ptr) final;
-    object_ptr
-      call(object_ptr, object_ptr, object_ptr, object_ptr, object_ptr, object_ptr, object_ptr)
-        final;
-    object_ptr call(object_ptr,
-                    object_ptr,
-                    object_ptr,
-                    object_ptr,
-                    object_ptr,
-                    object_ptr,
-                    object_ptr,
-                    object_ptr) final;
-    object_ptr call(object_ptr,
-                    object_ptr,
-                    object_ptr,
-                    object_ptr,
-                    object_ptr,
-                    object_ptr,
-                    object_ptr,
-                    object_ptr,
-                    object_ptr) final;
-    object_ptr call(object_ptr,
-                    object_ptr,
-                    object_ptr,
-                    object_ptr,
-                    object_ptr,
-                    object_ptr,
-                    object_ptr,
-                    object_ptr,
-                    object_ptr,
-                    object_ptr) final;
-
-    object_ptr this_object_ptr() final;
-
-    /* behavior::metadatable */
-    native_box<static_object> with_meta(object_ptr m) const;
-
-    object base{ object_type::native_function_wrapper };
-    obj::detail::function_type data{};
-    option<object_ptr> meta;
-  };
-
   namespace obj
   {
-    using native_function_wrapper = static_object<object_type::native_function_wrapper>;
-    using native_function_wrapper_ptr = native_box<native_function_wrapper>;
+
+    using native_function_wrapper_ptr = native_box<struct native_function_wrapper>;
+
+    struct native_function_wrapper
+      : gc
+      , behavior::callable
+    {
+      static constexpr object_type obj_type{ object_type::native_function_wrapper };
+      static constexpr native_bool pointer_free{ false };
+
+      native_function_wrapper() = default;
+      native_function_wrapper(native_function_wrapper &&) noexcept = default;
+      native_function_wrapper(native_function_wrapper const &) = default;
+      native_function_wrapper(obj::detail::function_type &&d);
+      native_function_wrapper(obj::detail::function_type const &d);
+
+      /* behavior::object_like */
+      native_bool equal(object const &) const;
+      native_persistent_string to_string() const;
+      void to_string(fmt::memory_buffer &buff) const;
+      native_persistent_string to_code_string() const;
+      native_hash to_hash() const;
+
+      /* behavior::callable */
+      object_ptr call() final;
+      object_ptr call(object_ptr) final;
+      object_ptr call(object_ptr, object_ptr) final;
+      object_ptr call(object_ptr, object_ptr, object_ptr) final;
+      object_ptr call(object_ptr, object_ptr, object_ptr, object_ptr) final;
+      object_ptr call(object_ptr, object_ptr, object_ptr, object_ptr, object_ptr) final;
+      object_ptr call(object_ptr, object_ptr, object_ptr, object_ptr, object_ptr, object_ptr) final;
+      object_ptr
+        call(object_ptr, object_ptr, object_ptr, object_ptr, object_ptr, object_ptr, object_ptr)
+          final;
+      object_ptr call(object_ptr,
+                      object_ptr,
+                      object_ptr,
+                      object_ptr,
+                      object_ptr,
+                      object_ptr,
+                      object_ptr,
+                      object_ptr) final;
+      object_ptr call(object_ptr,
+                      object_ptr,
+                      object_ptr,
+                      object_ptr,
+                      object_ptr,
+                      object_ptr,
+                      object_ptr,
+                      object_ptr,
+                      object_ptr) final;
+      object_ptr call(object_ptr,
+                      object_ptr,
+                      object_ptr,
+                      object_ptr,
+                      object_ptr,
+                      object_ptr,
+                      object_ptr,
+                      object_ptr,
+                      object_ptr,
+                      object_ptr) final;
+
+      object_ptr this_object_ptr() final;
+
+      /* behavior::metadatable */
+      native_function_wrapper_ptr with_meta(object_ptr m) const;
+
+      object base{ object_type::native_function_wrapper };
+      obj::detail::function_type data{};
+      option<object_ptr> meta;
+    };
   }
 
   namespace detail

--- a/compiler+runtime/include/cpp/jank/runtime/obj/native_function_wrapper.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/native_function_wrapper.hpp
@@ -129,7 +129,7 @@ namespace jank::runtime
       /* behavior::metadatable */
       native_function_wrapper_ptr with_meta(object_ptr m) const;
 
-      object base{ object_type::native_function_wrapper };
+      object base{ obj_type };
       obj::detail::function_type data{};
       option<object_ptr> meta;
     };

--- a/compiler+runtime/include/cpp/jank/runtime/obj/native_function_wrapper.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/native_function_wrapper.hpp
@@ -55,7 +55,8 @@ namespace jank::runtime
   struct invalid_arity : std::runtime_error
   {
     invalid_arity(native_persistent_string const &name)
-      : std::runtime_error{ fmt::format("invalid call to {} with {} args provided", name, Arity) }
+      : std::runtime_error{ std::string{ "invalid call to " } + name + " with "
+                            + std::to_string(Arity) + " args provided" }
     {
     }
   };
@@ -81,7 +82,7 @@ namespace jank::runtime
       /* behavior::object_like */
       native_bool equal(object const &) const;
       native_persistent_string to_string() const;
-      void to_string(fmt::memory_buffer &buff) const;
+      void to_string(util::string_builder &buff) const;
       native_persistent_string to_code_string() const;
       native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/native_pointer_wrapper.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/native_pointer_wrapper.hpp
@@ -2,17 +2,19 @@
 
 #include <jank/runtime/object.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  template <>
-  struct static_object<object_type::native_pointer_wrapper> : gc
+  using native_pointer_wrapper_ptr = native_box<struct native_pointer_wrapper>;
+
+  struct native_pointer_wrapper : gc
   {
+    static constexpr object_type obj_type{ object_type::native_pointer_wrapper };
     static constexpr native_bool pointer_free{ false };
 
-    static_object() = default;
-    static_object(static_object &&) = default;
-    static_object(static_object const &) = default;
-    static_object(void * const);
+    native_pointer_wrapper() = default;
+    native_pointer_wrapper(native_pointer_wrapper &&) noexcept = default;
+    native_pointer_wrapper(native_pointer_wrapper const &) = default;
+    native_pointer_wrapper(void * const);
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -28,13 +30,6 @@ namespace jank::runtime
     }
 
     object base{ object_type::native_pointer_wrapper };
-
     void *data{};
   };
-
-  namespace obj
-  {
-    using native_pointer_wrapper = static_object<object_type::native_pointer_wrapper>;
-    using native_pointer_wrapper_ptr = native_box<native_pointer_wrapper>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/native_pointer_wrapper.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/native_pointer_wrapper.hpp
@@ -29,7 +29,7 @@ namespace jank::runtime::obj
       return reinterpret_cast<T *>(data);
     }
 
-    object base{ object_type::native_pointer_wrapper };
+    object base{ obj_type };
     void *data{};
   };
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/native_pointer_wrapper.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/native_pointer_wrapper.hpp
@@ -19,7 +19,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/native_vector_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/native_vector_sequence.hpp
@@ -22,7 +22,7 @@ namespace jank::runtime::obj
 
     /* behavior::object_like */
     native_bool equal(object const &o) const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_string() const;
     native_persistent_string to_code_string() const;
     native_hash to_hash();

--- a/compiler+runtime/include/cpp/jank/runtime/obj/native_vector_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/native_vector_sequence.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
 #include <jank/runtime/object.hpp>
-#include <jank/runtime/obj/cons.hpp>
 
 namespace jank::runtime::obj
 {
+  using cons_ptr = native_box<struct cons>;
   using native_vector_sequence_ptr = native_box<struct native_vector_sequence>;
 
   struct native_vector_sequence : gc

--- a/compiler+runtime/include/cpp/jank/runtime/obj/native_vector_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/native_vector_sequence.hpp
@@ -3,20 +3,22 @@
 #include <jank/runtime/object.hpp>
 #include <jank/runtime/obj/cons.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  template <>
-  struct static_object<object_type::native_vector_sequence> : gc
+  using native_vector_sequence_ptr = native_box<struct native_vector_sequence>;
+
+  struct native_vector_sequence : gc
   {
+    static constexpr object_type obj_type{ object_type::native_vector_sequence };
     static constexpr native_bool pointer_free{ false };
     static constexpr native_bool is_sequential{ true };
 
-    static_object() = default;
-    static_object(static_object &&) = default;
-    static_object(static_object const &) = default;
-    static_object(native_vector<object_ptr> const &data, size_t index);
-    static_object(native_vector<object_ptr> &&data);
-    static_object(native_vector<object_ptr> &&data, size_t index);
+    native_vector_sequence() = default;
+    native_vector_sequence(native_vector_sequence &&) noexcept = default;
+    native_vector_sequence(native_vector_sequence const &) = default;
+    native_vector_sequence(native_vector<object_ptr> const &data, size_t index);
+    native_vector_sequence(native_vector<object_ptr> &&data);
+    native_vector_sequence(native_vector<object_ptr> &&data, size_t index);
 
     /* behavior::object_like */
     native_bool equal(object const &o) const;
@@ -26,28 +28,22 @@ namespace jank::runtime
     native_hash to_hash();
 
     /* behavior::seqable */
-    native_box<static_object> seq();
-    native_box<static_object> fresh_seq();
+    native_vector_sequence_ptr seq();
+    native_vector_sequence_ptr fresh_seq();
 
     /* behavior::countable */
     size_t count() const;
 
     /* behavior::sequence */
     object_ptr first() const;
-    native_box<static_object> next() const;
+    native_vector_sequence_ptr next() const;
     obj::cons_ptr conj(object_ptr head);
 
     /* behavior::sequenceable_in_place */
-    native_box<static_object> next_in_place();
+    native_vector_sequence_ptr next_in_place();
 
     object base{ object_type::native_vector_sequence };
     native_vector<object_ptr> data{};
     size_t index{};
   };
-
-  namespace obj
-  {
-    using native_vector_sequence = static_object<object_type::native_vector_sequence>;
-    using native_vector_sequence_ptr = native_box<native_vector_sequence>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/native_vector_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/native_vector_sequence.hpp
@@ -42,7 +42,7 @@ namespace jank::runtime::obj
     /* behavior::sequenceable_in_place */
     native_vector_sequence_ptr next_in_place();
 
-    object base{ object_type::native_vector_sequence };
+    object base{ obj_type };
     native_vector<object_ptr> data{};
     size_t index{};
   };

--- a/compiler+runtime/include/cpp/jank/runtime/obj/nil.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/nil.hpp
@@ -21,7 +21,7 @@ namespace jank::runtime::obj
     native_bool equal(object const &) const;
     native_persistent_string const &to_string() const;
     native_persistent_string const &to_code_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_hash to_hash() const;
 
     /* behavior::comparable */

--- a/compiler+runtime/include/cpp/jank/runtime/obj/nil.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/nil.hpp
@@ -2,24 +2,20 @@
 
 #include <jank/runtime/object.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  namespace obj
-  {
-    using persistent_array_map = static_object<object_type::persistent_array_map>;
-    using persistent_array_map_ptr = native_box<persistent_array_map>;
-    using cons = static_object<object_type::cons>;
-    using cons_ptr = native_box<cons>;
-  }
+  using persistent_array_map_ptr = native_box<struct persistent_array_map>;
+  using cons_ptr = native_box<struct cons>;
+  using nil_ptr = native_box<struct nil>;
 
-  template <>
-  struct static_object<object_type::nil> : gc
+  struct nil : gc
   {
+    static constexpr object_type obj_type{ object_type::nil };
     static constexpr native_bool pointer_free{ true };
 
-    static native_box<static_object> nil_const();
+    static nil_ptr nil_const();
 
-    static_object() = default;
+    nil() = default;
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -32,7 +28,7 @@ namespace jank::runtime
     native_integer compare(object const &) const;
 
     /* behavior::comparable extended */
-    native_integer compare(static_object const &) const;
+    native_integer compare(nil const &) const;
 
     /* behavior::associatively_readable */
     object_ptr get(object_ptr const key);
@@ -42,26 +38,20 @@ namespace jank::runtime
 
     /* behavior::associatively_writable */
     obj::persistent_array_map_ptr assoc(object_ptr key, object_ptr val) const;
-    native_box<static_object> dissoc(object_ptr key) const;
+    nil_ptr dissoc(object_ptr key) const;
 
     /* behavior::seqable */
-    native_box<static_object> seq();
-    native_box<static_object> fresh_seq() const;
+    nil_ptr seq();
+    nil_ptr fresh_seq() const;
 
     /* behavior::sequenceable */
-    native_box<static_object> first() const;
-    native_box<static_object> next() const;
+    nil_ptr first() const;
+    nil_ptr next() const;
     obj::cons_ptr conj(object_ptr head) const;
 
     /* behavior::sequenceable_in_place */
-    native_box<static_object> next_in_place();
+    nil_ptr next_in_place();
 
     object base{ object_type::nil };
   };
-
-  namespace obj
-  {
-    using nil = static_object<object_type::nil>;
-    using nil_ptr = native_box<nil>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/nil.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/nil.hpp
@@ -52,6 +52,6 @@ namespace jank::runtime::obj
     /* behavior::sequenceable_in_place */
     nil_ptr next_in_place();
 
-    object base{ object_type::nil };
+    object base{ obj_type };
   };
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/number.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/number.hpp
@@ -32,7 +32,7 @@ namespace jank::runtime::obj
     /* behavior::comparable extended */
     native_integer compare(boolean const &) const;
 
-    object base{ object_type::boolean };
+    object base{ obj_type };
     native_bool data{};
   };
 
@@ -66,7 +66,7 @@ namespace jank::runtime::obj
     native_real to_real() const;
 
     native_integer data{};
-    object base{ object_type::integer };
+    object base{ obj_type };
   };
 
   struct real : gc
@@ -97,6 +97,6 @@ namespace jank::runtime::obj
     native_real to_real() const;
 
     native_real data{};
-    object base{ object_type::real };
+    object base{ obj_type };
   };
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/number.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/number.hpp
@@ -2,20 +2,22 @@
 
 #include <jank/runtime/object.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  template <>
-  struct static_object<object_type::boolean> : gc
+  using boolean_ptr = native_box<struct boolean>;
+
+  struct boolean : gc
   {
+    static constexpr object_type obj_type{ object_type::boolean };
     static constexpr native_bool pointer_free{ true };
 
-    static native_box<static_object> true_const();
-    static native_box<static_object> false_const();
+    static boolean_ptr true_const();
+    static boolean_ptr false_const();
 
-    static_object() = default;
-    static_object(static_object &&) = default;
-    static_object(static_object const &) = default;
-    static_object(native_bool const d);
+    boolean() = default;
+    boolean(boolean &&) noexcept = default;
+    boolean(boolean const &) = default;
+    boolean(native_bool const d);
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -28,21 +30,23 @@ namespace jank::runtime
     native_integer compare(object const &) const;
 
     /* behavior::comparable extended */
-    native_integer compare(static_object const &) const;
+    native_integer compare(boolean const &) const;
 
     object base{ object_type::boolean };
     native_bool data{};
   };
 
-  template <>
-  struct static_object<object_type::integer> : gc
+  using integer_ptr = native_box<struct integer>;
+
+  struct integer : gc
   {
+    static constexpr object_type obj_type{ object_type::integer };
     static constexpr native_bool pointer_free{ true };
 
-    static_object() = default;
-    static_object(static_object &&) = default;
-    static_object(static_object const &) = default;
-    static_object(native_integer const d);
+    integer() = default;
+    integer(integer &&) noexcept = default;
+    integer(integer const &) = default;
+    integer(native_integer const d);
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -55,7 +59,7 @@ namespace jank::runtime
     native_integer compare(object const &) const;
 
     /* behavior::comparable extended */
-    native_integer compare(static_object const &) const;
+    native_integer compare(integer const &) const;
 
     /* behavior::number_like */
     native_integer to_integer() const;
@@ -65,15 +69,15 @@ namespace jank::runtime
     object base{ object_type::integer };
   };
 
-  template <>
-  struct static_object<object_type::real> : gc
+  struct real : gc
   {
+    static constexpr object_type obj_type{ object_type::real };
     static constexpr native_bool pointer_free{ true };
 
-    static_object() = default;
-    static_object(static_object &&) = default;
-    static_object(static_object const &) = default;
-    static_object(native_real const d);
+    real() = default;
+    real(real &&) noexcept = default;
+    real(real const &) = default;
+    real(native_real const d);
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -86,7 +90,7 @@ namespace jank::runtime
     native_integer compare(object const &) const;
 
     /* behavior::comparable extended */
-    native_integer compare(static_object const &) const;
+    native_integer compare(real const &) const;
 
     /* behavior::number_like */
     native_integer to_integer() const;
@@ -95,16 +99,4 @@ namespace jank::runtime
     native_real data{};
     object base{ object_type::real };
   };
-
-  namespace obj
-  {
-    using boolean = static_object<object_type::boolean>;
-    using boolean_ptr = native_box<boolean>;
-
-    using integer = static_object<object_type::integer>;
-    using integer_ptr = native_box<integer>;
-
-    using real = static_object<object_type::real>;
-    using real_ptr = native_box<real>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/number.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/number.hpp
@@ -22,7 +22,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;
 
@@ -51,7 +51,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;
 
@@ -82,7 +82,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_array_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_array_map.hpp
@@ -5,59 +5,61 @@
 #include <jank/runtime/obj/persistent_array_map_sequence.hpp>
 #include <jank/runtime/obj/detail/base_persistent_map.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  template <>
-  struct static_object<object_type::persistent_array_map>
-    : obj::detail::base_persistent_map<object_type::persistent_array_map,
-                                       object_type::persistent_array_map_sequence,
+  using persistent_array_map_ptr = native_box<struct persistent_array_map>;
+
+  struct persistent_array_map
+    : obj::detail::base_persistent_map<persistent_array_map,
+                                       persistent_array_map_sequence,
                                        runtime::detail::native_persistent_array_map>
   {
+    static constexpr object_type obj_type{ object_type::persistent_array_map };
     static constexpr size_t max_size{ value_type::max_size };
 
-    static_object() = default;
-    static_object(static_object &&) = default;
-    static_object(static_object const &) = default;
-    static_object(value_type &&d);
-    static_object(value_type const &d);
-    static_object(object_ptr meta, value_type &&d);
+    persistent_array_map() = default;
+    persistent_array_map(persistent_array_map &&) noexcept = default;
+    persistent_array_map(persistent_array_map const &) = default;
+    persistent_array_map(value_type &&d);
+    persistent_array_map(value_type const &d);
+    persistent_array_map(object_ptr meta, value_type &&d);
 
     template <typename... Args>
-    static_object(runtime::detail::in_place_unique, Args &&...args)
+    persistent_array_map(runtime::detail::in_place_unique, Args &&...args)
       : data{ runtime::detail::in_place_unique{}, std::forward<Args>(args)... }
     {
     }
 
     template <typename... Args>
-    static_object(object_ptr const meta, runtime::detail::in_place_unique, Args &&...args)
+    persistent_array_map(object_ptr const meta, runtime::detail::in_place_unique, Args &&...args)
       : data{ runtime::detail::in_place_unique{}, std::forward<Args>(args)... }
     {
       this->meta = meta;
     }
 
-    static native_box<static_object> empty()
+    static persistent_array_map_ptr empty()
     {
-      static auto const ret(make_box<static_object>());
+      static auto const ret(make_box<persistent_array_map>());
       return ret;
     }
 
     using base_persistent_map::base_persistent_map;
 
     template <typename... Args>
-    static native_box<static_object> create_unique(Args &&...args)
+    static persistent_array_map_ptr create_unique(Args &&...args)
     {
-      return make_box<static_object>(runtime::detail::in_place_unique{},
-                                     make_array_box<object_ptr>(std::forward<Args>(args)...),
-                                     sizeof...(args));
+      return make_box<persistent_array_map>(runtime::detail::in_place_unique{},
+                                            make_array_box<object_ptr>(std::forward<Args>(args)...),
+                                            sizeof...(args));
     }
 
     template <typename... Args>
-    static native_box<static_object> create_unique_with_meta(object_ptr const meta, Args &&...args)
+    static persistent_array_map_ptr create_unique_with_meta(object_ptr const meta, Args &&...args)
     {
-      return make_box<static_object>(meta,
-                                     runtime::detail::in_place_unique{},
-                                     make_array_box<object_ptr>(std::forward<Args>(args)...),
-                                     sizeof...(args));
+      return make_box<persistent_array_map>(meta,
+                                            runtime::detail::in_place_unique{},
+                                            make_array_box<object_ptr>(std::forward<Args>(args)...),
+                                            sizeof...(args));
     }
 
     /* behavior::associatively_readable */
@@ -68,7 +70,7 @@ namespace jank::runtime
 
     /* behavior::associatively_writable */
     object_ptr assoc(object_ptr key, object_ptr val) const;
-    native_box<static_object> dissoc(object_ptr key) const;
+    persistent_array_map_ptr dissoc(object_ptr key) const;
 
     /* behavior::conjable */
     object_ptr conj(object_ptr head) const;
@@ -79,10 +81,4 @@ namespace jank::runtime
 
     value_type data{};
   };
-
-  namespace obj
-  {
-    using persistent_array_map = static_object<object_type::persistent_array_map>;
-    using persistent_array_map_ptr = native_box<persistent_array_map>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_array_map_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_array_map_sequence.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <jank/runtime/obj/detail/base_persistent_map_sequence.hpp>
+#include <jank/runtime/detail/native_persistent_array_map.hpp>
 
 namespace jank::runtime::obj
 {

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_array_map_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_array_map_sequence.hpp
@@ -2,20 +2,17 @@
 
 #include <jank/runtime/obj/detail/base_persistent_map_sequence.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  template <>
-  struct static_object<object_type::persistent_array_map_sequence>
-    : obj::detail::base_persistent_map_sequence<
-        object_type::persistent_array_map_sequence,
+  using persistent_array_map_sequence_ptr = native_box<struct persistent_array_map_sequence>;
+
+  struct persistent_array_map_sequence
+    : detail::base_persistent_map_sequence<
+        persistent_array_map_sequence,
         runtime::detail::native_persistent_array_map::const_iterator>
   {
+    static constexpr object_type obj_type{ object_type::persistent_array_map_sequence };
+
     using base_persistent_map_sequence::base_persistent_map_sequence;
   };
-
-  namespace obj
-  {
-    using persistent_array_map_sequence = static_object<object_type::persistent_array_map_sequence>;
-    using persistent_array_map_sequence_ptr = native_box<persistent_array_map_sequence>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_map.hpp
@@ -5,72 +5,68 @@
 #include <jank/runtime/obj/persistent_hash_map_sequence.hpp>
 #include <jank/runtime/obj/detail/base_persistent_map.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  namespace obj
-  {
-    using persistent_array_map = static_object<object_type::persistent_array_map>;
-    using persistent_array_map_ptr = native_box<persistent_array_map>;
+  using persistent_array_map_ptr = native_box<struct persistent_array_map>;
+  using transient_hash_map_ptr = native_box<struct transient_hash_map>;
+  using persistent_hash_map_ptr = native_box<struct persistent_hash_map>;
 
-    using transient_hash_map = static_object<object_type::transient_hash_map>;
-    using transient_hash_map_ptr = native_box<transient_hash_map>;
-  }
-
-  template <>
-  struct static_object<object_type::persistent_hash_map>
-    : obj::detail::base_persistent_map<object_type::persistent_hash_map,
-                                       object_type::persistent_hash_map_sequence,
+  struct persistent_hash_map
+    : obj::detail::base_persistent_map<persistent_hash_map,
+                                       persistent_hash_map_sequence,
                                        runtime::detail::native_persistent_hash_map>
   {
-    using transient_type = static_object<object_type::transient_hash_map>;
+    static constexpr object_type obj_type{ object_type::persistent_hash_map };
 
-    static_object() = default;
-    static_object(static_object &&) = default;
-    static_object(static_object const &) = default;
-    static_object(runtime::detail::native_persistent_array_map const &m,
-                  object_ptr key,
-                  object_ptr val);
-    static_object(value_type &&d);
-    static_object(value_type const &d);
-    static_object(object_ptr meta, value_type &&d);
+    using transient_type = transient_hash_map;
+
+    persistent_hash_map() = default;
+    persistent_hash_map(persistent_hash_map &&) noexcept = default;
+    persistent_hash_map(persistent_hash_map const &) = default;
+    persistent_hash_map(runtime::detail::native_persistent_array_map const &m,
+                        object_ptr key,
+                        object_ptr val);
+    persistent_hash_map(value_type &&d);
+    persistent_hash_map(value_type const &d);
+    persistent_hash_map(object_ptr meta, value_type &&d);
 
     template <typename... Args>
-    static_object(runtime::detail::in_place_unique, Args &&...args)
+    persistent_hash_map(runtime::detail::in_place_unique, Args &&...args)
       : data{ std::forward<Args>(args)... }
     {
     }
 
     template <typename... Args>
-    static_object(object_ptr const meta, runtime::detail::in_place_unique, Args &&...args)
+    persistent_hash_map(object_ptr const meta, runtime::detail::in_place_unique, Args &&...args)
       : data{ std::forward<Args>(args)... }
     {
       this->meta = meta;
     }
 
-    static native_box<static_object> empty()
+    static persistent_hash_map_ptr empty()
     {
-      static auto const ret(make_box<static_object>());
+      static auto const ret(make_box<persistent_hash_map>());
       return ret;
     }
 
     using base_persistent_map::base_persistent_map;
 
     template <typename... Args>
-    static native_box<static_object> create_unique(Args &&...pairs)
+    static persistent_hash_map_ptr create_unique(Args &&...pairs)
     {
-      return make_box<static_object>(runtime::detail::in_place_unique{},
-                                     std::forward<Args>(pairs)...);
+      return make_box<persistent_hash_map>(runtime::detail::in_place_unique{},
+                                           std::forward<Args>(pairs)...);
     }
 
     template <typename... Args>
-    static native_box<static_object> create_unique_with_meta(object_ptr const meta, Args &&...pairs)
+    static persistent_hash_map_ptr create_unique_with_meta(object_ptr const meta, Args &&...pairs)
     {
-      return make_box<static_object>(meta,
-                                     runtime::detail::in_place_unique{},
-                                     std::forward<Args>(pairs)...);
+      return make_box<persistent_hash_map>(meta,
+                                           runtime::detail::in_place_unique{},
+                                           std::forward<Args>(pairs)...);
     }
 
-    static native_box<static_object> create_from_seq(object_ptr const seq);
+    static persistent_hash_map_ptr create_from_seq(object_ptr const seq);
 
     /* behavior::associatively_readable */
     object_ptr get(object_ptr const key) const;
@@ -79,11 +75,11 @@ namespace jank::runtime
     native_bool contains(object_ptr key) const;
 
     /* behavior::associatively_writable */
-    native_box<static_object> assoc(object_ptr key, object_ptr val) const;
-    native_box<static_object> dissoc(object_ptr key) const;
+    persistent_hash_map_ptr assoc(object_ptr key, object_ptr val) const;
+    persistent_hash_map_ptr dissoc(object_ptr key) const;
 
     /* behavior::conjable */
-    native_box<static_object> conj(object_ptr head) const;
+    persistent_hash_map_ptr conj(object_ptr head) const;
 
     /* behavior::callable */
     object_ptr call(object_ptr) const;
@@ -94,10 +90,4 @@ namespace jank::runtime
 
     value_type data{};
   };
-
-  namespace obj
-  {
-    using persistent_hash_map = static_object<object_type::persistent_hash_map>;
-    using persistent_hash_map_ptr = native_box<persistent_hash_map>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_map_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_map_sequence.hpp
@@ -2,20 +2,15 @@
 
 #include <jank/runtime/obj/detail/base_persistent_map_sequence.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  template <>
-  struct static_object<object_type::persistent_hash_map_sequence>
-    : obj::detail::base_persistent_map_sequence<
-        object_type::persistent_hash_map_sequence,
+  struct persistent_hash_map_sequence
+    : detail::base_persistent_map_sequence<
+        persistent_hash_map_sequence,
         runtime::detail::native_persistent_hash_map::const_iterator>
   {
+    static constexpr object_type obj_type{ object_type::persistent_hash_map_sequence };
+
     using base_persistent_map_sequence::base_persistent_map_sequence;
   };
-
-  namespace obj
-  {
-    using persistent_hash_map_sequence = static_object<object_type::persistent_hash_map_sequence>;
-    using persistent_hash_map_sequence_ptr = native_box<persistent_hash_map_sequence>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_set.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_set.hpp
@@ -44,7 +44,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_set.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_set.hpp
@@ -70,7 +70,7 @@ namespace jank::runtime::obj
     native_bool contains(object_ptr o) const;
     persistent_hash_set_ptr disj(object_ptr o) const;
 
-    object base{ object_type::persistent_hash_set };
+    object base{ obj_type };
     value_type data;
     option<object_ptr> meta;
   };

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_set.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_set.hpp
@@ -3,49 +3,46 @@
 #include <jank/runtime/object.hpp>
 #include <jank/runtime/obj/persistent_hash_set_sequence.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  namespace obj
-  {
-    using transient_hash_set = static_object<object_type::transient_hash_set>;
-    using transient_hash_set_ptr = native_box<transient_hash_set>;
-  }
+  using transient_hash_set_ptr = native_box<struct transient_hash_set>;
+  using persistent_hash_set_ptr = native_box<struct persistent_hash_set>;
 
-  template <>
-  struct static_object<object_type::persistent_hash_set> : gc
+  struct persistent_hash_set : gc
   {
-    using value_type = runtime::detail::native_persistent_hash_set;
-
+    static constexpr object_type obj_type{ object_type::persistent_hash_set };
     static constexpr native_bool pointer_free{ false };
     static constexpr native_bool is_set_like{ true };
 
-    static_object() = default;
-    static_object(static_object &&) noexcept = default;
-    static_object(static_object const &) = default;
-    static_object(value_type &&d);
-    static_object(value_type const &d);
-    static_object(object_ptr meta, value_type &&d);
+    using value_type = runtime::detail::native_persistent_hash_set;
+
+    persistent_hash_set() = default;
+    persistent_hash_set(persistent_hash_set &&) noexcept = default;
+    persistent_hash_set(persistent_hash_set const &) = default;
+    persistent_hash_set(value_type &&d);
+    persistent_hash_set(value_type const &d);
+    persistent_hash_set(object_ptr meta, value_type &&d);
 
     template <typename... Args>
-    static_object(std::in_place_t, Args &&...args)
+    persistent_hash_set(std::in_place_t, Args &&...args)
       : data{ std::forward<Args>(args)... }
     {
     }
 
     template <typename... Args>
-    static_object(object_ptr const meta, std::in_place_t, Args &&...args)
+    persistent_hash_set(object_ptr const meta, std::in_place_t, Args &&...args)
       : data{ std::forward<Args>(args)... }
       , meta{ meta }
     {
     }
 
-    static native_box<static_object> empty()
+    static persistent_hash_set_ptr empty()
     {
-      static auto const ret(make_box<static_object>());
+      static auto const ret(make_box<persistent_hash_set>());
       return ret;
     }
 
-    static native_box<static_object> create_from_seq(object_ptr const seq);
+    static persistent_hash_set_ptr create_from_seq(object_ptr const seq);
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -55,7 +52,7 @@ namespace jank::runtime
     native_hash to_hash() const;
 
     /* behavior::metadatable */
-    native_box<static_object> with_meta(object_ptr m) const;
+    persistent_hash_set_ptr with_meta(object_ptr m) const;
 
     /* behavior::seqable */
     obj::persistent_hash_set_sequence_ptr seq() const;
@@ -65,7 +62,7 @@ namespace jank::runtime
     size_t count() const;
 
     /* behavior::conjable */
-    native_box<static_object> conj(object_ptr head) const;
+    persistent_hash_set_ptr conj(object_ptr head) const;
 
     /* behavior::callable */
     object_ptr call(object_ptr) const;
@@ -74,13 +71,10 @@ namespace jank::runtime
     obj::transient_hash_set_ptr to_transient() const;
 
     native_bool contains(object_ptr o) const;
-    native_box<static_object> disj(object_ptr o) const;
+    persistent_hash_set_ptr disj(object_ptr o) const;
 
     object base{ object_type::persistent_hash_set };
     value_type data;
     option<object_ptr> meta;
   };
-
-  using persistent_hash_set = static_object<object_type::persistent_hash_set>;
-  using persistent_hash_set_ptr = native_box<persistent_hash_set>;
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_set.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_set.hpp
@@ -1,12 +1,13 @@
 #pragma once
 
 #include <jank/runtime/object.hpp>
-#include <jank/runtime/obj/persistent_hash_set_sequence.hpp>
+#include <jank/runtime/detail/type.hpp>
 
 namespace jank::runtime::obj
 {
   using transient_hash_set_ptr = native_box<struct transient_hash_set>;
   using persistent_hash_set_ptr = native_box<struct persistent_hash_set>;
+  using persistent_hash_set_sequence_ptr = native_box<struct persistent_hash_set_sequence>;
 
   struct persistent_hash_set : gc
   {
@@ -36,11 +37,7 @@ namespace jank::runtime::obj
     {
     }
 
-    static persistent_hash_set_ptr empty()
-    {
-      static auto const ret(make_box<persistent_hash_set>());
-      return ret;
-    }
+    static persistent_hash_set_ptr empty();
 
     static persistent_hash_set_ptr create_from_seq(object_ptr const seq);
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_set_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_set_sequence.hpp
@@ -5,35 +5,26 @@
 #include <jank/runtime/behavior/seqable.hpp>
 #include <jank/runtime/obj/detail/iterator_sequence.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  namespace obj
-  {
-    using persistent_hash_set = static_object<object_type::persistent_hash_set>;
-    using persistent_hash_set_ptr = native_box<persistent_hash_set>;
-  }
+  using persistent_hash_set_ptr = native_box<struct persistent_hash_set>;
+  using persistent_hash_set_sequence_ptr = native_box<struct persistent_hash_set_sequence>;
 
-  template <>
-  struct static_object<object_type::persistent_hash_set_sequence>
+  struct persistent_hash_set_sequence
     : gc
-    , obj::detail::iterator_sequence<static_object<object_type::persistent_hash_set_sequence>,
+    , obj::detail::iterator_sequence<persistent_hash_set_sequence,
                                      runtime::detail::native_persistent_hash_set::iterator>
   {
+    static constexpr object_type obj_type{ object_type::persistent_hash_set_sequence };
     static constexpr native_bool pointer_free{ false };
     static constexpr native_bool is_sequential{ true };
 
-    static_object(static_object &&) = default;
-    static_object(static_object const &) = default;
+    persistent_hash_set_sequence(persistent_hash_set_sequence &&) = default;
+    persistent_hash_set_sequence(persistent_hash_set_sequence const &) = default;
     using obj::detail::iterator_sequence<
-      static_object<object_type::persistent_hash_set_sequence>,
+      persistent_hash_set_sequence,
       runtime::detail::native_persistent_hash_set::iterator>::iterator_sequence;
 
     object base{ object_type::persistent_hash_set_sequence };
   };
-
-  namespace obj
-  {
-    using persistent_hash_set_sequence = static_object<object_type::persistent_hash_set_sequence>;
-    using persistent_hash_set_sequence_ptr = native_box<persistent_hash_set_sequence>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_set_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_set_sequence.hpp
@@ -25,6 +25,6 @@ namespace jank::runtime::obj
       persistent_hash_set_sequence,
       runtime::detail::native_persistent_hash_set::iterator>::iterator_sequence;
 
-    object base{ object_type::persistent_hash_set_sequence };
+    object base{ obj_type };
   };
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_list.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_list.hpp
@@ -78,7 +78,7 @@ namespace jank::runtime::obj
     object_ptr peek() const;
     persistent_list_ptr pop() const;
 
-    object base{ object_type::persistent_list };
+    object base{ obj_type };
     value_type data;
     option<object_ptr> meta;
   };

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_list.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_list.hpp
@@ -4,46 +4,46 @@
 #include <jank/runtime/obj/persistent_list_sequence.hpp>
 #include <jank/runtime/detail/native_persistent_list.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  object_ptr seq(object_ptr s);
+  using persistent_list_ptr = native_box<struct persistent_list>;
 
-  template <>
-  struct static_object<object_type::persistent_list> : gc
+  struct persistent_list : gc
   {
     using value_type = runtime::detail::native_persistent_list;
 
+    static constexpr object_type obj_type{ object_type::persistent_list };
     static constexpr native_bool pointer_free{ false };
     static constexpr native_bool is_sequential{ true };
 
     /* Create from a sequence. */
-    static native_box<static_object> create(object_ptr s);
-    static native_box<static_object> create(native_box<static_object> s);
+    static persistent_list_ptr create(object_ptr s);
+    static persistent_list_ptr create(persistent_list_ptr s);
 
-    static_object() = default;
-    static_object(static_object &&) noexcept = default;
-    static_object(static_object const &) = default;
-    static_object(value_type const &d);
-    static_object(object_ptr meta, value_type const &d);
+    persistent_list() = default;
+    persistent_list(persistent_list &&) noexcept = default;
+    persistent_list(persistent_list const &) = default;
+    persistent_list(value_type const &d);
+    persistent_list(object_ptr meta, value_type const &d);
 
     /* TODO: This is broken when `args` is a value_type list we're looking to wrap in another list.
      * It just uses the copy ctor. */
     template <typename... Args>
-    static_object(std::in_place_t, Args &&...args)
+    persistent_list(std::in_place_t, Args &&...args)
       : data{ std::forward<Args>(args)... }
     {
     }
 
     template <typename... Args>
-    static_object(object_ptr const meta, std::in_place_t, Args &&...args)
+    persistent_list(object_ptr const meta, std::in_place_t, Args &&...args)
       : data{ std::forward<Args>(args)... }
       , meta{ meta }
     {
     }
 
-    static native_box<static_object> empty()
+    static persistent_list_ptr empty()
     {
-      static auto const ret(make_box<static_object>());
+      static auto const ret(make_box<persistent_list>());
       return ret;
     }
 
@@ -55,7 +55,7 @@ namespace jank::runtime
     native_hash to_hash() const;
 
     /* behavior::metadatable */
-    native_box<static_object> with_meta(object_ptr m) const;
+    persistent_list_ptr with_meta(object_ptr m) const;
 
     /* behavior::seqable */
     obj::persistent_list_sequence_ptr seq() const;
@@ -65,7 +65,7 @@ namespace jank::runtime
     size_t count() const;
 
     /* behavior::conjable */
-    native_box<static_object> conj(object_ptr head) const;
+    persistent_list_ptr conj(object_ptr head) const;
 
     /* behavior::sequenceable */
     object_ptr first() const;
@@ -76,16 +76,10 @@ namespace jank::runtime
 
     /* behavior::stackable */
     object_ptr peek() const;
-    native_box<static_object> pop() const;
+    persistent_list_ptr pop() const;
 
     object base{ object_type::persistent_list };
     value_type data;
     option<object_ptr> meta;
   };
-
-  namespace obj
-  {
-    using persistent_list = static_object<object_type::persistent_list>;
-    using persistent_list_ptr = native_box<persistent_list>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_list.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_list.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
 #include <jank/runtime/object.hpp>
-#include <jank/runtime/obj/persistent_list_sequence.hpp>
 #include <jank/runtime/detail/native_persistent_list.hpp>
 
 namespace jank::runtime::obj
 {
   using persistent_list_ptr = native_box<struct persistent_list>;
+  using persistent_list_sequence_ptr = native_box<struct persistent_list_sequence>;
 
   struct persistent_list : gc
   {

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_list.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_list.hpp
@@ -50,7 +50,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_list_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_list_sequence.hpp
@@ -5,36 +5,27 @@
 #include <jank/runtime/obj/detail/iterator_sequence.hpp>
 #include <jank/runtime/detail/native_persistent_list.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  namespace obj
-  {
-    using persistent_list = static_object<object_type::persistent_list>;
-    using persistent_list_ptr = native_box<persistent_list>;
-  }
+  using persistent_list_ptr = native_box<struct persistent_list>;
+  using persistent_list_sequence_ptr = native_box<struct persistent_list_sequence>;
 
-  template <>
-  struct static_object<object_type::persistent_list_sequence>
+  struct persistent_list_sequence
     : gc
-    , obj::detail::iterator_sequence<static_object<object_type::persistent_list_sequence>,
+    , obj::detail::iterator_sequence<persistent_list_sequence,
                                      runtime::detail::native_persistent_list::iterator>
   {
+    static constexpr object_type obj_type{ object_type::persistent_list_sequence };
     static constexpr native_bool pointer_free{ false };
     static constexpr native_bool is_sequential{ true };
 
-    static_object() = default;
-    static_object(static_object &&) = default;
-    static_object(static_object const &) = default;
+    persistent_list_sequence() = default;
+    persistent_list_sequence(persistent_list_sequence &&) noexcept = default;
+    persistent_list_sequence(persistent_list_sequence const &) = default;
     using obj::detail::iterator_sequence<
-      static_object<object_type::persistent_list_sequence>,
+      persistent_list_sequence,
       runtime::detail::native_persistent_list::iterator>::iterator_sequence;
 
     object base{ object_type::persistent_list_sequence };
   };
-
-  namespace obj
-  {
-    using persistent_list_sequence = static_object<object_type::persistent_list_sequence>;
-    using persistent_list_sequence_ptr = native_box<persistent_list_sequence>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_list_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_list_sequence.hpp
@@ -26,6 +26,6 @@ namespace jank::runtime::obj
       persistent_list_sequence,
       runtime::detail::native_persistent_list::iterator>::iterator_sequence;
 
-    object base{ object_type::persistent_list_sequence };
+    object base{ obj_type };
   };
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_sorted_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_sorted_map.hpp
@@ -5,66 +5,64 @@
 #include <jank/runtime/obj/detail/base_persistent_map.hpp>
 #include <jank/runtime/detail/native_persistent_array_map.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  namespace obj
-  {
-    using transient_sorted_map = static_object<object_type::transient_sorted_map>;
-    using transient_sorted_map_ptr = native_box<transient_sorted_map>;
-  }
+  using transient_sorted_map_ptr = native_box<struct transient_sorted_map>;
+  using persistent_sorted_map_ptr = native_box<struct persistent_sorted_map>;
 
-  template <>
-  struct static_object<object_type::persistent_sorted_map>
-    : obj::detail::base_persistent_map<object_type::persistent_sorted_map,
-                                       object_type::persistent_sorted_map_sequence,
+  struct persistent_sorted_map
+    : obj::detail::base_persistent_map<persistent_sorted_map,
+                                       persistent_sorted_map_sequence,
                                        runtime::detail::native_persistent_sorted_map>
   {
-    using transient_type = static_object<object_type::transient_sorted_map>;
+    static constexpr object_type obj_type{ object_type::persistent_sorted_map };
 
-    static_object() = default;
-    static_object(static_object &&) = default;
-    static_object(static_object const &) = default;
-    static_object(value_type &&d);
-    static_object(value_type const &d);
-    static_object(object_ptr meta, value_type &&d);
+    using transient_type = transient_sorted_map;
+
+    persistent_sorted_map() = default;
+    persistent_sorted_map(persistent_sorted_map &&) noexcept = default;
+    persistent_sorted_map(persistent_sorted_map const &) = default;
+    persistent_sorted_map(value_type &&d);
+    persistent_sorted_map(value_type const &d);
+    persistent_sorted_map(object_ptr meta, value_type &&d);
 
     template <typename... Args>
-    static_object(runtime::detail::in_place_unique, Args &&...args)
+    persistent_sorted_map(runtime::detail::in_place_unique, Args &&...args)
       : data{ std::forward<Args>(args)... }
     {
     }
 
     template <typename... Args>
-    static_object(object_ptr const meta, runtime::detail::in_place_unique, Args &&...args)
+    persistent_sorted_map(object_ptr const meta, runtime::detail::in_place_unique, Args &&...args)
       : data{ std::forward<Args>(args)... }
     {
       this->meta = meta;
     }
 
-    static native_box<static_object> empty()
+    static persistent_sorted_map_ptr empty()
     {
-      static auto const ret(make_box<static_object>());
+      static auto const ret(make_box<persistent_sorted_map>());
       return ret;
     }
 
     using base_persistent_map::base_persistent_map;
 
     template <typename... Args>
-    static native_box<static_object> create_unique(Args &&...pairs)
+    static persistent_sorted_map_ptr create_unique(Args &&...pairs)
     {
-      return make_box<static_object>(runtime::detail::in_place_unique{},
-                                     std::forward<Args>(pairs)...);
+      return make_box<persistent_sorted_map>(runtime::detail::in_place_unique{},
+                                             std::forward<Args>(pairs)...);
     }
 
     template <typename... Args>
-    static native_box<static_object> create_unique_with_meta(object_ptr const meta, Args &&...pairs)
+    static persistent_sorted_map_ptr create_unique_with_meta(object_ptr const meta, Args &&...pairs)
     {
-      return make_box<static_object>(meta,
-                                     runtime::detail::in_place_unique{},
-                                     std::forward<Args>(pairs)...);
+      return make_box<persistent_sorted_map>(meta,
+                                             runtime::detail::in_place_unique{},
+                                             std::forward<Args>(pairs)...);
     }
 
-    static native_box<static_object> create_from_seq(object_ptr const seq);
+    static persistent_sorted_map_ptr create_from_seq(object_ptr const seq);
 
     /* behavior::associatively_readable */
     object_ptr get(object_ptr const key) const;
@@ -73,11 +71,11 @@ namespace jank::runtime
     native_bool contains(object_ptr key) const;
 
     /* behavior::associatively_writable */
-    native_box<static_object> assoc(object_ptr key, object_ptr val) const;
-    native_box<static_object> dissoc(object_ptr key) const;
+    persistent_sorted_map_ptr assoc(object_ptr key, object_ptr val) const;
+    persistent_sorted_map_ptr dissoc(object_ptr key) const;
 
     /* behavior::conjable */
-    native_box<static_object> conj(object_ptr head) const;
+    persistent_sorted_map_ptr conj(object_ptr head) const;
 
     /* behavior::callable */
     object_ptr call(object_ptr) const;
@@ -88,10 +86,4 @@ namespace jank::runtime
 
     value_type data{};
   };
-
-  namespace obj
-  {
-    using persistent_sorted_map = static_object<object_type::persistent_sorted_map>;
-    using persistent_sorted_map_ptr = native_box<persistent_sorted_map>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_sorted_map_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_sorted_map_sequence.hpp
@@ -2,21 +2,17 @@
 
 #include <jank/runtime/obj/detail/base_persistent_map_sequence.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  template <>
-  struct static_object<object_type::persistent_sorted_map_sequence>
-    : obj::detail::base_persistent_map_sequence<
-        object_type::persistent_sorted_map_sequence,
+  using persistent_sorted_map_sequence_ptr = native_box<struct persistent_sorted_map_sequence>;
+
+  struct persistent_sorted_map_sequence
+    : detail::base_persistent_map_sequence<
+        persistent_sorted_map_sequence,
         runtime::detail::native_persistent_sorted_map::const_iterator>
   {
+    static constexpr object_type obj_type{ object_type::persistent_sorted_map_sequence };
+
     using base_persistent_map_sequence::base_persistent_map_sequence;
   };
-
-  namespace obj
-  {
-    using persistent_sorted_map_sequence
-      = static_object<object_type::persistent_sorted_map_sequence>;
-    using persistent_sorted_map_sequence_ptr = native_box<persistent_sorted_map_sequence>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_sorted_set.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_sorted_set.hpp
@@ -1,12 +1,13 @@
 #pragma once
 
 #include <jank/runtime/object.hpp>
-#include <jank/runtime/obj/persistent_sorted_set_sequence.hpp>
+#include <jank/runtime/detail/type.hpp>
 
 namespace jank::runtime::obj
 {
   using transient_sorted_set_ptr = native_box<struct transient_sorted_set>;
   using persistent_sorted_set_ptr = native_box<struct persistent_sorted_set>;
+  using persistent_sorted_set_sequence_ptr = native_box<struct persistent_sorted_set_sequence>;
 
   struct persistent_sorted_set : gc
   {

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_sorted_set.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_sorted_set.hpp
@@ -74,7 +74,7 @@ namespace jank::runtime::obj
     native_bool contains(object_ptr o) const;
     persistent_sorted_set_ptr disj(object_ptr o) const;
 
-    object base{ object_type::persistent_sorted_set };
+    object base{ obj_type };
     value_type data;
     option<object_ptr> meta;
   };

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_sorted_set.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_sorted_set.hpp
@@ -3,49 +3,46 @@
 #include <jank/runtime/object.hpp>
 #include <jank/runtime/obj/persistent_sorted_set_sequence.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  namespace obj
-  {
-    using transient_sorted_set = static_object<object_type::transient_sorted_set>;
-    using transient_sorted_set_ptr = native_box<transient_sorted_set>;
-  }
+  using transient_sorted_set_ptr = native_box<struct transient_sorted_set>;
+  using persistent_sorted_set_ptr = native_box<struct persistent_sorted_set>;
 
-  template <>
-  struct static_object<object_type::persistent_sorted_set> : gc
+  struct persistent_sorted_set : gc
   {
-    using value_type = runtime::detail::native_persistent_sorted_set;
-
+    static constexpr object_type obj_type{ object_type::persistent_sorted_set };
     static constexpr native_bool pointer_free{ false };
     static constexpr native_bool is_set_like{ true };
 
-    static_object() = default;
-    static_object(static_object &&) noexcept = default;
-    static_object(static_object const &) = default;
-    static_object(value_type &&d);
-    static_object(value_type const &d);
-    static_object(object_ptr meta, value_type &&d);
+    using value_type = runtime::detail::native_persistent_sorted_set;
+
+    persistent_sorted_set() = default;
+    persistent_sorted_set(persistent_sorted_set &&) noexcept = default;
+    persistent_sorted_set(persistent_sorted_set const &) = default;
+    persistent_sorted_set(value_type &&d);
+    persistent_sorted_set(value_type const &d);
+    persistent_sorted_set(object_ptr meta, value_type &&d);
 
     template <typename... Args>
-    static_object(std::in_place_t, Args &&...args)
+    persistent_sorted_set(std::in_place_t, Args &&...args)
       : data{ std::forward<Args>(args)... }
     {
     }
 
     template <typename... Args>
-    static_object(object_ptr const meta, std::in_place_t, Args &&...args)
+    persistent_sorted_set(object_ptr const meta, std::in_place_t, Args &&...args)
       : data{ std::forward<Args>(args)... }
       , meta{ meta }
     {
     }
 
-    static native_box<static_object> empty()
+    static persistent_sorted_set_ptr empty()
     {
-      static auto const ret(make_box<static_object>());
+      static auto const ret(make_box<persistent_sorted_set>());
       return ret;
     }
 
-    static native_box<static_object> create_from_seq(object_ptr const seq);
+    static persistent_sorted_set_ptr create_from_seq(object_ptr const seq);
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -55,17 +52,17 @@ namespace jank::runtime
     native_hash to_hash() const;
 
     /* behavior::metadatable */
-    native_box<static_object> with_meta(object_ptr m) const;
+    persistent_sorted_set_ptr with_meta(object_ptr m) const;
 
     /* behavior::seqable */
-    obj::persistent_sorted_set_sequence_ptr seq() const;
-    obj::persistent_sorted_set_sequence_ptr fresh_seq() const;
+    persistent_sorted_set_sequence_ptr seq() const;
+    persistent_sorted_set_sequence_ptr fresh_seq() const;
 
     /* behavior::countable */
     size_t count() const;
 
     /* behavior::conjable */
-    native_box<static_object> conj(object_ptr head) const;
+    persistent_sorted_set_ptr conj(object_ptr head) const;
 
     /* behavior::callable */
     object_ptr call(object_ptr);
@@ -74,13 +71,10 @@ namespace jank::runtime
     obj::transient_sorted_set_ptr to_transient() const;
 
     native_bool contains(object_ptr o) const;
-    native_box<static_object> disj(object_ptr o) const;
+    persistent_sorted_set_ptr disj(object_ptr o) const;
 
     object base{ object_type::persistent_sorted_set };
     value_type data;
     option<object_ptr> meta;
   };
-
-  using persistent_sorted_set = static_object<object_type::persistent_sorted_set>;
-  using persistent_sorted_set_ptr = native_box<persistent_sorted_set>;
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_sorted_set.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_sorted_set.hpp
@@ -48,7 +48,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_sorted_set_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_sorted_set_sequence.hpp
@@ -5,36 +5,26 @@
 #include <jank/runtime/behavior/seqable.hpp>
 #include <jank/runtime/obj/detail/iterator_sequence.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  namespace obj
-  {
-    using persistent_sorted_set = static_object<object_type::persistent_sorted_set>;
-    using persistent_sorted_set_ptr = native_box<persistent_sorted_set>;
-  }
+  using persistent_sorted_set_ptr = native_box<struct persistent_sorted_set>;
+  using persistent_sorted_set_sequence_ptr = native_box<struct persistent_sorted_set_sequence>;
 
-  template <>
-  struct static_object<object_type::persistent_sorted_set_sequence>
+  struct persistent_sorted_set_sequence
     : gc
-    , obj::detail::iterator_sequence<static_object<object_type::persistent_sorted_set_sequence>,
+    , obj::detail::iterator_sequence<persistent_sorted_set_sequence,
                                      runtime::detail::native_persistent_sorted_set::const_iterator>
   {
+    static constexpr object_type obj_type{ object_type::persistent_sorted_set_sequence };
     static constexpr native_bool pointer_free{ false };
     static constexpr native_bool is_sequential{ true };
 
-    static_object(static_object &&) = default;
-    static_object(static_object const &) = default;
+    persistent_sorted_set_sequence(persistent_sorted_set_sequence &&) noexcept = default;
+    persistent_sorted_set_sequence(persistent_sorted_set_sequence const &) = default;
     using obj::detail::iterator_sequence<
-      static_object<object_type::persistent_sorted_set_sequence>,
+      persistent_sorted_set_sequence,
       runtime::detail::native_persistent_sorted_set::const_iterator>::iterator_sequence;
 
     object base{ object_type::persistent_sorted_set_sequence };
   };
-
-  namespace obj
-  {
-    using persistent_sorted_set_sequence
-      = static_object<object_type::persistent_sorted_set_sequence>;
-    using persistent_sorted_set_sequence_ptr = native_box<persistent_sorted_set_sequence>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_sorted_set_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_sorted_set_sequence.hpp
@@ -25,6 +25,6 @@ namespace jank::runtime::obj
       persistent_sorted_set_sequence,
       runtime::detail::native_persistent_sorted_set::const_iterator>::iterator_sequence;
 
-    object base{ object_type::persistent_sorted_set_sequence };
+    object base{ obj_type };
   };
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_string.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_string.hpp
@@ -53,7 +53,7 @@ namespace jank::runtime::obj
     obj::persistent_string_sequence_ptr seq() const;
     obj::persistent_string_sequence_ptr fresh_seq() const;
 
-    object base{ object_type::persistent_string };
+    object base{ obj_type };
     native_persistent_string data;
   };
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_string.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_string.hpp
@@ -4,22 +4,24 @@
 #include <jank/runtime/obj/persistent_string_sequence.hpp>
 #include <jank/result.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  template <>
-  struct static_object<object_type::persistent_string> : gc
+  using persistent_string_ptr = native_box<struct persistent_string>;
+
+  struct persistent_string : gc
   {
+    static constexpr object_type obj_type{ object_type::persistent_string };
     static constexpr native_bool pointer_free{ false };
 
-    static_object() = default;
-    static_object(static_object &&) = default;
-    static_object(static_object const &) = default;
-    static_object(native_persistent_string const &d);
-    static_object(native_persistent_string &&d);
+    persistent_string() = default;
+    persistent_string(persistent_string &&) noexcept = default;
+    persistent_string(persistent_string const &) = default;
+    persistent_string(native_persistent_string const &d);
+    persistent_string(native_persistent_string &&d);
 
-    static native_box<static_object> empty()
+    static persistent_string_ptr empty()
     {
-      static auto const ret(make_box<static_object>());
+      static auto const ret(make_box<persistent_string>());
       return ret;
     }
 
@@ -34,12 +36,10 @@ namespace jank::runtime
     native_integer compare(object const &) const;
 
     /* behavior::comparable extended */
-    native_integer compare(static_object const &) const;
+    native_integer compare(persistent_string const &) const;
 
-    result<native_box<static_object>, native_persistent_string>
-    substring(native_integer start) const;
-    result<native_box<static_object>, native_persistent_string>
-    substring(native_integer start, native_integer end) const;
+    string_result<persistent_string_ptr> substring(native_integer start) const;
+    string_result<persistent_string_ptr> substring(native_integer start, native_integer end) const;
 
     /* Returns -1 when not found. Turns the arg into a string, so it accepts anything.
      * Searches for the whole string, not just a char. */
@@ -56,10 +56,4 @@ namespace jank::runtime
     object base{ object_type::persistent_string };
     native_persistent_string data;
   };
-
-  namespace obj
-  {
-    using persistent_string = static_object<object_type::persistent_string>;
-    using persistent_string_ptr = native_box<persistent_string>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_string.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_string.hpp
@@ -28,7 +28,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string const &to_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_string.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_string.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
 #include <jank/runtime/object.hpp>
-#include <jank/runtime/obj/persistent_string_sequence.hpp>
 #include <jank/result.hpp>
 
 namespace jank::runtime::obj
 {
   using persistent_string_ptr = native_box<struct persistent_string>;
+  using persistent_string_sequence_ptr = native_box<struct persistent_string_sequence>;
 
   struct persistent_string : gc
   {

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_string_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_string_sequence.hpp
@@ -22,7 +22,7 @@ namespace jank::runtime::obj
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_string() const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_string_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_string_sequence.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
 #include <jank/runtime/object.hpp>
-#include <jank/runtime/obj/cons.hpp>
 
 namespace jank::runtime::obj
 {
+  using cons_ptr = native_box<struct cons>;
   using persistent_string_ptr = native_box<struct persistent_string>;
   using persistent_string_sequence_ptr = native_box<struct persistent_string_sequence>;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_string_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_string_sequence.hpp
@@ -3,25 +3,22 @@
 #include <jank/runtime/object.hpp>
 #include <jank/runtime/obj/cons.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  namespace obj
-  {
-    using persistent_string = static_object<object_type::persistent_string>;
-    using persistent_string_ptr = native_box<persistent_string>;
-  }
+  using persistent_string_ptr = native_box<struct persistent_string>;
+  using persistent_string_sequence_ptr = native_box<struct persistent_string_sequence>;
 
-  template <>
-  struct static_object<object_type::persistent_string_sequence> : gc
+  struct persistent_string_sequence : gc
   {
+    static constexpr object_type obj_type{ object_type::persistent_string_sequence };
     static constexpr native_bool pointer_free{ false };
     static constexpr native_bool is_sequential{ true };
 
-    static_object() = default;
-    static_object(static_object &&) = default;
-    static_object(static_object const &) = default;
-    static_object(obj::persistent_string_ptr const s);
-    static_object(obj::persistent_string_ptr const s, size_t const i);
+    persistent_string_sequence() = default;
+    persistent_string_sequence(persistent_string_sequence &&) noexcept = default;
+    persistent_string_sequence(persistent_string_sequence const &) = default;
+    persistent_string_sequence(obj::persistent_string_ptr const s);
+    persistent_string_sequence(obj::persistent_string_ptr const s, size_t const i);
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -34,25 +31,19 @@ namespace jank::runtime
     size_t count() const;
 
     /* behavior::seqable */
-    native_box<static_object> seq();
-    native_box<static_object> fresh_seq() const;
+    persistent_string_sequence_ptr seq();
+    persistent_string_sequence_ptr fresh_seq() const;
 
     /* behavior::sequenceable */
     object_ptr first() const;
-    native_box<static_object> next() const;
+    persistent_string_sequence_ptr next() const;
     obj::cons_ptr conj(object_ptr head);
 
     /* behavior::sequenceable_in_place */
-    native_box<static_object> next_in_place();
+    persistent_string_sequence_ptr next_in_place();
 
     object base{ object_type::persistent_string_sequence };
     obj::persistent_string_ptr str{};
     size_t index{};
   };
-
-  namespace obj
-  {
-    using persistent_string_sequence = static_object<object_type::persistent_string_sequence>;
-    using persistent_string_sequence_ptr = native_box<persistent_string_sequence>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_string_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_string_sequence.hpp
@@ -42,7 +42,7 @@ namespace jank::runtime::obj
     /* behavior::sequenceable_in_place */
     persistent_string_sequence_ptr next_in_place();
 
-    object base{ object_type::persistent_string_sequence };
+    object base{ obj_type };
     obj::persistent_string_ptr str{};
     size_t index{};
   };

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_vector.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_vector.hpp
@@ -85,7 +85,7 @@ namespace jank::runtime::obj
     /* behavior::transientable */
     obj::transient_vector_ptr to_transient() const;
 
-    object base{ object_type::persistent_vector };
+    object base{ obj_type };
     value_type data;
     option<object_ptr> meta;
     mutable native_hash hash{};

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_vector.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_vector.hpp
@@ -45,7 +45,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_vector.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_vector.hpp
@@ -4,50 +4,43 @@
 #include <jank/runtime/detail/type.hpp>
 #include <jank/runtime/obj/persistent_vector_sequence.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  namespace obj
-  {
-    using transient_vector = static_object<object_type::transient_vector>;
-    using transient_vector_ptr = native_box<transient_vector>;
-  }
+  using transient_vector_ptr = native_box<struct transient_vector>;
+  using persistent_vector_ptr = native_box<struct persistent_vector>;
 
-  template <>
-  struct static_object<object_type::persistent_vector> : gc
+  struct persistent_vector : gc
   {
-    using transient_type = static_object<object_type::transient_vector>;
-    using value_type = runtime::detail::native_persistent_vector;
-
+    static constexpr object_type obj_type{ object_type::persistent_vector };
     static constexpr native_bool pointer_free{ false };
     static constexpr native_bool is_sequential{ true };
 
-    static_object() = default;
-    static_object(static_object &&) noexcept = default;
-    static_object(static_object const &) = default;
-    static_object(value_type &&d);
-    static_object(value_type const &d);
-    static_object(object_ptr meta, value_type &&d);
+    using transient_type = transient_vector;
+    using value_type = runtime::detail::native_persistent_vector;
+
+    persistent_vector() = default;
+    persistent_vector(persistent_vector &&) noexcept = default;
+    persistent_vector(persistent_vector const &) = default;
+    persistent_vector(value_type &&d);
+    persistent_vector(value_type const &d);
+    persistent_vector(object_ptr meta, value_type &&d);
 
     template <typename... Args>
-    static_object(std::in_place_t, Args &&...args)
+    persistent_vector(std::in_place_t, Args &&...args)
       : data{ std::forward<Args>(args)... }
     {
     }
 
     template <typename... Args>
-    static_object(object_ptr const meta, std::in_place_t, Args &&...args)
+    persistent_vector(object_ptr const meta, std::in_place_t, Args &&...args)
       : data{ std::forward<Args>(args)... }
       , meta{ meta }
     {
     }
 
-    static native_box<static_object> create(object_ptr s);
+    static persistent_vector_ptr create(object_ptr s);
 
-    static native_box<static_object> empty()
-    {
-      static auto const ret(make_box<static_object>());
-      return ret;
-    }
+    static persistent_vector_ptr empty();
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -60,10 +53,10 @@ namespace jank::runtime
     native_integer compare(object const &) const;
 
     /* behavior::comparable extended */
-    native_integer compare(static_object const &) const;
+    native_integer compare(persistent_vector const &) const;
 
     /* behavior::metadatable */
-    native_box<static_object> with_meta(object_ptr m) const;
+    persistent_vector_ptr with_meta(object_ptr m) const;
 
     /* behavior::seqable */
     obj::persistent_vector_sequence_ptr seq() const;
@@ -79,11 +72,11 @@ namespace jank::runtime
     native_bool contains(object_ptr key) const;
 
     /* behavior::conjable */
-    native_box<static_object> conj(object_ptr head) const;
+    persistent_vector_ptr conj(object_ptr head) const;
 
     /* behavior::stackable */
     object_ptr peek() const;
-    native_box<static_object> pop() const;
+    persistent_vector_ptr pop() const;
 
     /* behavior::indexable */
     object_ptr nth(object_ptr index) const;
@@ -97,10 +90,4 @@ namespace jank::runtime
     option<object_ptr> meta;
     mutable native_hash hash{};
   };
-
-  namespace obj
-  {
-    using persistent_vector = static_object<object_type::persistent_vector>;
-    using persistent_vector_ptr = native_box<persistent_vector>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_vector.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_vector.hpp
@@ -2,12 +2,12 @@
 
 #include <jank/runtime/object.hpp>
 #include <jank/runtime/detail/type.hpp>
-#include <jank/runtime/obj/persistent_vector_sequence.hpp>
 
 namespace jank::runtime::obj
 {
   using transient_vector_ptr = native_box<struct transient_vector>;
   using persistent_vector_ptr = native_box<struct persistent_vector>;
+  using persistent_vector_sequence_ptr = native_box<struct persistent_vector_sequence>;
 
   struct persistent_vector : gc
   {
@@ -59,8 +59,8 @@ namespace jank::runtime::obj
     persistent_vector_ptr with_meta(object_ptr m) const;
 
     /* behavior::seqable */
-    obj::persistent_vector_sequence_ptr seq() const;
-    obj::persistent_vector_sequence_ptr fresh_seq() const;
+    persistent_vector_sequence_ptr seq() const;
+    persistent_vector_sequence_ptr fresh_seq() const;
 
     /* behavior::countable */
     size_t count() const;

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_vector_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_vector_sequence.hpp
@@ -22,7 +22,7 @@ namespace jank::runtime::obj
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_string() const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_vector_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_vector_sequence.hpp
@@ -42,7 +42,7 @@ namespace jank::runtime::obj
     /* behavior::sequenceable_in_place */
     persistent_vector_sequence_ptr next_in_place();
 
-    object base{ object_type::persistent_vector_sequence };
+    object base{ obj_type };
     obj::persistent_vector_ptr vec{};
     size_t index{};
   };

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_vector_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_vector_sequence.hpp
@@ -3,25 +3,22 @@
 #include <jank/runtime/object.hpp>
 #include <jank/runtime/obj/cons.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  namespace obj
-  {
-    using persistent_vector = static_object<object_type::persistent_vector>;
-    using persistent_vector_ptr = native_box<persistent_vector>;
-  }
+  using persistent_vector_ptr = native_box<struct persistent_vector>;
+  using persistent_vector_sequence_ptr = native_box<struct persistent_vector_sequence>;
 
-  template <>
-  struct static_object<object_type::persistent_vector_sequence> : gc
+  struct persistent_vector_sequence : gc
   {
+    static constexpr object_type obj_type{ object_type::persistent_vector_sequence };
     static constexpr native_bool pointer_free{ false };
     static constexpr native_bool is_sequential{ true };
 
-    static_object() = default;
-    static_object(static_object &&) = default;
-    static_object(static_object const &) = default;
-    static_object(obj::persistent_vector_ptr v);
-    static_object(obj::persistent_vector_ptr v, size_t i);
+    persistent_vector_sequence() = default;
+    persistent_vector_sequence(persistent_vector_sequence &&) noexcept = default;
+    persistent_vector_sequence(persistent_vector_sequence const &) = default;
+    persistent_vector_sequence(obj::persistent_vector_ptr v);
+    persistent_vector_sequence(obj::persistent_vector_ptr v, size_t i);
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -34,25 +31,19 @@ namespace jank::runtime
     size_t count() const;
 
     /* behavior::seqable */
-    native_box<static_object> seq();
-    native_box<static_object> fresh_seq() const;
+    persistent_vector_sequence_ptr seq();
+    persistent_vector_sequence_ptr fresh_seq() const;
 
     /* behavior::sequenceable */
     object_ptr first() const;
-    native_box<static_object> next() const;
+    persistent_vector_sequence_ptr next() const;
     obj::cons_ptr conj(object_ptr head);
 
     /* behavior::sequenceable_in_place */
-    native_box<static_object> next_in_place();
+    persistent_vector_sequence_ptr next_in_place();
 
     object base{ object_type::persistent_vector_sequence };
     obj::persistent_vector_ptr vec{};
     size_t index{};
   };
-
-  namespace obj
-  {
-    using persistent_vector_sequence = static_object<object_type::persistent_vector_sequence>;
-    using persistent_vector_sequence_ptr = native_box<persistent_vector_sequence>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_vector_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_vector_sequence.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
 #include <jank/runtime/object.hpp>
-#include <jank/runtime/obj/cons.hpp>
 
 namespace jank::runtime::obj
 {
+  using cons_ptr = native_box<struct cons>;
   using persistent_vector_ptr = native_box<struct persistent_vector>;
   using persistent_vector_sequence_ptr = native_box<struct persistent_vector_sequence>;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/range.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/range.hpp
@@ -5,34 +5,35 @@
 #include <jank/runtime/obj/array_chunk.hpp>
 #include <jank/runtime/obj/cons.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
+  using range_ptr = native_box<struct range>;
+
   /* A range from X to Y, exclusive, incrementing by S. This is for non-integer values.
    * For integer values, use integer_range. This is not countable in constant time, due
    * to floating point shenanigans. */
-  /* TODO: integer_range */
-  template <>
-  struct static_object<object_type::range> : gc
+  struct range : gc
   {
+    static constexpr object_type obj_type{ object_type::range };
     static constexpr native_bool pointer_free{ false };
     static constexpr native_bool is_sequential{ true };
     static constexpr native_integer chunk_size{ 32 };
 
     using bounds_check_t = native_bool (*)(object_ptr, object_ptr);
 
-    static_object() = default;
-    static_object(static_object &&) = default;
-    static_object(static_object const &) = default;
-    static_object(object_ptr end);
-    static_object(object_ptr start, object_ptr end);
-    static_object(object_ptr start, object_ptr end, object_ptr step);
-    static_object(object_ptr start, object_ptr end, object_ptr step, bounds_check_t bounds_check);
-    static_object(object_ptr start,
-                  object_ptr end,
-                  object_ptr step,
-                  bounds_check_t bounds_check,
-                  obj::array_chunk_ptr chunk,
-                  native_box<static_object> chunk_next);
+    range() = default;
+    range(range &&) noexcept = default;
+    range(range const &) = default;
+    range(object_ptr end);
+    range(object_ptr start, object_ptr end);
+    range(object_ptr start, object_ptr end, object_ptr step);
+    range(object_ptr start, object_ptr end, object_ptr step, bounds_check_t bounds_check);
+    range(object_ptr start,
+          object_ptr end,
+          object_ptr step,
+          bounds_check_t bounds_check,
+          obj::array_chunk_ptr chunk,
+          range_ptr chunk_next);
 
     static object_ptr create(object_ptr end);
     static object_ptr create(object_ptr start, object_ptr end);
@@ -46,26 +47,26 @@ namespace jank::runtime
     native_hash to_hash() const;
 
     /* behavior::seqable */
-    native_box<static_object> seq();
-    native_box<static_object> fresh_seq() const;
+    range_ptr seq();
+    range_ptr fresh_seq() const;
 
     /* behavior::sequenceable */
     object_ptr first() const;
-    native_box<static_object> next() const;
+    range_ptr next() const;
 
     /* behavior::sequenceable_in_place */
-    native_box<static_object> next_in_place();
+    range_ptr next_in_place();
 
     /* behavior::chunkable */
     obj::array_chunk_ptr chunked_first() const;
-    native_box<static_object> chunked_next() const;
+    range_ptr chunked_next() const;
     void force_chunk() const;
 
     /* behavior::conjable */
     obj::cons_ptr conj(object_ptr head) const;
 
     /* behavior::metadatable */
-    native_box<static_object> with_meta(object_ptr m) const;
+    range_ptr with_meta(object_ptr m) const;
 
     object base{ object_type::range };
     object_ptr start{};
@@ -73,14 +74,8 @@ namespace jank::runtime
     object_ptr step{};
     bounds_check_t bounds_check{};
     mutable obj::array_chunk_ptr chunk{};
-    mutable native_box<static_object> chunk_next{};
-    mutable native_box<static_object> cached_next{};
+    mutable range_ptr chunk_next{};
+    mutable range_ptr cached_next{};
     option<object_ptr> meta{};
   };
-
-  namespace obj
-  {
-    using range = static_object<object_type::range>;
-    using range_ptr = native_box<range>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/range.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/range.hpp
@@ -42,7 +42,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string();
-    void to_string(fmt::memory_buffer &buff);
+    void to_string(util::string_builder &buff);
     native_persistent_string to_code_string();
     native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/range.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/range.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
 #include <jank/runtime/object.hpp>
-#include <jank/runtime/behavior/seqable.hpp>
-#include <jank/runtime/obj/array_chunk.hpp>
-#include <jank/runtime/obj/cons.hpp>
+#include <jank/option.hpp>
 
 namespace jank::runtime::obj
 {
+  using array_chunk_ptr = native_box<struct array_chunk>;
+  using cons_ptr = native_box<struct cons>;
   using range_ptr = native_box<struct range>;
 
   /* A range from X to Y, exclusive, incrementing by S. This is for non-integer values.

--- a/compiler+runtime/include/cpp/jank/runtime/obj/range.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/range.hpp
@@ -68,7 +68,7 @@ namespace jank::runtime::obj
     /* behavior::metadatable */
     range_ptr with_meta(object_ptr m) const;
 
-    object base{ object_type::range };
+    object base{ obj_type };
     object_ptr start{};
     object_ptr end{};
     object_ptr step{};

--- a/compiler+runtime/include/cpp/jank/runtime/obj/ratio.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/ratio.hpp
@@ -34,7 +34,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/ratio.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/ratio.hpp
@@ -48,7 +48,7 @@ namespace jank::runtime::obj
     native_integer to_integer() const;
     native_real to_real() const;
 
-    object base{ object_type::ratio };
+    object base{ obj_type };
     ratio_data data;
   };
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/ratio.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/ratio.hpp
@@ -1,33 +1,33 @@
 #pragma once
 
 #include <jank/runtime/object.hpp>
-#include <jank/runtime/obj/number.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  namespace obj
+  struct ratio_data
   {
-    struct ratio_data
-    {
-      ratio_data(native_integer const, native_integer const);
-      ratio_data(ratio_data const &) = default;
+    ratio_data(native_integer const, native_integer const);
+    ratio_data(ratio_data const &) = default;
 
-      native_real to_real() const;
-      native_integer to_integer() const;
+    native_real to_real() const;
+    native_integer to_integer() const;
 
-      native_integer numerator{};
-      native_integer denominator{};
-    };
-  }
+    native_integer numerator{};
+    native_integer denominator{};
+  };
 
-  template <>
-  struct static_object<object_type::ratio> : gc
+  using integer_ptr = native_box<struct integer>;
+  using real_ptr = native_box<struct real>;
+  using ratio_ptr = native_box<struct ratio>;
+
+  struct ratio : gc
   {
+    static constexpr object_type obj_type{ object_type::ratio };
     static constexpr native_bool pointer_free{ true };
 
-    static_object(static_object &&) noexcept = default;
-    static_object(static_object const &) = default;
-    static_object(obj::ratio_data const &);
+    ratio(ratio &&) noexcept = default;
+    ratio(ratio const &) = default;
+    ratio(ratio_data const &);
 
     static object_ptr create(native_integer const, native_integer const);
 
@@ -42,105 +42,99 @@ namespace jank::runtime
     native_integer compare(object const &) const;
 
     /* behavior::comparable extended */
-    native_integer compare(static_object const &) const;
+    native_integer compare(ratio const &) const;
 
     /* behavior::number_like */
     native_integer to_integer() const;
     native_real to_real() const;
 
     object base{ object_type::ratio };
-    obj::ratio_data data;
+    ratio_data data;
   };
 
-  namespace obj
-  {
-    using ratio = static_object<object_type::ratio>;
-    using ratio_ptr = native_box<ratio>;
-
-    object_ptr operator+(obj::ratio_data const &l, obj::ratio_data const &r);
-    obj::ratio_ptr operator+(obj::integer_ptr l, obj::ratio_data const &r);
-    obj::ratio_ptr operator+(obj::ratio_data const &l, obj::integer_ptr r);
-    native_real operator+(obj::real_ptr l, obj::ratio_data const &r);
-    native_real operator+(obj::ratio_data const &l, obj::real_ptr r);
-    native_real operator+(obj::ratio_data const &l, native_real r);
-    native_real operator+(native_real l, obj::ratio_data const &r);
-    obj::ratio_ptr operator+(obj::ratio_data const &l, native_integer r);
-    obj::ratio_ptr operator+(native_integer l, obj::ratio_data const &r);
-    object_ptr operator-(obj::ratio_data const &l, obj::ratio_data const &r);
-    obj::ratio_ptr operator-(obj::integer_ptr l, obj::ratio_data const &r);
-    obj::ratio_ptr operator-(obj::ratio_data const &l, obj::integer_ptr r);
-    native_real operator-(obj::real_ptr l, obj::ratio_data const &r);
-    native_real operator-(obj::ratio_data const &l, obj::real_ptr r);
-    native_real operator-(obj::ratio_data const &l, native_real r);
-    native_real operator-(native_real l, obj::ratio_data const &r);
-    obj::ratio_ptr operator-(obj::ratio_data const &l, native_integer r);
-    obj::ratio_ptr operator-(native_integer l, obj::ratio_data const &r);
-    object_ptr operator*(obj::ratio_data const &l, obj::ratio_data const &r);
-    object_ptr operator*(obj::integer_ptr l, obj::ratio_data const &r);
-    object_ptr operator*(obj::ratio_data const &l, obj::integer_ptr r);
-    native_real operator*(obj::real_ptr l, obj::ratio_data const &r);
-    native_real operator*(obj::ratio_data const &l, obj::real_ptr r);
-    native_real operator*(obj::ratio_data const &l, native_real r);
-    native_real operator*(native_real l, obj::ratio_data const &r);
-    object_ptr operator*(obj::ratio_data const &l, native_integer r);
-    object_ptr operator*(native_integer l, obj::ratio_data const &r);
-    object_ptr operator/(obj::ratio_data const &l, obj::ratio_data const &r);
-    object_ptr operator/(obj::integer_ptr l, obj::ratio_data const &r);
-    obj::ratio_ptr operator/(obj::ratio_data const &l, obj::integer_ptr r);
-    native_real operator/(obj::real_ptr l, obj::ratio_data const &r);
-    native_real operator/(obj::ratio_data const &l, obj::real_ptr r);
-    native_real operator/(obj::ratio_data const &l, native_real r);
-    native_real operator/(native_real l, obj::ratio_data const &r);
-    obj::ratio_ptr operator/(obj::ratio_data const &l, native_integer r);
-    object_ptr operator/(native_integer l, obj::ratio_data const &r);
-    native_bool operator==(obj::ratio_data const &l, obj::ratio_data const &r);
-    native_bool operator==(obj::integer_ptr l, obj::ratio_data const &r);
-    native_bool operator==(obj::ratio_data const &l, obj::integer_ptr r);
-    native_bool operator==(obj::real_ptr l, obj::ratio_data const &r);
-    native_bool operator==(obj::ratio_data const &l, obj::real_ptr r);
-    native_bool operator==(obj::ratio_data const &l, native_real r);
-    native_bool operator==(native_real l, obj::ratio_data const &r);
-    native_bool operator==(obj::ratio_data const &l, native_integer r);
-    native_bool operator==(native_integer l, obj::ratio_data const &r);
-    native_bool operator<(obj::ratio_data const &l, obj::ratio_data const &r);
-    native_bool operator<(obj::integer_ptr l, obj::ratio_data const &r);
-    native_bool operator<(obj::ratio_data const &l, obj::integer_ptr r);
-    native_bool operator<(obj::real_ptr l, obj::ratio_data const &r);
-    native_bool operator<(obj::ratio_data const &l, obj::real_ptr r);
-    native_bool operator<(obj::ratio_data const &l, native_real r);
-    native_bool operator<(native_real l, obj::ratio_data const &r);
-    native_bool operator<(obj::ratio_data const &l, native_integer r);
-    native_bool operator<(native_integer l, obj::ratio_data const &r);
-    native_bool operator<(native_bool l, obj::ratio_data const &r);
-    native_bool operator<(obj::ratio_data const &l, native_bool r);
-    native_bool operator<=(obj::ratio_data const &l, obj::ratio_data const &r);
-    native_bool operator<=(obj::integer_ptr l, obj::ratio_data const &r);
-    native_bool operator<=(obj::ratio_data const &l, obj::integer_ptr r);
-    native_bool operator<=(obj::real_ptr l, obj::ratio_data const &r);
-    native_bool operator<=(obj::ratio_data const &l, obj::real_ptr r);
-    native_bool operator<=(obj::ratio_data const &l, native_real r);
-    native_bool operator<=(native_real l, obj::ratio_data const &r);
-    native_bool operator<=(obj::ratio_data const &l, native_integer r);
-    native_bool operator<=(native_integer l, obj::ratio_data const &r);
-    native_bool operator>(obj::ratio_data const &l, obj::ratio_data const &r);
-    native_bool operator>(obj::integer_ptr l, obj::ratio_data const &r);
-    native_bool operator>(obj::ratio_data const &l, obj::integer_ptr r);
-    native_bool operator>(obj::real_ptr l, obj::ratio_data const &r);
-    native_bool operator>(obj::ratio_data const &l, obj::real_ptr r);
-    native_bool operator>(obj::ratio_data const &l, native_real r);
-    native_bool operator>(native_real l, obj::ratio_data const &r);
-    native_bool operator>(obj::ratio_data const &l, native_integer r);
-    native_bool operator>(native_integer l, obj::ratio_data const &r);
-    native_bool operator>(native_bool l, obj::ratio_data const &r);
-    native_bool operator>(obj::ratio_data const &l, native_bool r);
-    native_bool operator>=(obj::ratio_data const &l, obj::ratio_data const &r);
-    native_bool operator>=(obj::integer_ptr l, obj::ratio_data const &r);
-    native_bool operator>=(obj::ratio_data const &l, obj::integer_ptr r);
-    native_bool operator>=(obj::real_ptr l, obj::ratio_data const &r);
-    native_bool operator>=(obj::ratio_data const &l, obj::real_ptr r);
-    native_bool operator>=(obj::ratio_data const &l, native_real r);
-    native_bool operator>=(native_real l, obj::ratio_data const &r);
-    native_bool operator>=(obj::ratio_data const &l, native_integer r);
-    native_bool operator>=(native_integer l, obj::ratio_data const &r);
-  }
+  object_ptr operator+(ratio_data const &l, ratio_data const &r);
+  ratio_ptr operator+(integer_ptr l, ratio_data const &r);
+  ratio_ptr operator+(ratio_data const &l, integer_ptr r);
+  native_real operator+(real_ptr l, ratio_data const &r);
+  native_real operator+(ratio_data const &l, real_ptr r);
+  native_real operator+(ratio_data const &l, native_real r);
+  native_real operator+(native_real l, ratio_data const &r);
+  ratio_ptr operator+(ratio_data const &l, native_integer r);
+  ratio_ptr operator+(native_integer l, ratio_data const &r);
+  object_ptr operator-(ratio_data const &l, ratio_data const &r);
+  ratio_ptr operator-(integer_ptr l, ratio_data const &r);
+  ratio_ptr operator-(ratio_data const &l, integer_ptr r);
+  native_real operator-(real_ptr l, ratio_data const &r);
+  native_real operator-(ratio_data const &l, real_ptr r);
+  native_real operator-(ratio_data const &l, native_real r);
+  native_real operator-(native_real l, ratio_data const &r);
+  ratio_ptr operator-(ratio_data const &l, native_integer r);
+  ratio_ptr operator-(native_integer l, ratio_data const &r);
+  object_ptr operator*(ratio_data const &l, ratio_data const &r);
+  object_ptr operator*(integer_ptr l, ratio_data const &r);
+  object_ptr operator*(ratio_data const &l, integer_ptr r);
+  native_real operator*(real_ptr l, ratio_data const &r);
+  native_real operator*(ratio_data const &l, real_ptr r);
+  native_real operator*(ratio_data const &l, native_real r);
+  native_real operator*(native_real l, ratio_data const &r);
+  object_ptr operator*(ratio_data const &l, native_integer r);
+  object_ptr operator*(native_integer l, ratio_data const &r);
+  object_ptr operator/(ratio_data const &l, ratio_data const &r);
+  object_ptr operator/(integer_ptr l, ratio_data const &r);
+  ratio_ptr operator/(ratio_data const &l, integer_ptr r);
+  native_real operator/(real_ptr l, ratio_data const &r);
+  native_real operator/(ratio_data const &l, real_ptr r);
+  native_real operator/(ratio_data const &l, native_real r);
+  native_real operator/(native_real l, ratio_data const &r);
+  ratio_ptr operator/(ratio_data const &l, native_integer r);
+  object_ptr operator/(native_integer l, ratio_data const &r);
+  native_bool operator==(ratio_data const &l, ratio_data const &r);
+  native_bool operator==(integer_ptr l, ratio_data const &r);
+  native_bool operator==(ratio_data const &l, integer_ptr r);
+  native_bool operator==(real_ptr l, ratio_data const &r);
+  native_bool operator==(ratio_data const &l, real_ptr r);
+  native_bool operator==(ratio_data const &l, native_real r);
+  native_bool operator==(native_real l, ratio_data const &r);
+  native_bool operator==(ratio_data const &l, native_integer r);
+  native_bool operator==(native_integer l, ratio_data const &r);
+  native_bool operator<(ratio_data const &l, ratio_data const &r);
+  native_bool operator<(integer_ptr l, ratio_data const &r);
+  native_bool operator<(ratio_data const &l, integer_ptr r);
+  native_bool operator<(real_ptr l, ratio_data const &r);
+  native_bool operator<(ratio_data const &l, real_ptr r);
+  native_bool operator<(ratio_data const &l, native_real r);
+  native_bool operator<(native_real l, ratio_data const &r);
+  native_bool operator<(ratio_data const &l, native_integer r);
+  native_bool operator<(native_integer l, ratio_data const &r);
+  native_bool operator<(native_bool l, ratio_data const &r);
+  native_bool operator<(ratio_data const &l, native_bool r);
+  native_bool operator<=(ratio_data const &l, ratio_data const &r);
+  native_bool operator<=(integer_ptr l, ratio_data const &r);
+  native_bool operator<=(ratio_data const &l, integer_ptr r);
+  native_bool operator<=(real_ptr l, ratio_data const &r);
+  native_bool operator<=(ratio_data const &l, real_ptr r);
+  native_bool operator<=(ratio_data const &l, native_real r);
+  native_bool operator<=(native_real l, ratio_data const &r);
+  native_bool operator<=(ratio_data const &l, native_integer r);
+  native_bool operator<=(native_integer l, ratio_data const &r);
+  native_bool operator>(ratio_data const &l, ratio_data const &r);
+  native_bool operator>(integer_ptr l, ratio_data const &r);
+  native_bool operator>(ratio_data const &l, integer_ptr r);
+  native_bool operator>(real_ptr l, ratio_data const &r);
+  native_bool operator>(ratio_data const &l, real_ptr r);
+  native_bool operator>(ratio_data const &l, native_real r);
+  native_bool operator>(native_real l, ratio_data const &r);
+  native_bool operator>(ratio_data const &l, native_integer r);
+  native_bool operator>(native_integer l, ratio_data const &r);
+  native_bool operator>(native_bool l, ratio_data const &r);
+  native_bool operator>(ratio_data const &l, native_bool r);
+  native_bool operator>=(ratio_data const &l, ratio_data const &r);
+  native_bool operator>=(integer_ptr l, ratio_data const &r);
+  native_bool operator>=(ratio_data const &l, integer_ptr r);
+  native_bool operator>=(real_ptr l, ratio_data const &r);
+  native_bool operator>=(ratio_data const &l, real_ptr r);
+  native_bool operator>=(ratio_data const &l, native_real r);
+  native_bool operator>=(native_real l, ratio_data const &r);
+  native_bool operator>=(ratio_data const &l, native_integer r);
+  native_bool operator>=(native_integer l, ratio_data const &r);
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/reduced.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/reduced.hpp
@@ -2,15 +2,17 @@
 
 #include <jank/runtime/object.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  template <>
-  struct static_object<object_type::reduced> : gc
+  using reduced_ptr = native_box<struct reduced>;
+
+  struct reduced : gc
   {
+    static constexpr object_type obj_type{ object_type::reduced };
     static constexpr native_bool pointer_free{ false };
 
-    static_object() = default;
-    static_object(object_ptr o);
+    reduced() = default;
+    reduced(object_ptr o);
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -25,10 +27,4 @@ namespace jank::runtime
     object base{ object_type::reduced };
     object_ptr val{};
   };
-
-  namespace obj
-  {
-    using reduced = static_object<object_type::reduced>;
-    using reduced_ptr = native_box<reduced>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/reduced.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/reduced.hpp
@@ -24,7 +24,7 @@ namespace jank::runtime::obj
     /* behavior::derefable */
     object_ptr deref() const;
 
-    object base{ object_type::reduced };
+    object base{ obj_type };
     object_ptr val{};
   };
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/reduced.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/reduced.hpp
@@ -17,7 +17,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/repeat.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/repeat.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <jank/runtime/object.hpp>
-#include <jank/runtime/obj/cons.hpp>
-#include <jank/runtime/behavior/seqable.hpp>
+#include <jank/option.hpp>
 
 namespace jank::runtime::obj
 {
+  using cons_ptr = native_box<struct cons>;
   using repeat_ptr = native_box<struct repeat>;
 
   struct repeat : gc

--- a/compiler+runtime/include/cpp/jank/runtime/obj/repeat.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/repeat.hpp
@@ -4,18 +4,20 @@
 #include <jank/runtime/obj/cons.hpp>
 #include <jank/runtime/behavior/seqable.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  template <>
-  struct static_object<object_type::repeat> : gc
+  using repeat_ptr = native_box<struct repeat>;
+
+  struct repeat : gc
   {
+    static constexpr object_type obj_type{ object_type::repeat };
     static constexpr native_bool pointer_free{ false };
     static constexpr native_bool is_sequential{ true };
     static constexpr native_integer infinite{ -1 };
 
-    static_object() = default;
-    static_object(object_ptr value);
-    static_object(object_ptr count, object_ptr value);
+    repeat() = default;
+    repeat(object_ptr value);
+    repeat(object_ptr count, object_ptr value);
 
     static object_ptr create(object_ptr value);
     static object_ptr create(object_ptr count, object_ptr value);
@@ -28,31 +30,25 @@ namespace jank::runtime
     native_hash to_hash() const;
 
     /* behavior::seqable */
-    native_box<static_object> seq();
-    native_box<static_object> fresh_seq() const;
+    repeat_ptr seq();
+    repeat_ptr fresh_seq() const;
 
     /* behavior::sequenceable */
     object_ptr first() const;
-    native_box<static_object> next() const;
+    repeat_ptr next() const;
 
     /* behavior::sequenceable_in_place */
-    native_box<static_object> next_in_place();
+    repeat_ptr next_in_place();
 
     /* behavior::conjable */
     obj::cons_ptr conj(object_ptr head) const;
 
     /* behavior::metadatable */
-    native_box<static_object> with_meta(object_ptr m) const;
+    repeat_ptr with_meta(object_ptr m) const;
 
     object base{ object_type::repeat };
     object_ptr value{};
     object_ptr count{};
     option<object_ptr> meta{};
   };
-
-  namespace obj
-  {
-    using repeat = static_object<object_type::repeat>;
-    using repeat_ptr = native_box<repeat>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/repeat.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/repeat.hpp
@@ -25,7 +25,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string();
-    void to_string(fmt::memory_buffer &buff);
+    void to_string(util::string_builder &buff);
     native_persistent_string to_code_string();
     native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/repeat.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/repeat.hpp
@@ -46,7 +46,7 @@ namespace jank::runtime::obj
     /* behavior::metadatable */
     repeat_ptr with_meta(object_ptr m) const;
 
-    object base{ object_type::repeat };
+    object base{ obj_type };
     object_ptr value{};
     object_ptr count{};
     option<object_ptr> meta{};

--- a/compiler+runtime/include/cpp/jank/runtime/obj/symbol.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/symbol.hpp
@@ -3,33 +3,28 @@
 #include <jank/runtime/object.hpp>
 #include <jank/option.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  namespace obj
-  {
-    using persistent_array_map = static_object<object_type::persistent_array_map>;
-    using persistent_array_map_ptr = native_box<persistent_array_map>;
-  }
+  using persistent_array_map_ptr = native_box<struct persistent_array_map>;
+  using symbol_ptr = native_box<struct symbol>;
 
-  template <>
-  struct static_object<object_type::symbol> : gc
+  struct symbol : gc
   {
+    static constexpr object_type obj_type{ object_type::symbol };
     static constexpr native_bool pointer_free{ false };
 
-    static_object() = default;
-    static_object(static_object &&) = default;
-    static_object(static_object const &) = default;
-    static_object(native_persistent_string const &d);
-    static_object(native_persistent_string &&d);
-    static_object(native_persistent_string const &ns, native_persistent_string const &n);
-    static_object(native_persistent_string &&ns, native_persistent_string &&n);
-    static_object(native_persistent_string const &ns,
-                  native_persistent_string const &n,
-                  object_ptr meta);
-    static_object(object_ptr ns, object_ptr n);
+    symbol() = default;
+    symbol(symbol &&) noexcept = default;
+    symbol(symbol const &) = default;
+    symbol(native_persistent_string const &d);
+    symbol(native_persistent_string &&d);
+    symbol(native_persistent_string const &ns, native_persistent_string const &n);
+    symbol(native_persistent_string &&ns, native_persistent_string &&n);
+    symbol(native_persistent_string const &ns, native_persistent_string const &n, object_ptr meta);
+    symbol(object_ptr ns, object_ptr n);
 
-    static_object &operator=(static_object const &) = default;
-    static_object &operator=(static_object &&) = default;
+    symbol &operator=(symbol const &) = default;
+    symbol &operator=(symbol &&) = default;
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -39,23 +34,23 @@ namespace jank::runtime
     native_hash to_hash() const;
 
     /* behavior::object_like extended */
-    native_bool equal(static_object const &) const;
+    native_bool equal(symbol const &) const;
 
     /* behavior::comparable */
     native_integer compare(object const &) const;
 
     /* behavior::comparable extended */
-    native_integer compare(static_object const &) const;
+    native_integer compare(symbol const &) const;
 
     /* behavior::metadatable */
-    native_box<static_object> with_meta(object_ptr m) const;
+    symbol_ptr with_meta(object_ptr m) const;
 
     /* behavior::nameable */
     native_persistent_string const &get_name() const;
     native_persistent_string const &get_namespace() const;
 
-    native_bool operator==(static_object const &rhs) const;
-    native_bool operator<(static_object const &rhs) const;
+    native_bool operator==(symbol const &rhs) const;
+    native_bool operator<(symbol const &rhs) const;
 
     void set_ns(native_persistent_string const &);
     void set_name(native_persistent_string const &);
@@ -69,12 +64,6 @@ namespace jank::runtime
     option<object_ptr> meta;
     mutable native_hash hash{};
   };
-
-  namespace obj
-  {
-    using symbol = static_object<object_type::symbol>;
-    using symbol_ptr = native_box<symbol>;
-  }
 }
 
 namespace std

--- a/compiler+runtime/include/cpp/jank/runtime/obj/symbol.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/symbol.hpp
@@ -29,7 +29,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/symbol.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/symbol.hpp
@@ -55,7 +55,7 @@ namespace jank::runtime::obj
     void set_ns(native_persistent_string const &);
     void set_name(native_persistent_string const &);
 
-    object base{ object_type::symbol };
+    object base{ obj_type };
 
     /* These require mutation fns, since changing them will affect the hash. */
     native_persistent_string ns;

--- a/compiler+runtime/include/cpp/jank/runtime/obj/transient_hash_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/transient_hash_map.hpp
@@ -3,27 +3,26 @@
 #include <jank/runtime/object.hpp>
 #include <jank/runtime/detail/type.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  template <>
-  struct static_object<object_type::transient_hash_map> : gc
+  using transient_hash_map_ptr = native_box<struct transient_hash_map>;
+
+  struct transient_hash_map : gc
   {
+    static constexpr object_type obj_type{ object_type::transient_hash_map };
     static constexpr bool pointer_free{ false };
 
-    using value_type = detail::native_transient_hash_map;
-    using persistent_type = static_object<object_type::persistent_hash_map>;
+    using value_type = runtime::detail::native_transient_hash_map;
+    using persistent_type_ptr = native_box<struct persistent_hash_map>;
 
-    static_object() = default;
-    static_object(static_object &&) noexcept = default;
-    static_object(static_object const &) = default;
-    static_object(detail::native_persistent_hash_map const &d);
-    static_object(detail::native_persistent_hash_map &&d);
-    static_object(value_type &&d);
+    transient_hash_map() = default;
+    transient_hash_map(transient_hash_map &&) noexcept = default;
+    transient_hash_map(transient_hash_map const &) = default;
+    transient_hash_map(runtime::detail::native_persistent_hash_map const &d);
+    transient_hash_map(runtime::detail::native_persistent_hash_map &&d);
+    transient_hash_map(value_type &&d);
 
-    static native_box<static_object> empty()
-    {
-      return make_box<static_object>();
-    }
+    static transient_hash_map_ptr empty();
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -42,14 +41,14 @@ namespace jank::runtime
     native_bool contains(object_ptr key) const;
 
     /* behavior::associatively_writable_in_place */
-    native_box<static_object> assoc_in_place(object_ptr const key, object_ptr const val);
-    native_box<static_object> dissoc_in_place(object_ptr const key);
+    transient_hash_map_ptr assoc_in_place(object_ptr const key, object_ptr const val);
+    transient_hash_map_ptr dissoc_in_place(object_ptr const key);
 
     /* behavior::conjable_in_place */
-    native_box<static_object> conj_in_place(object_ptr head);
+    transient_hash_map_ptr conj_in_place(object_ptr head);
 
     /* behavior::persistentable */
-    native_box<persistent_type> to_persistent();
+    persistent_type_ptr to_persistent();
 
     /* behavior::callable */
     object_ptr call(object_ptr) const;
@@ -62,10 +61,4 @@ namespace jank::runtime
     mutable native_hash hash{};
     native_bool active{ true };
   };
-
-  namespace obj
-  {
-    using transient_hash_map = static_object<object_type::transient_hash_map>;
-    using transient_hash_map_ptr = native_box<transient_hash_map>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/transient_hash_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/transient_hash_map.hpp
@@ -27,7 +27,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/transient_hash_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/transient_hash_map.hpp
@@ -56,7 +56,7 @@ namespace jank::runtime::obj
 
     void assert_active() const;
 
-    object base{ object_type::transient_hash_map };
+    object base{ obj_type };
     value_type data;
     mutable native_hash hash{};
     native_bool active{ true };

--- a/compiler+runtime/include/cpp/jank/runtime/obj/transient_hash_set.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/transient_hash_set.hpp
@@ -3,27 +3,26 @@
 #include <jank/runtime/object.hpp>
 #include <jank/runtime/detail/type.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  template <>
-  struct static_object<object_type::transient_hash_set> : gc
+  using transient_hash_set_ptr = native_box<struct transient_hash_set>;
+
+  struct transient_hash_set : gc
   {
+    static constexpr object_type obj_type{ object_type::transient_hash_set };
     static constexpr bool pointer_free{ false };
 
-    using value_type = detail::native_transient_hash_set;
-    using persistent_type = static_object<object_type::persistent_hash_set>;
+    using value_type = runtime::detail::native_transient_hash_set;
+    using persistent_type_ptr = native_box<struct persistent_hash_set>;
 
-    static_object() = default;
-    static_object(static_object &&) noexcept = default;
-    static_object(static_object const &) = default;
-    static_object(detail::native_persistent_hash_set const &d);
-    static_object(detail::native_persistent_hash_set &&d);
-    static_object(value_type &&d);
+    transient_hash_set() = default;
+    transient_hash_set(transient_hash_set &&) noexcept = default;
+    transient_hash_set(transient_hash_set const &) = default;
+    transient_hash_set(runtime::detail::native_persistent_hash_set const &d);
+    transient_hash_set(runtime::detail::native_persistent_hash_set &&d);
+    transient_hash_set(value_type &&d);
 
-    static native_box<static_object> empty()
-    {
-      return make_box<static_object>();
-    }
+    static transient_hash_set_ptr empty();
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -36,10 +35,10 @@ namespace jank::runtime
     size_t count() const;
 
     /* behavior::conjable_in_place */
-    native_box<static_object> conj_in_place(object_ptr elem);
+    transient_hash_set_ptr conj_in_place(object_ptr elem);
 
     /* behavior::persistentable */
-    native_box<persistent_type> to_persistent();
+    persistent_type_ptr to_persistent();
 
     /* behavior::callable */
     object_ptr call(object_ptr const) const;
@@ -51,7 +50,7 @@ namespace jank::runtime
     object_ptr get_entry(object_ptr const elem) const;
     native_bool contains(object_ptr const elem) const;
 
-    native_box<static_object> disjoin_in_place(object_ptr const elem);
+    transient_hash_set_ptr disjoin_in_place(object_ptr const elem);
 
     void assert_active() const;
 
@@ -60,10 +59,4 @@ namespace jank::runtime
     mutable native_hash hash{};
     native_bool active{ true };
   };
-
-  namespace obj
-  {
-    using transient_hash_set = static_object<object_type::transient_hash_set>;
-    using transient_hash_set_ptr = native_box<transient_hash_set>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/transient_hash_set.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/transient_hash_set.hpp
@@ -27,7 +27,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/transient_hash_set.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/transient_hash_set.hpp
@@ -54,7 +54,7 @@ namespace jank::runtime::obj
 
     void assert_active() const;
 
-    object base{ object_type::transient_hash_set };
+    object base{ obj_type };
     value_type data;
     mutable native_hash hash{};
     native_bool active{ true };

--- a/compiler+runtime/include/cpp/jank/runtime/obj/transient_sorted_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/transient_sorted_map.hpp
@@ -56,7 +56,7 @@ namespace jank::runtime::obj
 
     void assert_active() const;
 
-    object base{ object_type::transient_sorted_map };
+    object base{ obj_type };
     value_type data;
     mutable native_hash hash{};
     native_bool active{ true };

--- a/compiler+runtime/include/cpp/jank/runtime/obj/transient_sorted_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/transient_sorted_map.hpp
@@ -27,7 +27,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/transient_sorted_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/transient_sorted_map.hpp
@@ -3,27 +3,26 @@
 #include <jank/runtime/object.hpp>
 #include <jank/runtime/detail/type.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  template <>
-  struct static_object<object_type::transient_sorted_map> : gc
+  using transient_sorted_map_ptr = native_box<struct transient_sorted_map>;
+
+  struct transient_sorted_map : gc
   {
+    static constexpr object_type obj_type{ object_type::transient_sorted_map };
     static constexpr bool pointer_free{ false };
 
-    using value_type = detail::native_transient_sorted_map;
-    using persistent_type = static_object<object_type::persistent_sorted_map>;
+    using value_type = runtime::detail::native_transient_sorted_map;
+    using persistent_type_ptr = native_box<struct persistent_sorted_map>;
 
-    static_object() = default;
-    static_object(static_object &&) noexcept = default;
-    static_object(static_object const &) = default;
-    static_object(detail::native_persistent_sorted_map const &d);
-    static_object(detail::native_persistent_sorted_map &&d);
-    static_object(value_type &&d);
+    transient_sorted_map() = default;
+    transient_sorted_map(transient_sorted_map &&) noexcept = default;
+    transient_sorted_map(transient_sorted_map const &) = default;
+    transient_sorted_map(runtime::detail::native_persistent_sorted_map const &d);
+    transient_sorted_map(runtime::detail::native_persistent_sorted_map &&d);
+    transient_sorted_map(value_type &&d);
 
-    static native_box<static_object> empty()
-    {
-      return make_box<static_object>();
-    }
+    static transient_sorted_map_ptr empty();
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -42,14 +41,14 @@ namespace jank::runtime
     native_bool contains(object_ptr key) const;
 
     /* behavior::associatively_writable_in_place */
-    native_box<static_object> assoc_in_place(object_ptr const key, object_ptr const val);
-    native_box<static_object> dissoc_in_place(object_ptr const key);
+    transient_sorted_map_ptr assoc_in_place(object_ptr const key, object_ptr const val);
+    transient_sorted_map_ptr dissoc_in_place(object_ptr const key);
 
     /* behavior::conjable_in_place */
-    native_box<static_object> conj_in_place(object_ptr head);
+    transient_sorted_map_ptr conj_in_place(object_ptr head);
 
     /* behavior::persistentable */
-    native_box<persistent_type> to_persistent();
+    persistent_type_ptr to_persistent();
 
     /* behavior::callable */
     object_ptr call(object_ptr) const;
@@ -62,10 +61,4 @@ namespace jank::runtime
     mutable native_hash hash{};
     native_bool active{ true };
   };
-
-  namespace obj
-  {
-    using transient_sorted_map = static_object<object_type::transient_sorted_map>;
-    using transient_sorted_map_ptr = native_box<transient_sorted_map>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/transient_sorted_set.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/transient_sorted_set.hpp
@@ -27,7 +27,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/transient_sorted_set.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/transient_sorted_set.hpp
@@ -3,27 +3,26 @@
 #include <jank/runtime/object.hpp>
 #include <jank/runtime/detail/type.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  template <>
-  struct static_object<object_type::transient_sorted_set> : gc
+  using transient_sorted_set_ptr = native_box<struct transient_sorted_set>;
+
+  struct transient_sorted_set : gc
   {
+    static constexpr object_type obj_type{ object_type::transient_sorted_set };
     static constexpr bool pointer_free{ false };
 
-    using value_type = detail::native_transient_sorted_set;
-    using persistent_type = static_object<object_type::persistent_sorted_set>;
+    using value_type = runtime::detail::native_transient_sorted_set;
+    using persistent_type_ptr = native_box<struct persistent_sorted_set>;
 
-    static_object() = default;
-    static_object(static_object &&) noexcept = default;
-    static_object(static_object const &) = default;
-    static_object(detail::native_persistent_sorted_set const &d);
-    static_object(detail::native_persistent_sorted_set &&d);
-    static_object(value_type &&d);
+    transient_sorted_set() = default;
+    transient_sorted_set(transient_sorted_set &&) noexcept = default;
+    transient_sorted_set(transient_sorted_set const &) = default;
+    transient_sorted_set(runtime::detail::native_persistent_sorted_set const &d);
+    transient_sorted_set(runtime::detail::native_persistent_sorted_set &&d);
+    transient_sorted_set(value_type &&d);
 
-    static native_box<static_object> empty()
-    {
-      return make_box<static_object>();
-    }
+    static transient_sorted_set_ptr empty();
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -36,10 +35,10 @@ namespace jank::runtime
     size_t count() const;
 
     /* behavior::conjable_in_place */
-    native_box<static_object> conj_in_place(object_ptr elem);
+    transient_sorted_set_ptr conj_in_place(object_ptr elem);
 
     /* behavior::persistentable */
-    native_box<persistent_type> to_persistent();
+    persistent_type_ptr to_persistent();
 
     /* behavior::callable */
     object_ptr call(object_ptr const);
@@ -51,7 +50,7 @@ namespace jank::runtime
     object_ptr get_entry(object_ptr const elem);
     native_bool contains(object_ptr const elem) const;
 
-    native_box<static_object> disjoin_in_place(object_ptr const elem);
+    transient_sorted_set_ptr disjoin_in_place(object_ptr const elem);
 
     void assert_active() const;
 
@@ -60,10 +59,4 @@ namespace jank::runtime
     mutable native_hash hash{};
     native_bool active{ true };
   };
-
-  namespace obj
-  {
-    using transient_sorted_set = static_object<object_type::transient_sorted_set>;
-    using transient_sorted_set_ptr = native_box<transient_sorted_set>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/transient_sorted_set.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/transient_sorted_set.hpp
@@ -54,7 +54,7 @@ namespace jank::runtime::obj
 
     void assert_active() const;
 
-    object base{ object_type::transient_sorted_set };
+    object base{ obj_type };
     value_type data;
     mutable native_hash hash{};
     native_bool active{ true };

--- a/compiler+runtime/include/cpp/jank/runtime/obj/transient_vector.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/transient_vector.hpp
@@ -3,27 +3,26 @@
 #include <jank/runtime/object.hpp>
 #include <jank/runtime/detail/type.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  template <>
-  struct static_object<object_type::transient_vector> : gc
+  using transient_vector_ptr = native_box<struct transient_vector>;
+
+  struct transient_vector : gc
   {
+    static constexpr object_type obj_type{ object_type::transient_vector };
     static constexpr bool pointer_free{ false };
 
-    using value_type = detail::native_transient_vector;
-    using persistent_type = static_object<object_type::persistent_vector>;
+    using value_type = runtime::detail::native_transient_vector;
+    using persistent_type_ptr = native_box<struct persistent_vector>;
 
-    static_object() = default;
-    static_object(static_object &&) noexcept = default;
-    static_object(static_object const &) = default;
-    static_object(detail::native_persistent_vector const &d);
-    static_object(detail::native_persistent_vector &&d);
-    static_object(value_type &&d);
+    transient_vector() = default;
+    transient_vector(transient_vector &&) noexcept = default;
+    transient_vector(transient_vector const &) = default;
+    transient_vector(runtime::detail::native_persistent_vector const &d);
+    transient_vector(runtime::detail::native_persistent_vector &&d);
+    transient_vector(value_type &&d);
 
-    static native_box<static_object> empty()
-    {
-      return make_box<static_object>();
-    }
+    static transient_vector_ptr empty();
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -36,10 +35,10 @@ namespace jank::runtime
     size_t count() const;
 
     /* behavior::conjable_in_place */
-    native_box<static_object> conj_in_place(object_ptr head);
+    transient_vector_ptr conj_in_place(object_ptr head);
 
     /* behavior::persistentable */
-    native_box<persistent_type> to_persistent();
+    persistent_type_ptr to_persistent();
 
     /* behavior::callable */
     object_ptr call(object_ptr const) const;
@@ -50,7 +49,7 @@ namespace jank::runtime
     object_ptr get_entry(object_ptr const idx) const;
     native_bool contains(object_ptr const elem) const;
 
-    native_box<static_object> pop_in_place();
+    transient_vector_ptr pop_in_place();
 
     void assert_active() const;
 
@@ -59,10 +58,4 @@ namespace jank::runtime
     mutable native_hash hash{};
     native_bool active{ true };
   };
-
-  namespace obj
-  {
-    using transient_vector = static_object<object_type::transient_vector>;
-    using transient_vector_ptr = native_box<transient_vector>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/transient_vector.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/transient_vector.hpp
@@ -27,7 +27,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/transient_vector.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/transient_vector.hpp
@@ -53,7 +53,7 @@ namespace jank::runtime::obj
 
     void assert_active() const;
 
-    object base{ object_type::transient_vector };
+    object base{ obj_type };
     value_type data;
     mutable native_hash hash{};
     native_bool active{ true };

--- a/compiler+runtime/include/cpp/jank/runtime/obj/volatile.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/volatile.hpp
@@ -2,15 +2,17 @@
 
 #include <jank/runtime/object.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  template <>
-  struct static_object<object_type::volatile_> : gc
+  using volatile_ptr = native_box<struct volatile_>;
+
+  struct volatile_ : gc
   {
+    static constexpr object_type obj_type{ object_type::volatile_ };
     static constexpr native_bool pointer_free{ false };
 
-    static_object() = default;
-    static_object(object_ptr o);
+    volatile_() = default;
+    volatile_(object_ptr o);
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -27,10 +29,4 @@ namespace jank::runtime
     object base{ object_type::volatile_ };
     object_ptr val{};
   };
-
-  namespace obj
-  {
-    using volatile_ = static_object<object_type::volatile_>;
-    using volatile_ptr = native_box<volatile_>;
-  }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/volatile.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/volatile.hpp
@@ -26,7 +26,7 @@ namespace jank::runtime::obj
 
     object_ptr reset(object_ptr o);
 
-    object base{ object_type::volatile_ };
+    object base{ obj_type };
     object_ptr val{};
   };
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/volatile.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/volatile.hpp
@@ -17,7 +17,7 @@ namespace jank::runtime::obj
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/object.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/object.hpp
@@ -54,6 +54,7 @@ namespace jank::runtime
     cons,
     lazy_sequence,
     range,
+    integer_range,
     repeat,
     iterator,
     native_array_sequence,
@@ -160,6 +161,8 @@ namespace jank::runtime
         return "lazy_sequence";
       case object_type::range:
         return "range";
+      case object_type::integer_range:
+        return "integer_range";
       case object_type::repeat:
         return "repeat";
       case object_type::iterator:

--- a/compiler+runtime/include/cpp/jank/runtime/object.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/object.hpp
@@ -86,17 +86,10 @@ namespace jank::runtime
   {
     object_type type{};
   };
-
-  template <object_type T>
-  struct static_object;
 }
-
-#include <jank/runtime/native_box.hpp>
 
 namespace jank::runtime
 {
-  using object_ptr = native_box<object>;
-
   namespace behavior
   {
     /* Every object implements this behavior and it's the only behavior in common with
@@ -104,6 +97,8 @@ namespace jank::runtime
      * instead just be a part of this. */
     template <typename T>
     concept object_like = requires(T * const t) {
+      { T::obj_type } -> std::convertible_to<object_type>;
+
       /* Determines is the specified object is equal, but not necessarily identical, to
        * the current object. Identical means having the same address, the same identity.
        * Equal just means having equal values. Equivalent means having equal values of the
@@ -128,10 +123,17 @@ namespace jank::runtime
       /* Every object needs to have this base field, which is the actual object field.
        * When we pass around object pointers, we pass around pointers to this field within
        * the overall object. This field stores the type of the object and we use that
-       * type to shift the object pointer and cast it into the fully typed static_object. */
+       * type to shift the object pointer and cast it into the fully typed object. */
       { t->base } -> std::same_as<object &>;
     };
   }
+}
+
+#include <jank/runtime/native_box.hpp>
+
+namespace jank::runtime
+{
+  using object_ptr = native_box<object>;
 
   /* This isn't a great name, but it represents more than just value equality, since it
    * also includes type equality. Otherwise, [] equals '(). This is important when deduping

--- a/compiler+runtime/include/cpp/jank/runtime/object.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/object.hpp
@@ -82,51 +82,175 @@ namespace jank::runtime
     var_unbound_root,
   };
 
+  constexpr char const *object_type_str(object_type const type)
+  {
+    switch(type)
+    {
+      case object_type::nil:
+        return "nil";
+
+      case object_type::boolean:
+        return "boolean";
+      case object_type::integer:
+        return "integer";
+      case object_type::real:
+        return "real";
+      case object_type::ratio:
+        return "ratio";
+
+      case object_type::persistent_string:
+        return "persistent_string";
+      case object_type::persistent_string_sequence:
+        return "persistent_string_sequence";
+
+      case object_type::keyword:
+        return "keyword";
+      case object_type::symbol:
+        return "symbol";
+      case object_type::character:
+        return "character";
+
+      case object_type::persistent_list:
+        return "persistent_list";
+      case object_type::persistent_list_sequence:
+        return "persistent_list_sequence";
+
+      case object_type::persistent_vector:
+        return "persistent_vector";
+      case object_type::transient_vector:
+        return "transient_vector";
+      case object_type::persistent_vector_sequence:
+        return "persistent_vector_sequence";
+
+      case object_type::persistent_array_map:
+        return "persistent_array_map";
+      case object_type::persistent_array_map_sequence:
+        return "persistent_array_map_sequence";
+
+      case object_type::persistent_hash_map:
+        return "persistent_hash_map";
+      case object_type::transient_hash_map:
+        return "transient_hash_map";
+      case object_type::persistent_hash_map_sequence:
+        return "persistent_hash_map_sequence";
+
+      case object_type::persistent_sorted_map:
+        return "persistent_sorted_map";
+      case object_type::transient_sorted_map:
+        return "transient_sorted_map";
+      case object_type::persistent_sorted_map_sequence:
+        return "persistent_sorted_map_sequence";
+
+      case object_type::persistent_hash_set:
+        return "persistent_hash_set";
+      case object_type::transient_hash_set:
+        return "transient_hash_set";
+      case object_type::persistent_hash_set_sequence:
+        return "persistent_hash_set_sequence";
+
+      case object_type::persistent_sorted_set:
+        return "persistent_sorted_set";
+      case object_type::transient_sorted_set:
+        return "transient_sorted_set";
+      case object_type::persistent_sorted_set_sequence:
+        return "persistent_sorted_set_sequence";
+
+      case object_type::cons:
+        return "cons";
+      case object_type::lazy_sequence:
+        return "lazy_sequence";
+      case object_type::range:
+        return "range";
+      case object_type::repeat:
+        return "repeat";
+      case object_type::iterator:
+        return "iterator";
+      case object_type::native_array_sequence:
+        return "native_array_sequence";
+      case object_type::native_vector_sequence:
+        return "native_vector_sequence";
+
+      case object_type::chunk_buffer:
+        return "chunk_buffer";
+      case object_type::array_chunk:
+        return "array_chunk";
+      case object_type::chunked_cons:
+        return "chunked_cons";
+
+      case object_type::native_function_wrapper:
+        return "native_function_wrapper";
+      case object_type::jit_function:
+        return "jit_function";
+      case object_type::jit_closure:
+        return "jit_closure";
+      case object_type::multi_function:
+        return "multi_function";
+
+      case object_type::native_pointer_wrapper:
+        return "native_pointer_wrapper";
+
+      case object_type::atom:
+        return "atom";
+      case object_type::volatile_:
+        return "volatile_";
+      case object_type::reduced:
+        return "reduced";
+      case object_type::delay:
+        return "delay";
+      case object_type::ns:
+        return "ns";
+
+      case object_type::var:
+        return "var";
+      case object_type::var_thread_binding:
+        return "var_thread_binding";
+      case object_type::var_unbound_root:
+        return "var_unbound_root";
+    }
+  }
+
   struct object
   {
     object_type type{};
   };
 }
 
-namespace jank::runtime
+namespace jank::runtime::behavior
 {
-  namespace behavior
-  {
-    /* Every object implements this behavior and it's the only behavior in common with
-     * every object. If there's any other behavior which every object must have, it should
-     * instead just be a part of this. */
-    template <typename T>
-    concept object_like = requires(T * const t) {
-      { T::obj_type } -> std::convertible_to<object_type>;
+  /* Every object implements this behavior and it's the only behavior in common with
+   * every object. If there's any other behavior which every object must have, it should
+   * instead just be a part of this. */
+  template <typename T>
+  concept object_like = requires(T * const t) {
+    { T::obj_type } -> std::convertible_to<object_type>;
 
-      /* Determines is the specified object is equal, but not necessarily identical, to
-       * the current object. Identical means having the same address, the same identity.
-       * Equal just means having equal values. Equivalent means having equal values of the
-       * same type. :O Here, we're just focused on equality. */
-      { t->equal(std::declval<object const &>()) } -> std::convertible_to<native_bool>;
+    /* Determines is the specified object is equal, but not necessarily identical, to
+     * the current object. Identical means having the same address, the same identity.
+     * Equal just means having equal values. Equivalent means having equal values of the
+     * same type. :O Here, we're just focused on equality. */
+    { t->equal(std::declval<object const &>()) } -> std::convertible_to<native_bool>;
 
-      /* Returns a string version of the object, generally for printing or displaying. This
-       * is distinct from its code representation, which doesn't yet have a corresponding
-       * function in this behavior. */
-      { t->to_string() } -> std::convertible_to<native_persistent_string>;
-      { t->to_string(std::declval<fmt::memory_buffer &>()) } -> std::same_as<void>;
+    /* Returns a string version of the object, generally for printing or displaying. This
+     * is distinct from its code representation, which doesn't yet have a corresponding
+     * function in this behavior. */
+    { t->to_string() } -> std::convertible_to<native_persistent_string>;
+    { t->to_string(std::declval<fmt::memory_buffer &>()) } -> std::same_as<void>;
 
-      /* Returns the code representation of the object. */
-      { t->to_code_string() } -> std::convertible_to<native_persistent_string>;
+    /* Returns the code representation of the object. */
+    { t->to_code_string() } -> std::convertible_to<native_persistent_string>;
 
-      /* Returns a deterministic hash value for the object. For some objects, like functions
-       * and transients, the hash is actually just the object's address. For others, it's
-       * based on the value, or values, within the object. There are a set of hash functions
-       * which should be used for this in hash.hpp. */
-      { t->to_hash() } -> std::convertible_to<native_integer>;
+    /* Returns a deterministic hash value for the object. For some objects, like functions
+     * and transients, the hash is actually just the object's address. For others, it's
+     * based on the value, or values, within the object. There are a set of hash functions
+     * which should be used for this in hash.hpp. */
+    { t->to_hash() } -> std::convertible_to<native_integer>;
 
-      /* Every object needs to have this base field, which is the actual object field.
-       * When we pass around object pointers, we pass around pointers to this field within
-       * the overall object. This field stores the type of the object and we use that
-       * type to shift the object pointer and cast it into the fully typed object. */
-      { t->base } -> std::same_as<object &>;
-    };
-  }
+    /* Every object needs to have this base field, which is the actual object field.
+     * When we pass around object pointers, we pass around pointers to this field within
+     * the overall object. This field stores the type of the object and we use that
+     * type to shift the object pointer and cast it into the fully typed object. */
+    { t->base } -> std::same_as<object &>;
+  };
 }
 
 #include <jank/runtime/native_box.hpp>

--- a/compiler+runtime/include/cpp/jank/runtime/object.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/object.hpp
@@ -2,9 +2,8 @@
 
 #include <concepts>
 
-#include <fmt/format.h>
-
 #include <jank/type.hpp>
+#include <jank/util/string_builder.hpp>
 
 /* TODO: Move to obj namespace */
 namespace jank::runtime
@@ -207,6 +206,7 @@ namespace jank::runtime
       case object_type::var_unbound_root:
         return "var_unbound_root";
     }
+    return "unknown";
   }
 
   struct object
@@ -234,7 +234,7 @@ namespace jank::runtime::behavior
      * is distinct from its code representation, which doesn't yet have a corresponding
      * function in this behavior. */
     { t->to_string() } -> std::convertible_to<native_persistent_string>;
-    { t->to_string(std::declval<fmt::memory_buffer &>()) } -> std::same_as<void>;
+    { t->to_string(std::declval<util::string_builder &>()) } -> std::same_as<void>;
 
     /* Returns the code representation of the object. */
     { t->to_code_string() } -> std::convertible_to<native_persistent_string>;

--- a/compiler+runtime/include/cpp/jank/runtime/rtti.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/rtti.hpp
@@ -62,14 +62,18 @@ namespace jank::runtime
   template <typename T>
   requires behavior::object_like<T>
   [[gnu::always_inline, gnu::flatten, gnu::hot]]
-  constexpr native_box<T> try_object(object const * const o)
+  native_box<T> try_object(object const * const o)
   {
     assert(o);
     if(o->type != T::obj_type)
     {
-      throw std::runtime_error{ fmt::format("invalid object type (expected {}, found {})",
-                                            object_type_str(T::obj_type),
-                                            object_type_str(o->type)) };
+      util::string_builder sb;
+      sb("invalid object type (expected ");
+      sb(object_type_str(T::obj_type));
+      sb(" found ");
+      sb(object_type_str(o->type));
+      sb(")");
+      throw std::runtime_error{ sb.str() };
     }
     return reinterpret_cast<T *>(reinterpret_cast<char *>(const_cast<object *>(o))
                                  - offsetof(T, base));

--- a/compiler+runtime/include/cpp/jank/runtime/rtti.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/rtti.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <magic_enum.hpp>
-
 #include <jank/runtime/object.hpp>
 
 namespace jank::runtime
@@ -70,8 +68,8 @@ namespace jank::runtime
     if(o->type != T::obj_type)
     {
       throw std::runtime_error{ fmt::format("invalid object type (expected {}, found {})",
-                                            magic_enum::enum_name(T::obj_type),
-                                            magic_enum::enum_name(o->type)) };
+                                            object_type_str(T::obj_type),
+                                            object_type_str(o->type)) };
     }
     return reinterpret_cast<T *>(reinterpret_cast<char *>(const_cast<object *>(o))
                                  - offsetof(T, base));

--- a/compiler+runtime/include/cpp/jank/runtime/rtti.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/rtti.hpp
@@ -6,18 +6,6 @@
 
 namespace jank::runtime
 {
-  namespace detail
-  {
-    template <typename T>
-    struct object_type_to_enum;
-
-    template <object_type O>
-    struct object_type_to_enum<static_object<O>>
-    {
-      static constexpr object_type value{ O };
-    };
-  }
-
   /* Most of the system is polymorphic using type-erased objects. Given any object, an erase call
    * will get you what you need. If you don't need to type-erase, though, don't! */
   template <typename T>
@@ -56,7 +44,7 @@ namespace jank::runtime
   constexpr native_box<T> isa(object const * const o)
   {
     assert(o);
-    return o->type == detail::object_type_to_enum<T>::value;
+    return o->type == T::obj_type;
   }
 
   template <typename T>
@@ -65,7 +53,7 @@ namespace jank::runtime
   constexpr native_box<T> dyn_cast(object const * const o)
   {
     assert(o);
-    if(o->type != detail::object_type_to_enum<T>::value)
+    if(o->type != T::obj_type)
     {
       return nullptr;
     }
@@ -79,12 +67,11 @@ namespace jank::runtime
   constexpr native_box<T> try_object(object const * const o)
   {
     assert(o);
-    if(o->type != detail::object_type_to_enum<T>::value)
+    if(o->type != T::obj_type)
     {
-      throw std::runtime_error{ fmt::format(
-        "invalid object type (expected {}, found {})",
-        magic_enum::enum_name(detail::object_type_to_enum<T>::value),
-        magic_enum::enum_name(o->type)) };
+      throw std::runtime_error{ fmt::format("invalid object type (expected {}, found {})",
+                                            magic_enum::enum_name(T::obj_type),
+                                            magic_enum::enum_name(o->type)) };
     }
     return reinterpret_cast<T *>(reinterpret_cast<char *>(const_cast<object *>(o))
                                  - offsetof(T, base));
@@ -99,7 +86,7 @@ namespace jank::runtime
   constexpr native_box<T> expect_object(object_ptr const o)
   {
     assert(o);
-    assert(o->type == detail::object_type_to_enum<T>::value);
+    assert(o->type == T::obj_type);
     return reinterpret_cast<T *>(reinterpret_cast<char *>(o.data) - offsetof(T, base));
   }
 
@@ -109,7 +96,7 @@ namespace jank::runtime
   constexpr native_box<T> expect_object(object const * const o)
   {
     assert(o);
-    assert(o->type == detail::object_type_to_enum<T>::value);
+    assert(o->type == T::obj_type);
     return reinterpret_cast<T *>(reinterpret_cast<char *>(const_cast<object *>(o))
                                  - offsetof(T, base));
   }

--- a/compiler+runtime/include/cpp/jank/runtime/var.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/var.hpp
@@ -38,7 +38,7 @@ namespace jank::runtime
     native_bool equal(object const &) const;
     native_persistent_string to_string() const;
     native_persistent_string to_code_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_hash to_hash() const;
 
     /* behavior::object_like extended */
@@ -92,7 +92,7 @@ namespace jank::runtime
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;
 
@@ -116,7 +116,7 @@ namespace jank::runtime
     /* behavior::object_like */
     native_bool equal(object const &) const;
     native_persistent_string to_string() const;
-    void to_string(fmt::memory_buffer &buff) const;
+    void to_string(util::string_builder &buff) const;
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/var.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/var.hpp
@@ -67,7 +67,7 @@ namespace jank::runtime
 
     var_ptr clone() const;
 
-    object base{ object_type::var };
+    object base{ obj_type };
     ns_ptr n{};
     /* Unqualified. */
     obj::symbol_ptr name{};
@@ -96,7 +96,7 @@ namespace jank::runtime
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;
 
-    object base{ object_type::var_thread_binding };
+    object base{ obj_type };
     object_ptr value{};
     std::thread::id thread_id;
   };
@@ -120,7 +120,7 @@ namespace jank::runtime
     native_persistent_string to_code_string() const;
     native_hash to_hash() const;
 
-    object base{ object_type::var_unbound_root };
+    object base{ obj_type };
     var_ptr var{};
   };
 }

--- a/compiler+runtime/include/cpp/jank/runtime/var.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/var.hpp
@@ -4,9 +4,9 @@
 
 #include <folly/Synchronized.h>
 
-#include <jank/runtime/obj/symbol.hpp>
-#include <jank/runtime/obj/persistent_hash_map.hpp>
 #include <jank/result.hpp>
+#include <jank/runtime/object.hpp>
+#include <jank/runtime/obj/symbol.hpp>
 
 namespace jank::runtime
 {
@@ -14,6 +14,11 @@ namespace jank::runtime
   using var_ptr = native_box<struct var>;
   using var_thread_binding_ptr = native_box<struct var_thread_binding>;
   using var_unbound_root_ptr = native_box<struct var_unbound_root>;
+
+  namespace obj
+  {
+    using persistent_hash_map_ptr = native_box<struct persistent_hash_map>;
+  }
 
   struct var : gc
   {

--- a/compiler+runtime/include/cpp/jank/runtime/var.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/var.hpp
@@ -10,22 +10,24 @@
 
 namespace jank::runtime
 {
-  using ns = static_object<object_type::ns>;
-  using ns_ptr = native_box<ns>;
+  using ns_ptr = native_box<struct ns>;
+  using var_ptr = native_box<struct var>;
+  using var_thread_binding_ptr = native_box<struct var_thread_binding>;
+  using var_unbound_root_ptr = native_box<struct var_unbound_root>;
 
-  template <>
-  struct static_object<object_type::var> : gc
+  struct var : gc
   {
+    static constexpr object_type obj_type{ object_type::var };
     static constexpr native_bool pointer_free{ false };
 
-    static_object() = delete;
-    static_object(ns_ptr const &n, obj::symbol_ptr const &name);
-    static_object(ns_ptr const &n, obj::symbol_ptr const &name, object_ptr root);
-    static_object(ns_ptr const &n,
-                  obj::symbol_ptr const &name,
-                  object_ptr const root,
-                  native_bool dynamic,
-                  native_bool thread_bound);
+    var() = delete;
+    var(ns_ptr const &n, obj::symbol_ptr const &name);
+    var(ns_ptr const &n, obj::symbol_ptr const &name, object_ptr root);
+    var(ns_ptr const &n,
+        obj::symbol_ptr const &name,
+        object_ptr const root,
+        native_bool dynamic,
+        native_bool thread_bound);
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -35,30 +37,30 @@ namespace jank::runtime
     native_hash to_hash() const;
 
     /* behavior::object_like extended */
-    native_bool equal(static_object const &) const;
+    native_bool equal(var const &) const;
 
     /* behavior::metadatable */
-    native_box<static_object> with_meta(object_ptr m);
+    var_ptr with_meta(object_ptr m);
 
     native_bool is_bound() const;
     object_ptr get_root() const;
     /* Binding a root changes it for all threads. */
-    native_box<static_object> bind_root(object_ptr r);
+    var_ptr bind_root(object_ptr r);
     object_ptr alter_root(object_ptr f, object_ptr args);
     /* Setting a var does not change its root, it only affects the current thread
      * binding. If there is no thread binding, a var cannot be set. */
     string_result<void> set(object_ptr r) const;
 
-    native_box<static_object> set_dynamic(native_bool dyn);
+    var_ptr set_dynamic(native_bool dyn);
 
-    native_box<static_object<object_type::var_thread_binding>> get_thread_binding() const;
+    var_thread_binding_ptr get_thread_binding() const;
 
     /* behavior::derefable */
     object_ptr deref() const;
 
-    native_bool operator==(static_object const &rhs) const;
+    native_bool operator==(var const &rhs) const;
 
-    native_box<static_object> clone() const;
+    var_ptr clone() const;
 
     object base{ object_type::var };
     ns_ptr n{};
@@ -75,15 +77,12 @@ namespace jank::runtime
     std::atomic_bool thread_bound{ false };
   };
 
-  using var = static_object<object_type::var>;
-  using var_ptr = native_box<var>;
-
-  template <>
-  struct static_object<object_type::var_thread_binding> : gc
+  struct var_thread_binding : gc
   {
+    static constexpr object_type obj_type{ object_type::var_thread_binding };
     static constexpr native_bool pointer_free{ false };
 
-    static_object(object_ptr value, std::thread::id id);
+    var_thread_binding(object_ptr value, std::thread::id id);
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -97,20 +96,17 @@ namespace jank::runtime
     std::thread::id thread_id;
   };
 
-  using var_thread_binding = static_object<object_type::var_thread_binding>;
-  using var_thread_binding_ptr = native_box<var_thread_binding>;
-
   struct thread_binding_frame
   {
     obj::persistent_hash_map_ptr bindings{};
   };
 
-  template <>
-  struct static_object<object_type::var_unbound_root> : gc
+  struct var_unbound_root : gc
   {
+    static constexpr object_type obj_type{ object_type::var_unbound_root };
     static constexpr native_bool pointer_free{ true };
 
-    static_object(var_ptr var);
+    var_unbound_root(var_ptr var);
 
     /* behavior::object_like */
     native_bool equal(object const &) const;
@@ -122,9 +118,6 @@ namespace jank::runtime
     object base{ object_type::var_unbound_root };
     var_ptr var{};
   };
-
-  using var_unbound_root = static_object<object_type::var_unbound_root>;
-  using var_unbound_root_ptr = native_box<var_unbound_root>;
 }
 
 namespace std

--- a/compiler+runtime/include/cpp/jank/runtime/visit.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/visit.hpp
@@ -50,6 +50,7 @@
 #include <jank/runtime/ns.hpp>
 #include <jank/runtime/var.hpp>
 #include <jank/runtime/rtti.hpp>
+#include <jank/runtime/core/to_string.hpp>
 
 namespace jank::runtime
 {

--- a/compiler+runtime/include/cpp/jank/runtime/visit.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/visit.hpp
@@ -348,7 +348,7 @@ namespace jank::runtime
       default:
         {
           throw std::runtime_error{ fmt::format("invalid object type: {} raw value {}",
-                                                magic_enum::enum_name(erased->type),
+                                                object_type_str(erased->type),
                                                 static_cast<int>(erased->type)) };
         }
         break;

--- a/compiler+runtime/include/cpp/jank/runtime/visit.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/visit.hpp
@@ -68,7 +68,7 @@ namespace jank::runtime
   template <typename F, typename... Args>
   requires visitable<F, Args...>
   [[gnu::hot]]
-  constexpr auto visit_object(F const &fn, object const * const const_erased, Args &&...args)
+  auto visit_object(F const &fn, object const * const const_erased, Args &&...args)
   {
     assert(const_erased);
     auto * const erased(const_cast<object *>(const_erased));
@@ -348,9 +348,12 @@ namespace jank::runtime
         break;
       default:
         {
-          throw std::runtime_error{ fmt::format("invalid object type: {} raw value {}",
-                                                object_type_str(erased->type),
-                                                static_cast<int>(erased->type)) };
+          util::string_builder sb;
+          sb("invalid object type: ");
+          sb(object_type_str(erased->type));
+          sb(" raw value ");
+          sb(static_cast<int>(erased->type));
+          throw std::runtime_error{ sb.str() };
         }
         break;
     }

--- a/compiler+runtime/include/cpp/jank/runtime/visit.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/visit.hpp
@@ -29,6 +29,7 @@
 #include <jank/runtime/obj/array_chunk.hpp>
 #include <jank/runtime/obj/chunked_cons.hpp>
 #include <jank/runtime/obj/range.hpp>
+#include <jank/runtime/obj/integer_range.hpp>
 #include <jank/runtime/obj/repeat.hpp>
 #include <jank/runtime/obj/ratio.hpp>
 #include <jank/runtime/obj/jit_function.hpp>
@@ -201,6 +202,11 @@ namespace jank::runtime
       case object_type::range:
         {
           return fn(expect_object<obj::range>(erased), std::forward<Args>(args)...);
+        }
+        break;
+      case object_type::integer_range:
+        {
+          return fn(expect_object<obj::integer_range>(erased), std::forward<Args>(args)...);
         }
         break;
       case object_type::repeat:
@@ -454,6 +460,11 @@ namespace jank::runtime
       case object_type::range:
         {
           return fn(expect_object<obj::range>(erased), std::forward<Args>(args)...);
+        }
+        break;
+      case object_type::integer_range:
+        {
+          return fn(expect_object<obj::integer_range>(erased), std::forward<Args>(args)...);
         }
         break;
       case object_type::repeat:

--- a/compiler+runtime/include/cpp/jank/runtime/visit.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/visit.hpp
@@ -360,7 +360,7 @@ namespace jank::runtime
   [[gnu::hot]]
   constexpr auto visit_type(F const &fn, object const * const const_erased, Args &&...args)
   {
-    if(const_erased->type == detail::object_type_to_enum<T>::value)
+    if(const_erased->type == T::obj_type)
     {
       return fn(expect_object<T>(const_erased), std::forward<Args>(args)...);
     }

--- a/compiler+runtime/include/cpp/jank/util/escape.hpp
+++ b/compiler+runtime/include/cpp/jank/util/escape.hpp
@@ -66,9 +66,14 @@ namespace jank::util
     return escape_view<native_persistent_string_view>{ sv, q, e };
   }
 
+  struct unescape_error
+  {
+    native_persistent_string message;
+  };
+
   /* These provide normal escaping/unescaping, with no quoting. */
-  string_result<native_transient_string> unescape(native_transient_string const &input);
-  native_transient_string escape(native_transient_string const &input);
+  result<native_persistent_string, unescape_error> unescape(native_persistent_string const &input);
+  native_persistent_string escape(native_persistent_string const &input);
 }
 
 template <typename S>

--- a/compiler+runtime/include/cpp/jank/util/escape.hpp
+++ b/compiler+runtime/include/cpp/jank/util/escape.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <fmt/base.h>
+
 #include <jank/native_persistent_string.hpp>
 #include <jank/result.hpp>
 

--- a/compiler+runtime/include/cpp/jank/util/escape.hpp
+++ b/compiler+runtime/include/cpp/jank/util/escape.hpp
@@ -6,12 +6,12 @@
 namespace jank::util
 {
   /* This provides a fmt extension for escaping strings and wrapping them in
-  * quotes. It's largely adapted from here:
-  * https://github.com/fmtlib/fmt/issues/825#issuecomment-1227501168
-  *
-  * Usage just looks like:
-  * fmt::format("{}", util::escaped_quoted_view(s))
-  */
+   * quotes. It's largely adapted from here:
+   * https://github.com/fmtlib/fmt/issues/825#issuecomment-1227501168
+   *
+   * Usage just looks like:
+   * fmt::format("{}", util::escaped_quoted_view(s))
+   */
   template <typename S = native_persistent_string_view>
   struct escape_view
   {

--- a/compiler+runtime/include/cpp/jank/util/string_builder.hpp
+++ b/compiler+runtime/include/cpp/jank/util/string_builder.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <jank/runtime/object.hpp>
+
+namespace jank::util
+{
+  struct string_builder
+  {
+    static constexpr size_t initial_capacity{ 32 };
+
+    using value_type = char;
+    using traits_type = std::char_traits<value_type>;
+
+    string_builder();
+    string_builder(size_t capacity);
+    ~string_builder();
+
+    string_builder &operator()(native_bool d) &;
+    string_builder &operator()(native_integer d) &;
+    string_builder &operator()(native_real d) &;
+    string_builder &operator()(native_hash d) &;
+    string_builder &operator()(void const *d) &;
+    string_builder &operator()(int d) &;
+    string_builder &operator()(size_t d) &;
+    string_builder &operator()(char d) &;
+    string_builder &operator()(char32_t d) &;
+    string_builder &operator()(char const *d) &;
+    string_builder &operator()(native_transient_string const &d) &;
+    string_builder &operator()(native_persistent_string const &d) &;
+
+    void push_back(native_bool d) &;
+    void push_back(native_integer d) &;
+    void push_back(native_real d) &;
+    void push_back(native_hash d) &;
+    void push_back(void const *d) &;
+    void push_back(int d) &;
+    void push_back(size_t d) &;
+    void push_back(char d) &;
+    void push_back(char32_t d) &;
+    void push_back(char const *d) &;
+    void push_back(native_transient_string const &d) &;
+    void push_back(native_persistent_string const &d) &;
+
+    void reserve(size_t capacity);
+    value_type *data() const;
+    size_t size() const;
+
+    native_persistent_string release();
+    native_transient_string str() const;
+    native_persistent_string_view view() const &;
+
+    value_type *buffer{};
+    size_t pos{};
+    size_t capacity{ initial_capacity };
+  };
+}

--- a/compiler+runtime/src/cpp/clojure/core_native.cpp
+++ b/compiler+runtime/src/cpp/clojure/core_native.cpp
@@ -711,6 +711,27 @@ jank_object_ptr jank_load_clojure_core_native()
     fn->arity_0 = []() -> object * {
       return iterate(__rt_ctx->intern_var("clojure.core", "inc").expect_ok()->deref(), make_box(0));
     };
+    fn->arity_1 = [](object * const end) -> object * {
+      return obj::integer_range::create(try_object<obj::integer>(end));
+    };
+    fn->arity_2 = [](object * const start, object * const end) -> object * {
+      return obj::integer_range::create(try_object<obj::integer>(start),
+                                        try_object<obj::integer>(end));
+    };
+    fn->arity_3 = [](object * const start, object * const end, object * const step) -> object * {
+      return obj::integer_range::create(try_object<obj::integer>(start),
+                                        try_object<obj::integer>(end),
+                                        try_object<obj::integer>(step));
+    };
+    intern_fn_obj("integer-range", fn);
+  }
+
+  {
+    auto const fn(
+      make_box<obj::jit_function>(behavior::callable::build_arity_flags(3, false, false)));
+    fn->arity_0 = []() -> object * {
+      return iterate(__rt_ctx->intern_var("clojure.core", "inc").expect_ok()->deref(), make_box(0));
+    };
     fn->arity_2
       = [](object * const coll, object * const index) -> object * { return nth(coll, index); };
     fn->arity_3

--- a/compiler+runtime/src/cpp/clojure/core_native.cpp
+++ b/compiler+runtime/src/cpp/clojure/core_native.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include <jank/native_persistent_string/fmt.hpp>
 #include <clojure/core_native.hpp>
 #include <jank/runtime/convert.hpp>

--- a/compiler+runtime/src/cpp/clojure/core_native.cpp
+++ b/compiler+runtime/src/cpp/clojure/core_native.cpp
@@ -44,7 +44,7 @@ namespace clojure::core_native
         }
         else if constexpr(std::same_as<T, obj::keyword>)
         {
-          return make_box<obj::symbol>(typed_o->sym);
+          return typed_o->sym;
         }
         else
         {

--- a/compiler+runtime/src/cpp/clojure/core_native.cpp
+++ b/compiler+runtime/src/cpp/clojure/core_native.cpp
@@ -1,3 +1,4 @@
+#include <jank/native_persistent_string/fmt.hpp>
 #include <clojure/core_native.hpp>
 #include <jank/runtime/convert.hpp>
 #include <jank/runtime/core.hpp>

--- a/compiler+runtime/src/cpp/jank/analyze/local_frame.cpp
+++ b/compiler+runtime/src/cpp/jank/analyze/local_frame.cpp
@@ -278,7 +278,7 @@ namespace jank::analyze
       make_box("__type"),
       make_box("local_frame"),
       make_box("type"),
-      make_box(magic_enum::enum_name(type)),
+      make_box(frame_type_str(type)),
       make_box("parent"),
       jank::detail::to_runtime_data(parent),
       make_box("locals"),

--- a/compiler+runtime/src/cpp/jank/analyze/local_frame.cpp
+++ b/compiler+runtime/src/cpp/jank/analyze/local_frame.cpp
@@ -2,6 +2,7 @@
 
 #include <fmt/core.h>
 
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/context.hpp>
 #include <jank/runtime/visit.hpp>
 #include <jank/runtime/core/munge.hpp>

--- a/compiler+runtime/src/cpp/jank/analyze/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/analyze/processor.cpp
@@ -4,6 +4,7 @@
 
 #include <fmt/core.h>
 
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/visit.hpp>
 #include <jank/runtime/context.hpp>
 #include <jank/runtime/behavior/number_like.hpp>

--- a/compiler+runtime/src/cpp/jank/analyze/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/analyze/processor.cpp
@@ -478,7 +478,8 @@ namespace jank::analyze
     }
 
     auto const meta(runtime::obj::persistent_hash_map::create_unique(
-      std::make_pair(rt_ctx.intern_keyword("source").expect_ok(), make_box(full_list->to_string())),
+      std::make_pair(rt_ctx.intern_keyword("source").expect_ok(),
+                     make_box(full_list->to_code_string())),
       std::make_pair(
         rt_ctx.intern_keyword("name").expect_ok(),
         make_box(runtime::obj::symbol{ runtime::__rt_ctx->current_ns()->to_string(), name }

--- a/compiler+runtime/src/cpp/jank/analyze/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/analyze/processor.cpp
@@ -95,7 +95,7 @@ namespace jank::analyze
     {
       /* TODO: Error handling. */
       return err(error{ fmt::format("invalid def: name must be a symbol, not {}",
-                                    magic_enum::enum_name(sym_obj->type)) });
+                                    object_type_str(sym_obj->type)) });
     }
 
     auto const sym(runtime::expect_object<runtime::obj::symbol>(sym_obj));
@@ -1538,7 +1538,7 @@ namespace jank::analyze
         else
         {
           std::cerr << fmt::format("unsupported analysis of type {} with value {}\n",
-                                   magic_enum::enum_name(typed_o->base.type),
+                                   object_type_str(typed_o->base.type),
                                    typed_o->to_string());
           return err(error{ "unimplemented analysis" });
         }

--- a/compiler+runtime/src/cpp/jank/codegen/llvm_processor.cpp
+++ b/compiler+runtime/src/cpp/jank/codegen/llvm_processor.cpp
@@ -9,6 +9,7 @@
 #include <llvm/Transforms/Scalar/Reassociate.h>
 #include <llvm/Transforms/Scalar/SimplifyCFG.h>
 
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/codegen/llvm_processor.hpp>
 #include <jank/runtime/context.hpp>
 #include <jank/runtime/core.hpp>

--- a/compiler+runtime/src/cpp/jank/codegen/llvm_processor.cpp
+++ b/compiler+runtime/src/cpp/jank/codegen/llvm_processor.cpp
@@ -1205,8 +1205,8 @@ namespace jank::codegen
                                 false));
       auto const create_fn(ctx->module->getOrInsertFunction("jank_keyword_intern", create_fn_type));
 
-      llvm::SmallVector<llvm::Value *, 2> const args{ gen_global(make_box(k->sym.ns)),
-                                                      gen_global(make_box(k->sym.name)) };
+      llvm::SmallVector<llvm::Value *, 2> const args{ gen_global(make_box(k->sym->ns)),
+                                                      gen_global(make_box(k->sym->name)) };
       auto const call(ctx->builder->CreateCall(create_fn, args));
       ctx->builder->CreateStore(call, global);
 

--- a/compiler+runtime/src/cpp/jank/codegen/llvm_processor.cpp
+++ b/compiler+runtime/src/cpp/jank/codegen/llvm_processor.cpp
@@ -9,6 +9,8 @@
 #include <llvm/Transforms/Scalar/Reassociate.h>
 #include <llvm/Transforms/Scalar/SimplifyCFG.h>
 
+#include <fmt/format.h>
+
 #include <jank/native_persistent_string/fmt.hpp>
 #include <jank/codegen/llvm_processor.hpp>
 #include <jank/runtime/context.hpp>

--- a/compiler+runtime/src/cpp/jank/compiler_native.cpp
+++ b/compiler+runtime/src/cpp/jank/compiler_native.cpp
@@ -25,6 +25,7 @@ namespace jank::compiler_native
     codegen::llvm_processor cg_prc{ wrapped_expr, module, codegen::compilation_target::eval };
     cg_prc.gen().expect_ok();
 
+    /* TODO: Return a string, don't print it. */
     cg_prc.ctx->module->print(llvm::outs(), nullptr);
     return obj::nil::nil_const();
   }

--- a/compiler+runtime/src/cpp/jank/compiler_native.cpp
+++ b/compiler+runtime/src/cpp/jank/compiler_native.cpp
@@ -3,6 +3,8 @@
 #include <jank/runtime/context.hpp>
 #include <jank/runtime/core/munge.hpp>
 #include <jank/runtime/obj/native_function_wrapper.hpp>
+#include <jank/runtime/obj/persistent_hash_map.hpp>
+#include <jank/runtime/obj/keyword.hpp>
 #include <jank/evaluate.hpp>
 #include <jank/codegen/llvm_processor.hpp>
 

--- a/compiler+runtime/src/cpp/jank/evaluate.cpp
+++ b/compiler+runtime/src/cpp/jank/evaluate.cpp
@@ -430,7 +430,7 @@ namespace jank::evaluate
     if(expr.data->type == object_type::keyword)
     {
       auto const d(expect_object<obj::keyword>(expr.data));
-      return __rt_ctx->intern_keyword(d->sym.ns, d->sym.name).expect_ok();
+      return __rt_ctx->intern_keyword(d->sym->ns, d->sym->name).expect_ok();
     }
     return expr.data;
   }

--- a/compiler+runtime/src/cpp/jank/evaluate.cpp
+++ b/compiler+runtime/src/cpp/jank/evaluate.cpp
@@ -1,5 +1,6 @@
 #include <llvm/ExecutionEngine/Orc/LLJIT.h>
 
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/context.hpp>
 #include <jank/runtime/ns.hpp>
 #include <jank/runtime/visit.hpp>

--- a/compiler+runtime/src/cpp/jank/evaluate.cpp
+++ b/compiler+runtime/src/cpp/jank/evaluate.cpp
@@ -208,11 +208,16 @@ namespace jank::evaluate
       auto &body(fn.arities[0].body.values);
       /* We normally wrap one expression, which is a return statement, but we'll be potentially
        * adding more, so let's not make assumptions yet. */
-      body[0]->get_base()->position = expression_position::statement;
+      body[0]->propagate_position(expression_position::statement);
 
-      for(auto const &expr : exprs)
+      if(exprs.size() > 1)
       {
-        body.emplace_back(expr);
+        for(auto it(exprs.begin() + 1); it != exprs.end(); ++it)
+        {
+          auto &expr(*it);
+          expr->propagate_position(expression_position::statement);
+          body.emplace_back(expr);
+        }
       }
 
       /* Finally, mark the last body item as our return. */

--- a/compiler+runtime/src/cpp/jank/evaluate.cpp
+++ b/compiler+runtime/src/cpp/jank/evaluate.cpp
@@ -1,5 +1,7 @@
 #include <llvm/ExecutionEngine/Orc/LLJIT.h>
 
+#include <fmt/format.h>
+
 #include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/context.hpp>
 #include <jank/runtime/ns.hpp>

--- a/compiler+runtime/src/cpp/jank/hash.cpp
+++ b/compiler+runtime/src/cpp/jank/hash.cpp
@@ -1,5 +1,6 @@
 #include <jank/hash.hpp>
 #include <jank/runtime/visit.hpp>
+#include <jank/runtime/core/seq.hpp>
 
 namespace jank::hash
 {

--- a/compiler+runtime/src/cpp/jank/jit/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/jit/processor.cpp
@@ -107,7 +107,7 @@ namespace jank::jit
       args.emplace_back(strdup(fmt::format("-D{}", define_macro).c_str()));
     }
 
-    // fmt::println("jit flags {}", args);
+    //fmt::println("jit flags {}", args);
 
     clang::IncrementalCompilerBuilder compiler_builder;
     compiler_builder.SetCompilerArgs(args);

--- a/compiler+runtime/src/cpp/jank/jit/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/jit/processor.cpp
@@ -10,6 +10,7 @@
 
 #include <fmt/ranges.h>
 
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/util/process_location.hpp>
 #include <jank/util/make_array.hpp>
 #include <jank/util/dir.hpp>

--- a/compiler+runtime/src/cpp/jank/perf_native.cpp
+++ b/compiler+runtime/src/cpp/jank/perf_native.cpp
@@ -4,6 +4,8 @@
 #include <jank/runtime/core/munge.hpp>
 #include <jank/runtime/perf.hpp>
 #include <jank/runtime/obj/native_function_wrapper.hpp>
+#include <jank/runtime/obj/persistent_hash_map.hpp>
+#include <jank/runtime/obj/keyword.hpp>
 
 jank_object_ptr jank_load_jank_perf_native()
 {

--- a/compiler+runtime/src/cpp/jank/profile/time.cpp
+++ b/compiler+runtime/src/cpp/jank/profile/time.cpp
@@ -1,3 +1,8 @@
+#include <fstream>
+
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
 #include <jank/profile/time.hpp>
 
 namespace jank::profile

--- a/compiler+runtime/src/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/src/cpp/jank/read/lex.cpp
@@ -1,8 +1,6 @@
 #include <iostream>
 #include <iomanip>
 
-#include <magic_enum.hpp>
-
 #include <jank/read/lex.hpp>
 
 using namespace std::string_view_literals;
@@ -201,8 +199,8 @@ namespace jank::read
 
     std::ostream &operator<<(std::ostream &os, token const &t)
     {
-      return os << "token(" << t.pos << ", " << t.size << ", " << magic_enum::enum_name(t.kind)
-                << ", " << t.data << ")";
+      return os << "token(" << t.pos << ", " << t.size << ", " << token_kind_str(t.kind) << ", "
+                << t.data << ")";
     }
 
     std::ostream &operator<<(std::ostream &os, token::no_data const &)

--- a/compiler+runtime/src/cpp/jank/read/parse.cpp
+++ b/compiler+runtime/src/cpp/jank/read/parse.cpp
@@ -1,5 +1,6 @@
 #include <codecvt>
 
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/read/parse.hpp>
 #include <jank/util/escape.hpp>
 #include <jank/runtime/visit.hpp>

--- a/compiler+runtime/src/cpp/jank/read/parse.cpp
+++ b/compiler+runtime/src/cpp/jank/read/parse.cpp
@@ -1,7 +1,5 @@
 #include <codecvt>
 
-#include <magic_enum.hpp>
-
 #include <jank/read/parse.hpp>
 #include <jank/util/escape.hpp>
 #include <jank/runtime/visit.hpp>
@@ -275,7 +273,7 @@ namespace jank::read::parse
           {
             return err(error{
               latest_token.pos,
-              fmt::format("unexpected token kind: {}", magic_enum::enum_name(latest_token.kind)) });
+              fmt::format("unexpected token kind: {}", lex::token_kind_str(latest_token.kind)) });
           }
       }
     }
@@ -1028,7 +1026,7 @@ namespace jank::read::parse
           else
           {
             return err(fmt::format("unsupported collection type: {}",
-                                   magic_enum::enum_name(typed_form->base.type)));
+                                   object_type_str(typed_form->base.type)));
           }
         },
         /* For anything else, do nothing special aside from quoting. Hopefully that works. */

--- a/compiler+runtime/src/cpp/jank/read/parse.cpp
+++ b/compiler+runtime/src/cpp/jank/read/parse.cpp
@@ -2,12 +2,13 @@
 
 #include <magic_enum.hpp>
 
-#include <jank/runtime/obj/ratio.hpp>
 #include <jank/read/parse.hpp>
 #include <jank/util/escape.hpp>
 #include <jank/runtime/visit.hpp>
 #include <jank/runtime/context.hpp>
 #include <jank/runtime/core.hpp>
+#include <jank/runtime/obj/symbol.hpp>
+#include <jank/runtime/obj/ratio.hpp>
 #include <jank/util/scope_exit.hpp>
 
 namespace jank::read::parse

--- a/compiler+runtime/src/cpp/jank/read/parse.cpp
+++ b/compiler+runtime/src/cpp/jank/read/parse.cpp
@@ -1,5 +1,7 @@
 #include <codecvt>
 
+#include <fmt/format.h>
+
 #include <jank/native_persistent_string/fmt.hpp>
 #include <jank/read/parse.hpp>
 #include <jank/util/escape.hpp>
@@ -1319,7 +1321,7 @@ namespace jank::read::parse
     auto res(util::unescape({ sv.data(), sv.size() }));
     if(res.is_err())
     {
-      return err(error{ token.pos, res.expect_err_move() });
+      return err(error{ token.pos, res.expect_err().message });
     }
     return object_source_info{ make_box<obj::persistent_string>(res.expect_ok_move()),
                                token,

--- a/compiler+runtime/src/cpp/jank/runtime/behavior/callable.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/behavior/callable.cpp
@@ -1,5 +1,6 @@
 #include <fmt/core.h>
 
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/behavior/callable.hpp>
 #include <jank/runtime/behavior/seqable.hpp>
 #include <jank/runtime/visit.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/behavior/metadatable.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/behavior/metadatable.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/behavior/metadatable.hpp>
 #include <jank/runtime/core/seq.hpp>
@@ -10,7 +12,7 @@ namespace jank::runtime::behavior::detail
   {
     if(!m)
     {
-      throw std::runtime_error{ fmt::format("invalid meta: nullptr") };
+      throw std::runtime_error{ "invalid meta: nullptr" };
     }
 
     if(!is_map(m) && m != obj::nil::nil_const())

--- a/compiler+runtime/src/cpp/jank/runtime/behavior/metadatable.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/behavior/metadatable.cpp
@@ -1,3 +1,4 @@
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/behavior/metadatable.hpp>
 #include <jank/runtime/core/seq.hpp>
 #include <jank/runtime/core/to_string.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/context.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/context.cpp
@@ -9,6 +9,7 @@
 
 #include <fmt/compile.h>
 
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/read/lex.hpp>
 #include <jank/read/parse.hpp>
 #include <jank/runtime/context.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/context.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/context.cpp
@@ -162,6 +162,15 @@ namespace jank::runtime
       auto const &module(
         expect_object<runtime::ns>(intern_var("clojure.core", "*ns*").expect_ok()->deref())
           ->to_string());
+      /* No matter what's in the fn, we'll return nil. */
+      exprs.emplace_back(
+        make_box<analyze::expression>(analyze::expr::primitive_literal<analyze::expression>{
+          analyze::expression_base{ {},
+                                   analyze::expression_position::tail,
+                                   an_prc.root_frame,
+                                   true },
+          obj::nil::nil_const()
+      }));
       /* TODO: Pass in module_to_load_function result */
       auto wrapped_exprs(evaluate::wrap_expressions(exprs, an_prc, module));
       auto &fn(boost::get<analyze::expr::function<analyze::expression>>(wrapped_exprs->data));

--- a/compiler+runtime/src/cpp/jank/runtime/core.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core.cpp
@@ -1,3 +1,4 @@
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/core.hpp>
 #include <jank/runtime/visit.hpp>
 #include <jank/runtime/behavior/comparable.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/core.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/core.hpp>
 #include <jank/runtime/visit.hpp>
@@ -99,12 +101,11 @@ namespace jank::runtime
 
         if constexpr(behavior::sequenceable<T>)
         {
-          fmt::memory_buffer buff;
-          auto inserter(std::back_inserter(buff));
+          util::string_builder buff;
           runtime::to_string(typed_args->first(), buff);
           for(auto it(next_in_place(typed_args)); it != nullptr; it = next_in_place(it))
           {
-            fmt::format_to(inserter, " ");
+            buff(' ');
             runtime::to_string(it->first(), buff);
           }
           std::fwrite(buff.data(), 1, buff.size(), stdout);
@@ -131,12 +132,11 @@ namespace jank::runtime
         }
         else if constexpr(behavior::sequenceable<T>)
         {
-          fmt::memory_buffer buff;
-          auto inserter(std::back_inserter(buff));
+          util::string_builder buff;
           runtime::to_string(typed_more->first(), buff);
           for(auto it(next_in_place(typed_more)); it != nullptr; it = next_in_place(it))
           {
-            fmt::format_to(inserter, " ");
+            buff(' ');
             runtime::to_string(it->first(), buff);
           }
           std::fwrite(buff.data(), 1, buff.size(), stdout);
@@ -160,12 +160,11 @@ namespace jank::runtime
 
         if constexpr(behavior::sequenceable<T>)
         {
-          fmt::memory_buffer buff;
-          auto inserter(std::back_inserter(buff));
+          util::string_builder buff;
           runtime::to_code_string(typed_args->first(), buff);
           for(auto it(next_in_place(typed_args)); it != nullptr; it = next_in_place(it))
           {
-            fmt::format_to(inserter, " ");
+            buff(' ');
             runtime::to_code_string(it->first(), buff);
           }
           std::fwrite(buff.data(), 1, buff.size(), stdout);
@@ -192,12 +191,11 @@ namespace jank::runtime
         }
         else if constexpr(behavior::sequenceable<T>)
         {
-          fmt::memory_buffer buff;
-          auto inserter(std::back_inserter(buff));
+          util::string_builder buff;
           runtime::to_code_string(typed_more->first(), buff);
           for(auto it(next_in_place(typed_more)); it != nullptr; it = next_in_place(it))
           {
-            fmt::format_to(inserter, " ");
+            buff(' ');
             runtime::to_code_string(it->first(), buff);
           }
           std::fwrite(buff.data(), 1, buff.size(), stdout);

--- a/compiler+runtime/src/cpp/jank/runtime/core.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core.cpp
@@ -413,12 +413,12 @@ namespace jank::runtime
 
   native_bool is_simple_keyword(object_ptr const o)
   {
-    return o->type == object_type::keyword && expect_object<obj::keyword>(o)->sym.ns.empty();
+    return o->type == object_type::keyword && expect_object<obj::keyword>(o)->sym->ns.empty();
   }
 
   native_bool is_qualified_keyword(object_ptr const o)
   {
-    return o->type == object_type::keyword && !expect_object<obj::keyword>(o)->sym.ns.empty();
+    return o->type == object_type::keyword && !expect_object<obj::keyword>(o)->sym->ns.empty();
   }
 
   native_bool is_callable(object_ptr const o)

--- a/compiler+runtime/src/cpp/jank/runtime/core.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core.cpp
@@ -47,7 +47,7 @@ namespace jank::runtime
 
   native_persistent_string type(object_ptr const o)
   {
-    return magic_enum::enum_name(o->type);
+    return object_type_str(o->type);
   }
 
   native_bool is_nil(object_ptr const o)

--- a/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
@@ -782,8 +782,7 @@ namespace jank::runtime
         }
         else
         {
-          throw std::runtime_error{ fmt::format("not indexable: {}",
-                                                magic_enum::enum_name(o->type)) };
+          throw std::runtime_error{ fmt::format("not indexable: {}", object_type_str(o->type)) };
         }
       },
       o);
@@ -823,8 +822,7 @@ namespace jank::runtime
         }
         else
         {
-          throw std::runtime_error{ fmt::format("not indexable: {}",
-                                                magic_enum::enum_name(o->type)) };
+          throw std::runtime_error{ fmt::format("not indexable: {}", object_type_str(o->type)) };
         }
       },
       o);
@@ -847,8 +845,7 @@ namespace jank::runtime
         }
         else
         {
-          throw std::runtime_error{ fmt::format("not stackable: {}",
-                                                magic_enum::enum_name(o->type)) };
+          throw std::runtime_error{ fmt::format("not stackable: {}", object_type_str(o->type)) };
         }
       },
       o);
@@ -871,8 +868,7 @@ namespace jank::runtime
         }
         else
         {
-          throw std::runtime_error{ fmt::format("not stackable: {}",
-                                                magic_enum::enum_name(o->type)) };
+          throw std::runtime_error{ fmt::format("not stackable: {}", object_type_str(o->type)) };
         }
       },
       o);

--- a/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
@@ -897,7 +897,7 @@ namespace jank::runtime
   {
     return visit_seqable(
       [=](auto const typed_args) -> native_persistent_string {
-        fmt::memory_buffer buff;
+        util::string_builder buff;
         buff.reserve(16);
         runtime::to_string(o, buff);
         if(0 < sequence_length(typed_args))
@@ -909,7 +909,7 @@ namespace jank::runtime
             runtime::to_string(it->first(), buff);
           }
         }
-        return native_persistent_string{ buff.data(), buff.size() };
+        return buff.release();
       },
       args);
   }

--- a/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
@@ -1,5 +1,6 @@
 #include <fmt/core.h>
 
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/visit.hpp>
 #include <jank/runtime/behavior/associatively_readable.hpp>
 #include <jank/runtime/behavior/associatively_writable.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/core/to_string.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/to_string.cpp
@@ -9,12 +9,12 @@ namespace jank::runtime
     return visit_object([](auto const typed_o) { return typed_o->to_string(); }, o);
   }
 
-  void to_string(char const ch, fmt::memory_buffer &buff)
+  void to_string(char const ch, util::string_builder &buff)
   {
     obj::character{ ch }.to_string(buff);
   }
 
-  void to_string(object_ptr const o, fmt::memory_buffer &buff)
+  void to_string(object_ptr const o, util::string_builder &buff)
   {
     visit_object([&](auto const typed_o) { typed_o->to_string(buff); }, o);
   }
@@ -24,15 +24,15 @@ namespace jank::runtime
     return visit_object([](auto const typed_o) { return typed_o->to_code_string(); }, o);
   }
 
-  void to_code_string(char const ch, fmt::memory_buffer &buff)
+  void to_code_string(char const ch, util::string_builder &buff)
   {
-    fmt::format_to(std::back_inserter(buff), "{}", obj::character{ ch }.to_code_string());
+    buff(obj::character{ ch }.to_code_string());
   }
 
-  void to_code_string(object_ptr const o, fmt::memory_buffer &buff)
+  void to_code_string(object_ptr const o, util::string_builder &buff)
   {
     auto const value{ visit_object([](auto const typed_o) { return typed_o->to_code_string(); },
                                    o) };
-    fmt::format_to(std::back_inserter(buff), "{}", value);
+    buff(value);
   }
 }

--- a/compiler+runtime/src/cpp/jank/runtime/core/to_string.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/to_string.cpp
@@ -1,4 +1,5 @@
-#include <jank/runtime/core.hpp>
+#include <jank/native_persistent_string/fmt.hpp>
+#include <jank/runtime/core/to_string.hpp>
 #include <jank/runtime/visit.hpp>
 
 namespace jank::runtime

--- a/compiler+runtime/src/cpp/jank/runtime/detail/native_persistent_array_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/detail/native_persistent_array_map.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include <jank/runtime/detail/native_persistent_array_map.hpp>
 #include <jank/runtime/core.hpp>
 

--- a/compiler+runtime/src/cpp/jank/runtime/module/loader.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/module/loader.cpp
@@ -5,6 +5,8 @@
 
 #include <boost/filesystem.hpp>
 
+#include <fmt/format.h>
+
 #include <jank/util/mapped_file.hpp>
 #include <jank/util/process_location.hpp>
 #include <jank/runtime/module/loader.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/module/loader.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/module/loader.cpp
@@ -12,6 +12,7 @@
 #include <jank/runtime/core/munge.hpp>
 #include <jank/runtime/context.hpp>
 #include <jank/profile/time.hpp>
+#include <jank/native_persistent_string/fmt.hpp>
 
 namespace jank::runtime::module
 {

--- a/compiler+runtime/src/cpp/jank/runtime/ns.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/ns.cpp
@@ -4,7 +4,7 @@
 
 namespace jank::runtime
 {
-  ns::static_object(obj::symbol_ptr const &name, context &c)
+  ns::ns(obj::symbol_ptr const &name, context &c)
     : name{ name }
     , vars{ obj::persistent_hash_map::empty() }
     , aliases{ obj::persistent_hash_map::empty() }
@@ -56,8 +56,7 @@ namespace jank::runtime
     return { expect_object<var>(*found) };
   }
 
-  result<void, native_persistent_string>
-  ns::add_alias(obj::symbol_ptr const &sym, native_box<static_object> const &ns)
+  result<void, native_persistent_string> ns::add_alias(obj::symbol_ptr const &sym, ns_ptr const &ns)
   {
     auto locked_aliases(aliases.wlock());
     auto const found((*locked_aliases)->data.find(sym));

--- a/compiler+runtime/src/cpp/jank/runtime/ns.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/ns.cpp
@@ -2,6 +2,7 @@
 #include <jank/runtime/rtti.hpp>
 #include <jank/runtime/context.hpp>
 #include <jank/runtime/obj/persistent_hash_map.hpp>
+#include <jank/native_persistent_string/fmt.hpp>
 
 namespace jank::runtime
 {

--- a/compiler+runtime/src/cpp/jank/runtime/ns.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/ns.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include <jank/runtime/ns.hpp>
 #include <jank/runtime/rtti.hpp>
 #include <jank/runtime/context.hpp>
@@ -131,7 +133,7 @@ namespace jank::runtime
     return to_string();
   }
 
-  void ns::to_string(fmt::memory_buffer &buff) const
+  void ns::to_string(util::string_builder &buff) const
   {
     name->to_string(buff);
   }

--- a/compiler+runtime/src/cpp/jank/runtime/ns.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/ns.cpp
@@ -1,6 +1,7 @@
 #include <jank/runtime/ns.hpp>
 #include <jank/runtime/rtti.hpp>
 #include <jank/runtime/context.hpp>
+#include <jank/runtime/obj/persistent_hash_map.hpp>
 
 namespace jank::runtime
 {

--- a/compiler+runtime/src/cpp/jank/runtime/obj/array_chunk.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/array_chunk.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/array_chunk.hpp>
 #include <jank/runtime/obj/number.hpp>
@@ -30,12 +32,12 @@ namespace jank::runtime::obj
 
   native_persistent_string array_chunk::to_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     to_string(buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
-  void array_chunk::to_string(fmt::memory_buffer &buff) const
+  void array_chunk::to_string(util::string_builder &buff) const
   {
     fmt::format_to(std::back_inserter(buff), "{}@{}", object_type_str(base.type), fmt::ptr(&base));
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/array_chunk.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/array_chunk.cpp
@@ -1,3 +1,4 @@
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/array_chunk.hpp>
 #include <jank/runtime/obj/number.hpp>
 #include <jank/runtime/core/to_string.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/obj/array_chunk.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/array_chunk.cpp
@@ -5,38 +5,38 @@
 #include <jank/runtime/core/to_string.hpp>
 #include <jank/runtime/rtti.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::array_chunk::static_object(native_vector<object_ptr> const &buffer)
+  array_chunk::array_chunk(native_vector<object_ptr> const &buffer)
     : buffer{ buffer }
   {
   }
 
-  obj::array_chunk::static_object(native_vector<object_ptr> const &buffer, size_t const offset)
+  array_chunk::array_chunk(native_vector<object_ptr> const &buffer, size_t const offset)
     : buffer{ buffer }
     , offset{ offset }
   {
   }
 
-  obj::array_chunk::static_object(native_vector<object_ptr> &&buffer, size_t const offset)
+  array_chunk::array_chunk(native_vector<object_ptr> &&buffer, size_t const offset)
     : buffer{ std::move(buffer) }
     , offset{ offset }
   {
   }
 
-  native_bool obj::array_chunk::equal(object const &o) const
+  native_bool array_chunk::equal(object const &o) const
   {
     return &o == &base;
   }
 
-  native_persistent_string obj::array_chunk::to_string() const
+  native_persistent_string array_chunk::to_string() const
   {
     fmt::memory_buffer buff;
     to_string(buff);
     return native_persistent_string{ buff.data(), buff.size() };
   }
 
-  void obj::array_chunk::to_string(fmt::memory_buffer &buff) const
+  void array_chunk::to_string(fmt::memory_buffer &buff) const
   {
     fmt::format_to(std::back_inserter(buff),
                    "{}@{}",
@@ -44,27 +44,27 @@ namespace jank::runtime
                    fmt::ptr(&base));
   }
 
-  native_persistent_string obj::array_chunk::to_code_string() const
+  native_persistent_string array_chunk::to_code_string() const
   {
     return to_string();
   }
 
-  native_hash obj::array_chunk::to_hash() const
+  native_hash array_chunk::to_hash() const
   {
     return static_cast<native_hash>(reinterpret_cast<uintptr_t>(this));
   }
 
-  obj::array_chunk_ptr obj::array_chunk::chunk_next() const
+  array_chunk_ptr array_chunk::chunk_next() const
   {
     if(offset == buffer.size())
     {
       throw std::runtime_error{ "no more chunk remaining to chunk_next" };
     }
     /* TODO: This copying will be slow. Use a persistent_vector? */
-    return make_box<obj::array_chunk>(buffer, offset + 1);
+    return make_box<array_chunk>(buffer, offset + 1);
   }
 
-  obj::array_chunk_ptr obj::array_chunk::chunk_next_in_place()
+  array_chunk_ptr array_chunk::chunk_next_in_place()
   {
     if(offset == buffer.size())
     {
@@ -74,16 +74,16 @@ namespace jank::runtime
     return this;
   }
 
-  size_t obj::array_chunk::count() const
+  size_t array_chunk::count() const
   {
     return buffer.size() - offset;
   }
 
-  object_ptr obj::array_chunk::nth(object_ptr const index) const
+  object_ptr array_chunk::nth(object_ptr const index) const
   {
     if(index->type == object_type::integer)
     {
-      auto const i(static_cast<size_t>(expect_object<obj::integer>(index)->data));
+      auto const i(static_cast<size_t>(expect_object<integer>(index)->data));
       if(buffer.size() - offset <= i)
       {
         throw std::runtime_error{ fmt::format(
@@ -101,11 +101,11 @@ namespace jank::runtime
     }
   }
 
-  object_ptr obj::array_chunk::nth(object_ptr const index, object_ptr const fallback) const
+  object_ptr array_chunk::nth(object_ptr const index, object_ptr const fallback) const
   {
     if(index->type == object_type::integer)
     {
-      auto const i(static_cast<size_t>(expect_object<obj::integer>(index)->data));
+      auto const i(static_cast<size_t>(expect_object<integer>(index)->data));
       if(buffer.size() - offset <= i)
       {
         throw std::runtime_error{ fmt::format(

--- a/compiler+runtime/src/cpp/jank/runtime/obj/array_chunk.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/array_chunk.cpp
@@ -1,5 +1,3 @@
-#include <magic_enum.hpp>
-
 #include <jank/runtime/obj/array_chunk.hpp>
 #include <jank/runtime/obj/number.hpp>
 #include <jank/runtime/core/to_string.hpp>
@@ -38,10 +36,7 @@ namespace jank::runtime::obj
 
   void array_chunk::to_string(fmt::memory_buffer &buff) const
   {
-    fmt::format_to(std::back_inserter(buff),
-                   "{}@{}",
-                   magic_enum::enum_name(base.type),
-                   fmt::ptr(&base));
+    fmt::format_to(std::back_inserter(buff), "{}@{}", object_type_str(base.type), fmt::ptr(&base));
   }
 
   native_persistent_string array_chunk::to_code_string() const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/atom.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/atom.cpp
@@ -1,5 +1,3 @@
-#include <magic_enum.hpp>
-
 #include <jank/runtime/obj/atom.hpp>
 #include <jank/runtime/obj/persistent_vector.hpp>
 #include <jank/runtime/behavior/callable.hpp>
@@ -27,10 +25,7 @@ namespace jank::runtime::obj
 
   void atom::to_string(fmt::memory_buffer &buff) const
   {
-    fmt::format_to(std::back_inserter(buff),
-                   "{}@{}",
-                   magic_enum::enum_name(base.type),
-                   fmt::ptr(&base));
+    fmt::format_to(std::back_inserter(buff), "{}@{}", object_type_str(base.type), fmt::ptr(&base));
   }
 
   native_persistent_string atom::to_code_string() const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/atom.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/atom.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include <jank/runtime/obj/atom.hpp>
 #include <jank/runtime/obj/persistent_vector.hpp>
 #include <jank/runtime/behavior/callable.hpp>
@@ -18,12 +20,12 @@ namespace jank::runtime::obj
 
   native_persistent_string atom::to_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     to_string(buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
-  void atom::to_string(fmt::memory_buffer &buff) const
+  void atom::to_string(util::string_builder &buff) const
   {
     fmt::format_to(std::back_inserter(buff), "{}@{}", object_type_str(base.type), fmt::ptr(&base));
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/atom.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/atom.cpp
@@ -4,27 +4,27 @@
 #include <jank/runtime/behavior/callable.hpp>
 #include <jank/runtime/core.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::atom::static_object(object_ptr const o)
+  atom::atom(object_ptr const o)
     : val{ o }
   {
     assert(val);
   }
 
-  native_bool obj::atom::equal(object const &o) const
+  native_bool atom::equal(object const &o) const
   {
     return &o == &base;
   }
 
-  native_persistent_string obj::atom::to_string() const
+  native_persistent_string atom::to_string() const
   {
     fmt::memory_buffer buff;
     to_string(buff);
     return native_persistent_string{ buff.data(), buff.size() };
   }
 
-  void obj::atom::to_string(fmt::memory_buffer &buff) const
+  void atom::to_string(fmt::memory_buffer &buff) const
   {
     fmt::format_to(std::back_inserter(buff),
                    "{}@{}",
@@ -32,42 +32,42 @@ namespace jank::runtime
                    fmt::ptr(&base));
   }
 
-  native_persistent_string obj::atom::to_code_string() const
+  native_persistent_string atom::to_code_string() const
   {
     return to_string();
   }
 
-  native_hash obj::atom::to_hash() const
+  native_hash atom::to_hash() const
   {
     return static_cast<native_hash>(reinterpret_cast<uintptr_t>(this));
   }
 
-  object_ptr obj::atom::deref() const
+  object_ptr atom::deref() const
   {
     return val.load();
   }
 
-  object_ptr obj::atom::reset(object_ptr const o)
+  object_ptr atom::reset(object_ptr const o)
   {
     assert(o);
     val = o;
     return o;
   }
 
-  obj::persistent_vector_ptr obj::atom::reset_vals(object_ptr const o)
+  persistent_vector_ptr atom::reset_vals(object_ptr const o)
   {
     while(true)
     {
       auto v(val.load());
       if(val.compare_exchange_weak(v, o))
       {
-        return make_box<obj::persistent_vector>(std::in_place, v, o);
+        return make_box<persistent_vector>(std::in_place, v, o);
       }
     }
   }
 
   /* NOLINTNEXTLINE(cppcoreguidelines-noexcept-swap) */
-  object_ptr obj::atom::swap(object_ptr const fn)
+  object_ptr atom::swap(object_ptr const fn)
   {
     while(true)
     {
@@ -81,7 +81,7 @@ namespace jank::runtime
   }
 
   /* NOLINTNEXTLINE(cppcoreguidelines-noexcept-swap) */
-  object_ptr obj::atom::swap(object_ptr fn, object_ptr a1)
+  object_ptr atom::swap(object_ptr fn, object_ptr a1)
   {
     while(true)
     {
@@ -95,7 +95,7 @@ namespace jank::runtime
   }
 
   /* NOLINTNEXTLINE(cppcoreguidelines-noexcept-swap) */
-  object_ptr obj::atom::swap(object_ptr fn, object_ptr a1, object_ptr a2)
+  object_ptr atom::swap(object_ptr fn, object_ptr a1, object_ptr a2)
   {
     while(true)
     {
@@ -109,7 +109,7 @@ namespace jank::runtime
   }
 
   /* NOLINTNEXTLINE(cppcoreguidelines-noexcept-swap) */
-  object_ptr obj::atom::swap(object_ptr fn, object_ptr a1, object_ptr a2, object_ptr rest)
+  object_ptr atom::swap(object_ptr fn, object_ptr a1, object_ptr a2, object_ptr rest)
   {
     while(true)
     {
@@ -122,7 +122,7 @@ namespace jank::runtime
     }
   }
 
-  obj::persistent_vector_ptr obj::atom::swap_vals(object_ptr const fn)
+  persistent_vector_ptr atom::swap_vals(object_ptr const fn)
   {
     while(true)
     {
@@ -130,12 +130,12 @@ namespace jank::runtime
       auto const next(dynamic_call(fn, v));
       if(val.compare_exchange_weak(v, next))
       {
-        return make_box<obj::persistent_vector>(std::in_place, v, next);
+        return make_box<persistent_vector>(std::in_place, v, next);
       }
     }
   }
 
-  obj::persistent_vector_ptr obj::atom::swap_vals(object_ptr fn, object_ptr a1)
+  persistent_vector_ptr atom::swap_vals(object_ptr fn, object_ptr a1)
   {
     while(true)
     {
@@ -143,12 +143,12 @@ namespace jank::runtime
       auto const next(dynamic_call(fn, v, a1));
       if(val.compare_exchange_weak(v, next))
       {
-        return make_box<obj::persistent_vector>(std::in_place, v, next);
+        return make_box<persistent_vector>(std::in_place, v, next);
       }
     }
   }
 
-  obj::persistent_vector_ptr obj::atom::swap_vals(object_ptr fn, object_ptr a1, object_ptr a2)
+  persistent_vector_ptr atom::swap_vals(object_ptr fn, object_ptr a1, object_ptr a2)
   {
     while(true)
     {
@@ -156,13 +156,13 @@ namespace jank::runtime
       auto const next(dynamic_call(fn, v, a1, a2));
       if(val.compare_exchange_weak(v, next))
       {
-        return make_box<obj::persistent_vector>(std::in_place, v, next);
+        return make_box<persistent_vector>(std::in_place, v, next);
       }
     }
   }
 
-  obj::persistent_vector_ptr
-  obj::atom::swap_vals(object_ptr fn, object_ptr a1, object_ptr a2, object_ptr rest)
+  persistent_vector_ptr
+  atom::swap_vals(object_ptr fn, object_ptr a1, object_ptr a2, object_ptr rest)
   {
     while(true)
     {
@@ -170,12 +170,12 @@ namespace jank::runtime
       auto const next(apply_to(fn, conj(a1, conj(a2, rest))));
       if(val.compare_exchange_weak(v, next))
       {
-        return make_box<obj::persistent_vector>(std::in_place, v, next);
+        return make_box<persistent_vector>(std::in_place, v, next);
       }
     }
   }
 
-  object_ptr obj::atom::compare_and_set(object_ptr old_val, object_ptr new_val)
+  object_ptr atom::compare_and_set(object_ptr old_val, object_ptr new_val)
   {
     object *old{ old_val };
     return make_box(val.compare_exchange_weak(old, new_val));

--- a/compiler+runtime/src/cpp/jank/runtime/obj/atom.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/atom.cpp
@@ -1,6 +1,7 @@
 #include <magic_enum.hpp>
 
 #include <jank/runtime/obj/atom.hpp>
+#include <jank/runtime/obj/persistent_vector.hpp>
 #include <jank/runtime/behavior/callable.hpp>
 #include <jank/runtime/core.hpp>
 

--- a/compiler+runtime/src/cpp/jank/runtime/obj/character.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/character.cpp
@@ -1,6 +1,7 @@
 #include <jank/runtime/obj/character.hpp>
 #include <jank/runtime/rtti.hpp>
 #include <jank/util/escape.hpp>
+#include <jank/native_persistent_string/fmt.hpp>
 
 namespace jank::runtime::obj
 {

--- a/compiler+runtime/src/cpp/jank/runtime/obj/character.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/character.cpp
@@ -2,7 +2,7 @@
 #include <jank/runtime/rtti.hpp>
 #include <jank/util/escape.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
   static native_persistent_string get_literal_from_char_bytes(native_persistent_string const &bytes)
   {
@@ -32,43 +32,43 @@ namespace jank::runtime
     }
   }
 
-  obj::character::static_object(native_persistent_string const &d)
+  character::character(native_persistent_string const &d)
     : data{ d }
   {
   }
 
-  obj::character::static_object(char const ch)
+  character::character(char const ch)
     : data{ 1, ch }
   {
   }
 
-  native_bool obj::character::equal(object const &o) const
+  native_bool character::equal(object const &o) const
   {
     if(o.type != object_type::character)
     {
       return false;
     }
 
-    auto const c(expect_object<obj::character>(&o));
+    auto const c(expect_object<character>(&o));
     return data == c->data;
   }
 
-  void obj::character::to_string(fmt::memory_buffer &buff) const
+  void character::to_string(fmt::memory_buffer &buff) const
   {
     fmt::format_to(std::back_inserter(buff), "{}", data);
   }
 
-  native_persistent_string obj::character::to_string() const
+  native_persistent_string character::to_string() const
   {
     return data;
   }
 
-  native_persistent_string obj::character::to_code_string() const
+  native_persistent_string character::to_code_string() const
   {
     return get_literal_from_char_bytes(data);
   }
 
-  native_hash obj::character::to_hash() const
+  native_hash character::to_hash() const
   {
     return data.to_hash();
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/character.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/character.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include <jank/runtime/obj/character.hpp>
 #include <jank/runtime/rtti.hpp>
 #include <jank/util/escape.hpp>
@@ -54,9 +56,9 @@ namespace jank::runtime::obj
     return data == c->data;
   }
 
-  void character::to_string(fmt::memory_buffer &buff) const
+  void character::to_string(util::string_builder &buff) const
   {
-    fmt::format_to(std::back_inserter(buff), "{}", data);
+    buff(data);
   }
 
   native_persistent_string character::to_string() const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/chunk_buffer.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/chunk_buffer.cpp
@@ -4,15 +4,15 @@
 #include <jank/runtime/obj/array_chunk.hpp>
 #include <jank/runtime/core/math.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::chunk_buffer::static_object(size_t const capacity)
+  chunk_buffer::chunk_buffer(size_t const capacity)
     : capacity{ capacity }
   {
     buffer.reserve(capacity);
   }
 
-  obj::chunk_buffer::static_object(object_ptr const capacity)
+  chunk_buffer::chunk_buffer(object_ptr const capacity)
   {
     auto const c(to_int(capacity));
     if(c < 0)
@@ -23,19 +23,19 @@ namespace jank::runtime
     buffer.reserve(c);
   }
 
-  native_bool obj::chunk_buffer::equal(object const &o) const
+  native_bool chunk_buffer::equal(object const &o) const
   {
     return &o == &base;
   }
 
-  native_persistent_string obj::chunk_buffer::to_string() const
+  native_persistent_string chunk_buffer::to_string() const
   {
     fmt::memory_buffer buff;
     to_string(buff);
     return native_persistent_string{ buff.data(), buff.size() };
   }
 
-  void obj::chunk_buffer::to_string(fmt::memory_buffer &buff) const
+  void chunk_buffer::to_string(fmt::memory_buffer &buff) const
   {
     fmt::format_to(std::back_inserter(buff),
                    "{}@{}",
@@ -43,22 +43,22 @@ namespace jank::runtime
                    fmt::ptr(&base));
   }
 
-  native_persistent_string obj::chunk_buffer::to_code_string() const
+  native_persistent_string chunk_buffer::to_code_string() const
   {
     return to_string();
   }
 
-  native_hash obj::chunk_buffer::to_hash() const
+  native_hash chunk_buffer::to_hash() const
   {
     return static_cast<native_hash>(reinterpret_cast<uintptr_t>(this));
   }
 
-  size_t obj::chunk_buffer::count() const
+  size_t chunk_buffer::count() const
   {
     return buffer.size();
   }
 
-  void obj::chunk_buffer::append(object_ptr const o)
+  void chunk_buffer::append(object_ptr const o)
   {
     if(buffer.size() == capacity)
     {
@@ -67,9 +67,9 @@ namespace jank::runtime
     buffer.emplace_back(o);
   }
 
-  obj::array_chunk_ptr obj::chunk_buffer::chunk()
+  array_chunk_ptr chunk_buffer::chunk()
   {
-    auto const ret(make_box<obj::array_chunk>(std::move(buffer)));
+    auto const ret(make_box<array_chunk>(std::move(buffer)));
     buffer.clear();
     buffer.shrink_to_fit();
     capacity = 0;

--- a/compiler+runtime/src/cpp/jank/runtime/obj/chunk_buffer.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/chunk_buffer.cpp
@@ -1,5 +1,3 @@
-#include <magic_enum.hpp>
-
 #include <jank/runtime/obj/chunk_buffer.hpp>
 #include <jank/runtime/obj/array_chunk.hpp>
 #include <jank/runtime/core/math.hpp>
@@ -37,10 +35,7 @@ namespace jank::runtime::obj
 
   void chunk_buffer::to_string(fmt::memory_buffer &buff) const
   {
-    fmt::format_to(std::back_inserter(buff),
-                   "{}@{}",
-                   magic_enum::enum_name(base.type),
-                   fmt::ptr(&base));
+    fmt::format_to(std::back_inserter(buff), "{}@{}", object_type_str(base.type), fmt::ptr(&base));
   }
 
   native_persistent_string chunk_buffer::to_code_string() const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/chunk_buffer.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/chunk_buffer.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include <jank/runtime/obj/chunk_buffer.hpp>
 #include <jank/runtime/obj/array_chunk.hpp>
 #include <jank/runtime/core/math.hpp>
@@ -28,12 +30,12 @@ namespace jank::runtime::obj
 
   native_persistent_string chunk_buffer::to_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     to_string(buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
-  void chunk_buffer::to_string(fmt::memory_buffer &buff) const
+  void chunk_buffer::to_string(util::string_builder &buff) const
   {
     fmt::format_to(std::back_inserter(buff), "{}@{}", object_type_str(base.type), fmt::ptr(&base));
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/chunked_cons.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/chunked_cons.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/chunked_cons.hpp>
 #include <jank/runtime/visit.hpp>
@@ -171,7 +173,7 @@ namespace jank::runtime::obj
       &o);
   }
 
-  void chunked_cons::to_string(fmt::memory_buffer &buff) const
+  void chunked_cons::to_string(util::string_builder &buff) const
   {
     runtime::to_string(seq(), buff);
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/chunked_cons.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/chunked_cons.cpp
@@ -1,3 +1,4 @@
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/chunked_cons.hpp>
 #include <jank/runtime/visit.hpp>
 #include <jank/runtime/core/make_box.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/obj/chunked_cons.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/chunked_cons.cpp
@@ -1,6 +1,7 @@
 #include <jank/runtime/obj/chunked_cons.hpp>
 #include <jank/runtime/visit.hpp>
 #include <jank/runtime/core/make_box.hpp>
+#include <jank/runtime/core/seq.hpp>
 #include <jank/runtime/behavior/chunkable.hpp>
 
 namespace jank::runtime::obj

--- a/compiler+runtime/src/cpp/jank/runtime/obj/chunked_cons.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/chunked_cons.cpp
@@ -3,37 +3,35 @@
 #include <jank/runtime/core/make_box.hpp>
 #include <jank/runtime/behavior/chunkable.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::chunked_cons::static_object(object_ptr const head, object_ptr const tail)
+  chunked_cons::chunked_cons(object_ptr const head, object_ptr const tail)
     : head{ head }
-    , tail{ tail == obj::nil::nil_const() ? nullptr : tail }
+    , tail{ tail == nil::nil_const() ? nullptr : tail }
   {
     assert(head);
   }
 
-  obj::chunked_cons::static_object(object_ptr const meta,
-                                   object_ptr const head,
-                                   object_ptr const tail)
+  chunked_cons::chunked_cons(object_ptr const meta, object_ptr const head, object_ptr const tail)
     : head{ head }
-    , tail{ tail == obj::nil::nil_const() ? nullptr : tail }
+    , tail{ tail == nil::nil_const() ? nullptr : tail }
     , meta{ meta }
   {
     assert(head);
     assert(meta);
   }
 
-  obj::chunked_cons_ptr obj::chunked_cons::seq() const
+  chunked_cons_ptr chunked_cons::seq() const
   {
-    return const_cast<obj::chunked_cons *>(this);
+    return const_cast<chunked_cons *>(this);
   }
 
-  obj::chunked_cons_ptr obj::chunked_cons::fresh_seq() const
+  chunked_cons_ptr chunked_cons::fresh_seq() const
   {
-    return make_box<obj::chunked_cons>(head, tail);
+    return make_box<chunked_cons>(head, tail);
   }
 
-  object_ptr obj::chunked_cons::first() const
+  object_ptr chunked_cons::first() const
   {
     return visit_object(
       [&](auto const typed_head) -> object_ptr {
@@ -52,7 +50,7 @@ namespace jank::runtime
       head);
   }
 
-  object_ptr obj::chunked_cons::next() const
+  object_ptr chunked_cons::next() const
   {
     return visit_object(
       [&](auto const typed_head) -> object_ptr {
@@ -62,7 +60,7 @@ namespace jank::runtime
         {
           if(1 < typed_head->count())
           {
-            return make_box<obj::chunked_cons>(typed_head->chunk_next(), tail);
+            return make_box<chunked_cons>(typed_head->chunk_next(), tail);
           }
           return tail;
         }
@@ -75,7 +73,7 @@ namespace jank::runtime
       head);
   }
 
-  static obj::chunked_cons_ptr next_in_place_non_chunked(obj::chunked_cons_ptr const o)
+  static chunked_cons_ptr next_in_place_non_chunked(chunked_cons_ptr const o)
   {
     if(!o->tail)
     {
@@ -83,14 +81,14 @@ namespace jank::runtime
     }
 
     return visit_object(
-      [&](auto const typed_tail) -> obj::chunked_cons_ptr {
+      [&](auto const typed_tail) -> chunked_cons_ptr {
         using T = typename decltype(typed_tail)::value_type;
 
         if constexpr(behavior::sequenceable<T>)
         {
           o->head = typed_tail->first();
           o->tail = typed_tail->next();
-          if(o->tail == obj::nil::nil_const())
+          if(o->tail == nil::nil_const())
           {
             o->tail = nullptr;
           }
@@ -104,10 +102,10 @@ namespace jank::runtime
       o->tail);
   }
 
-  obj::chunked_cons_ptr obj::chunked_cons::next_in_place()
+  chunked_cons_ptr chunked_cons::next_in_place()
   {
     return visit_object(
-      [&](auto const typed_head) -> obj::chunked_cons_ptr {
+      [&](auto const typed_head) -> chunked_cons_ptr {
         using T = typename decltype(typed_head)::value_type;
 
         if constexpr(behavior::chunk_like<T>)
@@ -127,7 +125,7 @@ namespace jank::runtime
       head);
   }
 
-  object_ptr obj::chunked_cons::chunked_first() const
+  object_ptr chunked_cons::chunked_first() const
   {
     return visit_object(
       [&](auto const typed_head) -> object_ptr {
@@ -139,7 +137,7 @@ namespace jank::runtime
         }
         else
         {
-          auto const buffer(make_box<obj::chunk_buffer>(static_cast<size_t>(1)));
+          auto const buffer(make_box<chunk_buffer>(static_cast<size_t>(1)));
           buffer->append(typed_head);
           return buffer->chunk();
         }
@@ -147,12 +145,12 @@ namespace jank::runtime
       head);
   }
 
-  object_ptr obj::chunked_cons::chunked_next() const
+  object_ptr chunked_cons::chunked_next() const
   {
     return tail;
   }
 
-  native_bool obj::chunked_cons::equal(object const &o) const
+  native_bool chunked_cons::equal(object const &o) const
   {
     return visit_seqable(
       [this](auto const typed_o) {
@@ -171,32 +169,32 @@ namespace jank::runtime
       &o);
   }
 
-  void obj::chunked_cons::to_string(fmt::memory_buffer &buff) const
+  void chunked_cons::to_string(fmt::memory_buffer &buff) const
   {
     runtime::to_string(seq(), buff);
   }
 
-  native_persistent_string obj::chunked_cons::to_string() const
+  native_persistent_string chunked_cons::to_string() const
   {
     return runtime::to_string(seq());
   }
 
-  native_persistent_string obj::chunked_cons::to_code_string() const
+  native_persistent_string chunked_cons::to_code_string() const
   {
     return runtime::to_code_string(seq());
   }
 
-  native_hash obj::chunked_cons::to_hash() const
+  native_hash chunked_cons::to_hash() const
   {
     return hash::ordered(&base);
   }
 
-  obj::cons_ptr obj::chunked_cons::conj(object_ptr const head) const
+  cons_ptr chunked_cons::conj(object_ptr const head) const
   {
-    return make_box<obj::cons>(head, this);
+    return make_box<cons>(head, this);
   }
 
-  obj::chunked_cons_ptr obj::chunked_cons::with_meta(object_ptr const m) const
+  chunked_cons_ptr chunked_cons::with_meta(object_ptr const m) const
   {
     auto const meta(behavior::detail::validate_meta(m));
     auto ret(fresh_seq());

--- a/compiler+runtime/src/cpp/jank/runtime/obj/cons.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/cons.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/cons.hpp>
 #include <jank/runtime/core.hpp>
@@ -86,7 +88,7 @@ namespace jank::runtime::obj
       &o);
   }
 
-  void cons::to_string(fmt::memory_buffer &buff) const
+  void cons::to_string(util::string_builder &buff) const
   {
     runtime::to_string(seq(), buff);
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/cons.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/cons.cpp
@@ -1,3 +1,4 @@
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/cons.hpp>
 #include <jank/runtime/core.hpp>
 #include <jank/runtime/visit.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/obj/cons.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/cons.cpp
@@ -2,31 +2,31 @@
 #include <jank/runtime/core.hpp>
 #include <jank/runtime/visit.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::cons::static_object(object_ptr const head, object_ptr const tail)
+  cons::cons(object_ptr const head, object_ptr const tail)
     : head{ head }
-    , tail{ tail == obj::nil::nil_const() ? nullptr : tail }
+    , tail{ tail == nil::nil_const() ? nullptr : tail }
   {
     assert(head);
   }
 
-  obj::cons_ptr obj::cons::seq() const
+  cons_ptr cons::seq() const
   {
-    return const_cast<obj::cons *>(this);
+    return const_cast<cons *>(this);
   }
 
-  obj::cons_ptr obj::cons::fresh_seq() const
+  cons_ptr cons::fresh_seq() const
   {
-    return make_box<obj::cons>(head, tail);
+    return make_box<cons>(head, tail);
   }
 
-  object_ptr obj::cons::first() const
+  object_ptr cons::first() const
   {
     return head;
   }
 
-  object_ptr obj::cons::next() const
+  object_ptr cons::next() const
   {
     if(!tail)
     {
@@ -36,7 +36,7 @@ namespace jank::runtime
     return runtime::seq(tail);
   }
 
-  obj::cons_ptr obj::cons::next_in_place()
+  cons_ptr cons::next_in_place()
   {
     if(!tail)
     {
@@ -51,7 +51,7 @@ namespace jank::runtime
         {
           head = typed_tail->first();
           tail = typed_tail->next();
-          if(tail == obj::nil::nil_const())
+          if(tail == nil::nil_const())
           {
             tail = nullptr;
           }
@@ -66,7 +66,7 @@ namespace jank::runtime
     return this;
   }
 
-  native_bool obj::cons::equal(object const &o) const
+  native_bool cons::equal(object const &o) const
   {
     return visit_seqable(
       [this](auto const typed_o) {
@@ -85,22 +85,22 @@ namespace jank::runtime
       &o);
   }
 
-  void obj::cons::to_string(fmt::memory_buffer &buff) const
+  void cons::to_string(fmt::memory_buffer &buff) const
   {
     runtime::to_string(seq(), buff);
   }
 
-  native_persistent_string obj::cons::to_string() const
+  native_persistent_string cons::to_string() const
   {
     return runtime::to_string(seq());
   }
 
-  native_persistent_string obj::cons::to_code_string() const
+  native_persistent_string cons::to_code_string() const
   {
     return runtime::to_code_string(seq());
   }
 
-  native_hash obj::cons::to_hash() const
+  native_hash cons::to_hash() const
   {
     if(hash != 0)
     {
@@ -110,12 +110,12 @@ namespace jank::runtime
     return hash = hash::ordered(&base);
   }
 
-  obj::cons_ptr obj::cons::conj(object_ptr const head) const
+  cons_ptr cons::conj(object_ptr const head) const
   {
-    return make_box<obj::cons>(head, this);
+    return make_box<cons>(head, this);
   }
 
-  obj::cons_ptr obj::cons::with_meta(object_ptr const m) const
+  cons_ptr cons::with_meta(object_ptr const m) const
   {
     auto const meta(behavior::detail::validate_meta(m));
     auto ret(fresh_seq());

--- a/compiler+runtime/src/cpp/jank/runtime/obj/delay.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/delay.cpp
@@ -4,26 +4,26 @@
 #include <jank/runtime/behavior/callable.hpp>
 #include <jank/runtime/core/make_box.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::delay::static_object(object_ptr const fn)
+  delay::delay(object_ptr const fn)
     : fn{ fn }
   {
   }
 
-  native_bool obj::delay::equal(object const &o) const
+  native_bool delay::equal(object const &o) const
   {
     return &o == &base;
   }
 
-  native_persistent_string obj::delay::to_string() const
+  native_persistent_string delay::to_string() const
   {
     fmt::memory_buffer buff;
     to_string(buff);
     return native_persistent_string{ buff.data(), buff.size() };
   }
 
-  void obj::delay::to_string(fmt::memory_buffer &buff) const
+  void delay::to_string(fmt::memory_buffer &buff) const
   {
     fmt::format_to(std::back_inserter(buff),
                    "{}@{}",
@@ -31,17 +31,17 @@ namespace jank::runtime
                    fmt::ptr(&base));
   }
 
-  native_persistent_string obj::delay::to_code_string() const
+  native_persistent_string delay::to_code_string() const
   {
     return to_string();
   }
 
-  native_hash obj::delay::to_hash() const
+  native_hash delay::to_hash() const
   {
     return static_cast<native_hash>(reinterpret_cast<uintptr_t>(this));
   }
 
-  object_ptr obj::delay::deref()
+  object_ptr delay::deref()
   {
     std::lock_guard<std::mutex> const lock{ mutex };
     if(val != nullptr)

--- a/compiler+runtime/src/cpp/jank/runtime/obj/delay.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/delay.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include <jank/runtime/obj/delay.hpp>
 #include <jank/runtime/behavior/callable.hpp>
 #include <jank/runtime/core/make_box.hpp>
@@ -16,12 +18,12 @@ namespace jank::runtime::obj
 
   native_persistent_string delay::to_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     to_string(buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
-  void delay::to_string(fmt::memory_buffer &buff) const
+  void delay::to_string(util::string_builder &buff) const
   {
     fmt::format_to(std::back_inserter(buff), "{}@{}", object_type_str(base.type), fmt::ptr(&base));
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/delay.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/delay.cpp
@@ -1,5 +1,3 @@
-#include <magic_enum.hpp>
-
 #include <jank/runtime/obj/delay.hpp>
 #include <jank/runtime/behavior/callable.hpp>
 #include <jank/runtime/core/make_box.hpp>
@@ -25,10 +23,7 @@ namespace jank::runtime::obj
 
   void delay::to_string(fmt::memory_buffer &buff) const
   {
-    fmt::format_to(std::back_inserter(buff),
-                   "{}@{}",
-                   magic_enum::enum_name(base.type),
-                   fmt::ptr(&base));
+    fmt::format_to(std::back_inserter(buff), "{}@{}", object_type_str(base.type), fmt::ptr(&base));
   }
 
   native_persistent_string delay::to_code_string() const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/detail/base_persistent_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/detail/base_persistent_map.cpp
@@ -39,7 +39,7 @@ namespace jank::runtime::obj::detail
   template <typename PT, typename ST, typename V>
   void base_persistent_map<PT, ST, V>::to_string_impl(typename V::const_iterator const &begin,
                                                       typename V::const_iterator const &end,
-                                                      fmt::memory_buffer &buff,
+                                                      util::string_builder &buff,
                                                       native_bool const to_code)
   {
     auto inserter(std::back_inserter(buff));
@@ -76,7 +76,7 @@ namespace jank::runtime::obj::detail
   }
 
   template <typename PT, typename ST, typename V>
-  void base_persistent_map<PT, ST, V>::to_string(fmt::memory_buffer &buff) const
+  void base_persistent_map<PT, ST, V>::to_string(util::string_builder &buff) const
   {
     to_string_impl(static_cast<PT const *>(this)->data.begin(),
                    static_cast<PT const *>(this)->data.end(),
@@ -87,23 +87,23 @@ namespace jank::runtime::obj::detail
   template <typename PT, typename ST, typename V>
   native_persistent_string base_persistent_map<PT, ST, V>::to_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     to_string_impl(static_cast<PT const *>(this)->data.begin(),
                    static_cast<PT const *>(this)->data.end(),
                    buff,
                    false);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
   template <typename PT, typename ST, typename V>
   native_persistent_string base_persistent_map<PT, ST, V>::to_code_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     to_string_impl(static_cast<PT const *>(this)->data.begin(),
                    static_cast<PT const *>(this)->data.end(),
                    buff,
                    true);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
   template <typename PT, typename ST, typename V>

--- a/compiler+runtime/src/cpp/jank/runtime/obj/detail/base_persistent_map_sequence.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/detail/base_persistent_map_sequence.cpp
@@ -1,0 +1,169 @@
+#include <jank/runtime/obj/detail/base_persistent_map_sequence.hpp>
+#include <jank/runtime/visit.hpp>
+
+namespace jank::runtime::obj::detail
+{
+  template <typename PT, typename IT>
+  base_persistent_map_sequence<PT, IT>::base_persistent_map_sequence(object_ptr const c,
+                                                                     IT const &b,
+                                                                     IT const &e)
+    : coll{ c }
+    , begin{ b }
+    , end{ e }
+  {
+    assert(begin != end);
+  }
+
+  template <typename PT, typename IT>
+  native_bool base_persistent_map_sequence<PT, IT>::equal(object const &o) const
+  {
+    return visit_seqable(
+      [this](auto const typed_o) {
+        auto seq(typed_o->fresh_seq());
+        for(auto it(fresh_seq()); it != nullptr;
+            it = it->next_in_place(), seq = seq->next_in_place())
+        {
+          if(seq == nullptr || !runtime::equal(it, seq->first()))
+          {
+            return false;
+          }
+        }
+        return true;
+      },
+      []() { return false; },
+      &o);
+  }
+
+  template <typename PT, typename IT>
+  void base_persistent_map_sequence<PT, IT>::to_string_impl(fmt::memory_buffer &buff,
+                                                            native_bool const to_code) const
+  {
+    auto inserter(std::back_inserter(buff));
+    fmt::format_to(inserter, "(");
+    for(auto i(begin); i != end; ++i)
+    {
+      fmt::format_to(inserter, "[");
+      if(to_code)
+      {
+        runtime::to_code_string((*i).first, buff);
+      }
+      else
+      {
+        runtime::to_string((*i).first, buff);
+      }
+      fmt::format_to(inserter, " ");
+      if(to_code)
+      {
+        runtime::to_code_string((*i).second, buff);
+      }
+      else
+      {
+        runtime::to_string((*i).second, buff);
+      }
+      fmt::format_to(inserter, "]");
+      auto n(i);
+      if(++n != end)
+      {
+        fmt::format_to(inserter, " ");
+      }
+    }
+    fmt::format_to(inserter, ")");
+  }
+
+  template <typename PT, typename IT>
+  void base_persistent_map_sequence<PT, IT>::to_string(fmt::memory_buffer &buff) const
+  {
+    return to_string_impl(buff, false);
+  }
+
+  template <typename PT, typename IT>
+  native_persistent_string base_persistent_map_sequence<PT, IT>::to_string() const
+  {
+    fmt::memory_buffer buff;
+    to_string_impl(buff, false);
+    return native_persistent_string{ buff.data(), buff.size() };
+  }
+
+  template <typename PT, typename IT>
+  native_persistent_string base_persistent_map_sequence<PT, IT>::to_code_string() const
+  {
+    fmt::memory_buffer buff;
+    to_string_impl(buff, true);
+    return native_persistent_string{ buff.data(), buff.size() };
+  }
+
+  template <typename PT, typename IT>
+  native_hash base_persistent_map_sequence<PT, IT>::to_hash() const
+  {
+    return hash::unordered(&static_cast<PT const *>(this)->base);
+  }
+
+  template <typename PT, typename IT>
+  size_t base_persistent_map_sequence<PT, IT>::count() const
+  {
+    return std::distance(begin, end);
+  }
+
+  template <typename PT, typename IT>
+  native_box<PT> base_persistent_map_sequence<PT, IT>::seq()
+  {
+    return static_cast<PT *>(this);
+  }
+
+  template <typename PT, typename IT>
+  native_box<PT> base_persistent_map_sequence<PT, IT>::fresh_seq() const
+  {
+    return make_box<PT>(coll, begin, end);
+  }
+
+  template <typename PT, typename IT>
+  obj::persistent_vector_ptr base_persistent_map_sequence<PT, IT>::first() const
+  {
+    auto const pair(*begin);
+    return make_box<obj::persistent_vector>(
+      runtime::detail::native_persistent_vector{ pair.first, pair.second });
+  }
+
+  template <typename PT, typename IT>
+  native_box<PT> base_persistent_map_sequence<PT, IT>::next() const
+  {
+    auto n(begin);
+    ++n;
+
+    if(n == end)
+    {
+      return nullptr;
+    }
+
+    return make_box<PT>(coll, n, end);
+  }
+
+  template <typename PT, typename IT>
+  native_box<PT> base_persistent_map_sequence<PT, IT>::next_in_place()
+  {
+    ++begin;
+
+    if(begin == end)
+    {
+      return nullptr;
+    }
+
+    return static_cast<PT *>(this);
+  }
+
+  template <typename PT, typename IT>
+  obj::cons_ptr base_persistent_map_sequence<PT, IT>::conj(object_ptr const head)
+  {
+    return make_box<obj::cons>(head, static_cast<PT *>(this));
+  }
+
+  template struct base_persistent_map_sequence<
+    persistent_hash_map_sequence,
+    runtime::detail::native_persistent_hash_map::const_iterator>;
+  template struct base_persistent_map_sequence<
+    persistent_array_map_sequence,
+    runtime::detail::native_persistent_array_map::const_iterator>;
+  template struct base_persistent_map_sequence<
+    persistent_sorted_map_sequence,
+    runtime::detail::native_persistent_sorted_map::const_iterator>;
+}

--- a/compiler+runtime/src/cpp/jank/runtime/obj/detail/base_persistent_map_sequence.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/detail/base_persistent_map_sequence.cpp
@@ -35,14 +35,13 @@ namespace jank::runtime::obj::detail
   }
 
   template <typename PT, typename IT>
-  void base_persistent_map_sequence<PT, IT>::to_string_impl(fmt::memory_buffer &buff,
+  void base_persistent_map_sequence<PT, IT>::to_string_impl(util::string_builder &buff,
                                                             native_bool const to_code) const
   {
-    auto inserter(std::back_inserter(buff));
-    fmt::format_to(inserter, "(");
+    buff('(');
     for(auto i(begin); i != end; ++i)
     {
-      fmt::format_to(inserter, "[");
+      buff('[');
       if(to_code)
       {
         runtime::to_code_string((*i).first, buff);
@@ -51,7 +50,7 @@ namespace jank::runtime::obj::detail
       {
         runtime::to_string((*i).first, buff);
       }
-      fmt::format_to(inserter, " ");
+      buff(' ');
       if(to_code)
       {
         runtime::to_code_string((*i).second, buff);
@@ -60,18 +59,18 @@ namespace jank::runtime::obj::detail
       {
         runtime::to_string((*i).second, buff);
       }
-      fmt::format_to(inserter, "]");
+      buff(']');
       auto n(i);
       if(++n != end)
       {
-        fmt::format_to(inserter, " ");
+        buff(' ');
       }
     }
-    fmt::format_to(inserter, ")");
+    buff(')');
   }
 
   template <typename PT, typename IT>
-  void base_persistent_map_sequence<PT, IT>::to_string(fmt::memory_buffer &buff) const
+  void base_persistent_map_sequence<PT, IT>::to_string(util::string_builder &buff) const
   {
     return to_string_impl(buff, false);
   }
@@ -79,17 +78,17 @@ namespace jank::runtime::obj::detail
   template <typename PT, typename IT>
   native_persistent_string base_persistent_map_sequence<PT, IT>::to_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     to_string_impl(buff, false);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
   template <typename PT, typename IT>
   native_persistent_string base_persistent_map_sequence<PT, IT>::to_code_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     to_string_impl(buff, true);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
   template <typename PT, typename IT>

--- a/compiler+runtime/src/cpp/jank/runtime/obj/detail/iterator_sequence.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/detail/iterator_sequence.cpp
@@ -1,0 +1,139 @@
+#include <jank/runtime/obj/detail/iterator_sequence.hpp>
+#include <jank/runtime/core/seq.hpp>
+#include <jank/runtime/core/to_string.hpp>
+#include <jank/runtime/visit.hpp>
+
+namespace jank::runtime
+{
+  native_bool equal(object_ptr lhs, object_ptr rhs);
+}
+
+namespace jank::runtime::obj::detail
+{
+  template <typename Derived, typename It>
+  iterator_sequence<Derived, It>::iterator_sequence(object_ptr const &c,
+                                                    It const &b,
+                                                    It const &e,
+                                                    size_t const s)
+    : coll{ c }
+    , begin{ b }
+    , end{ e }
+    , size{ s }
+  {
+    if(begin == end)
+    {
+      throw std::runtime_error{ "iterator_sequence for empty sequence" };
+    }
+  }
+
+  template <typename Derived, typename It>
+  native_bool iterator_sequence<Derived, It>::equal(object const &o) const
+  {
+    return visit_seqable(
+      [this](auto const typed_o) {
+        auto seq(typed_o->fresh_seq());
+        for(auto it(begin); it != end; ++it, seq = seq->next_in_place())
+        {
+          if(seq == nullptr || !runtime::equal(*it, seq->first()))
+          {
+            return false;
+          }
+        }
+        return true;
+      },
+      []() { return false; },
+      &o);
+  }
+
+  template <typename Derived, typename It>
+  void iterator_sequence<Derived, It>::to_string(fmt::memory_buffer &buff) const
+  {
+    runtime::to_string(begin, end, "(", ')', buff);
+  }
+
+  template <typename Derived, typename It>
+  native_persistent_string iterator_sequence<Derived, It>::to_string() const
+  {
+    fmt::memory_buffer buff;
+    runtime::to_string(begin, end, "(", ')', buff);
+    return native_persistent_string{ buff.data(), buff.size() };
+  }
+
+  template <typename Derived, typename It>
+  native_persistent_string iterator_sequence<Derived, It>::to_code_string() const
+  {
+    fmt::memory_buffer buff;
+    runtime::to_code_string(begin, end, "(", ')', buff);
+    return native_persistent_string{ buff.data(), buff.size() };
+  }
+
+  template <typename Derived, typename It>
+  native_hash iterator_sequence<Derived, It>::to_hash() const
+  {
+    return hash::ordered(begin, end);
+  }
+
+  template <typename Derived, typename It>
+  native_box<Derived> iterator_sequence<Derived, It>::seq()
+  {
+    return static_cast<Derived *>(this);
+  }
+
+  template <typename Derived, typename It>
+  native_box<Derived> iterator_sequence<Derived, It>::fresh_seq() const
+  {
+    return make_box<Derived>(coll, begin, end, size);
+  }
+
+  template <typename Derived, typename It>
+  size_t iterator_sequence<Derived, It>::count() const
+  {
+    return size;
+  }
+
+  template <typename Derived, typename It>
+  object_ptr iterator_sequence<Derived, It>::first() const
+  {
+    return *begin;
+  }
+
+  template <typename Derived, typename It>
+  native_box<Derived> iterator_sequence<Derived, It>::next() const
+  {
+    auto n(begin);
+    ++n;
+
+    if(n == end)
+    {
+      return nullptr;
+    }
+
+    return make_box<Derived>(coll, n, end, size);
+  }
+
+  template <typename Derived, typename It>
+  native_box<Derived> iterator_sequence<Derived, It>::next_in_place()
+  {
+    ++begin;
+
+    if(begin == end)
+    {
+      return nullptr;
+    }
+
+    return static_cast<Derived *>(this);
+  }
+
+  template <typename Derived, typename It>
+  obj::cons_ptr iterator_sequence<Derived, It>::conj(object_ptr const head)
+  {
+    return make_box<obj::cons>(head, static_cast<Derived *>(this));
+  }
+
+  template struct iterator_sequence<persistent_list_sequence,
+                                    runtime::detail::native_persistent_list::iterator>;
+  template struct iterator_sequence<persistent_sorted_set_sequence,
+                                    runtime::detail::native_persistent_sorted_set::const_iterator>;
+  template struct iterator_sequence<persistent_hash_set_sequence,
+                                    runtime::detail::native_persistent_hash_set::iterator>;
+}

--- a/compiler+runtime/src/cpp/jank/runtime/obj/detail/iterator_sequence.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/detail/iterator_sequence.cpp
@@ -46,7 +46,7 @@ namespace jank::runtime::obj::detail
   }
 
   template <typename Derived, typename It>
-  void iterator_sequence<Derived, It>::to_string(fmt::memory_buffer &buff) const
+  void iterator_sequence<Derived, It>::to_string(util::string_builder &buff) const
   {
     runtime::to_string(begin, end, "(", ')', buff);
   }
@@ -54,17 +54,17 @@ namespace jank::runtime::obj::detail
   template <typename Derived, typename It>
   native_persistent_string iterator_sequence<Derived, It>::to_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     runtime::to_string(begin, end, "(", ')', buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
   template <typename Derived, typename It>
   native_persistent_string iterator_sequence<Derived, It>::to_code_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     runtime::to_code_string(begin, end, "(", ')', buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
   template <typename Derived, typename It>

--- a/compiler+runtime/src/cpp/jank/runtime/obj/integer_range.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/integer_range.cpp
@@ -1,0 +1,198 @@
+#include <jank/runtime/obj/integer_range.hpp>
+#include <jank/runtime/core/math.hpp>
+#include <jank/runtime/core/make_box.hpp>
+#include <jank/runtime/visit.hpp>
+#include <jank/runtime/behavior/metadatable.hpp>
+
+namespace jank::runtime::obj
+{
+  static native_bool positive_step_bounds_check(integer_ptr const val, integer_ptr const end)
+  {
+    return lte(end, val);
+  }
+
+  static native_bool negative_step_bounds_check(integer_ptr const val, integer_ptr const end)
+  {
+    return lte(val, end);
+  }
+
+  integer_range::integer_range(integer_ptr const end)
+    : start{ make_box<integer>(0) }
+    , end{ end }
+    , step{ make_box<integer>(1) }
+    , bounds_check{ positive_step_bounds_check }
+  {
+  }
+
+  integer_range::integer_range(integer_ptr const start, integer_ptr const end)
+    : start{ start }
+    , end{ end }
+    , step{ make_box<integer>(1) }
+    , bounds_check{ positive_step_bounds_check }
+  {
+  }
+
+  integer_range::integer_range(integer_ptr const start,
+                               integer_ptr const end,
+                               integer_ptr const step)
+    : start{ start }
+    , end{ end }
+    , step{ step }
+    , bounds_check{ lt(static_cast<native_integer>(0), step) ? positive_step_bounds_check
+                                                             : negative_step_bounds_check }
+  {
+  }
+
+  integer_range::integer_range(integer_ptr const start,
+                               integer_ptr const end,
+                               integer_ptr const step,
+                               integer_range::bounds_check_t const bounds_check)
+    : start{ start }
+    , end{ end }
+    , step{ step }
+    , bounds_check{ bounds_check }
+  {
+  }
+
+  object_ptr integer_range::create(integer_ptr const end)
+  {
+    if(is_pos(end))
+    {
+      return make_box<integer_range>(make_box<integer>(0),
+                                     end,
+                                     make_box<integer>(1),
+                                     positive_step_bounds_check);
+    }
+    return persistent_list::empty();
+  }
+
+  object_ptr integer_range::create(integer_ptr const start, integer_ptr const end)
+  {
+    return create(start, end, make_box<integer>(1));
+  }
+
+  object_ptr
+  integer_range::create(integer_ptr const start, integer_ptr const end, integer_ptr const step)
+  {
+    if((is_pos(step) && lt(end, start)) || (is_neg(step) && lt(start, end)) || is_equiv(start, end))
+    {
+      return persistent_list::empty();
+    }
+    else if(is_zero(step))
+    {
+      return make_box<repeat>(make_box<integer>(start));
+    }
+    return make_box<integer_range>(start,
+                                   end,
+                                   step,
+                                   is_pos(step) ? positive_step_bounds_check
+                                                : negative_step_bounds_check);
+  }
+
+  integer_range_ptr integer_range::seq() const
+  {
+    return this;
+  }
+
+  integer_range_ptr integer_range::fresh_seq() const
+  {
+    return make_box<integer_range>(start, end, step, bounds_check);
+  }
+
+  integer_ptr integer_range::first() const
+  {
+    return start;
+  }
+
+  integer_range_ptr integer_range::next() const
+  {
+    if(count() <= 1)
+    {
+      return nullptr;
+    }
+    return make_box<integer_range>(make_box<integer>(add(start, step)), end, step, bounds_check);
+  }
+
+  integer_range_ptr integer_range::next_in_place()
+  {
+    if(count() <= 1)
+    {
+      return nullptr;
+    }
+    start = make_box<integer>(add(start, step));
+    return this;
+  }
+
+  cons_ptr integer_range::conj(object_ptr const head) const
+  {
+    return make_box<cons>(head, this);
+  }
+
+  native_bool integer_range::equal(object const &o) const
+  {
+    return visit_seqable(
+      [this](auto const typed_o) {
+        auto seq(typed_o->fresh_seq());
+        /* TODO: This is common code; can it be shared? */
+        for(auto it(fresh_seq()); it != nullptr;
+            it = it->next_in_place(), seq = seq->next_in_place())
+        {
+          if(seq == nullptr || !runtime::equal(it, seq->first()))
+          {
+            return false;
+          }
+        }
+        return true;
+      },
+      []() { return false; },
+      &o);
+  }
+
+  void integer_range::to_string(util::string_builder &buff) const
+  {
+    runtime::to_string(seq(), buff);
+  }
+
+  native_persistent_string integer_range::to_string() const
+  {
+    return runtime::to_string(seq());
+  }
+
+  native_persistent_string integer_range::to_code_string() const
+  {
+    return runtime::to_code_string(seq());
+  }
+
+  native_hash integer_range::to_hash() const
+  {
+    return hash::ordered(&base);
+  }
+
+  integer_range_ptr integer_range::with_meta(object_ptr const m) const
+  {
+    auto const meta(behavior::detail::validate_meta(m));
+    auto const ret(fresh_seq());
+    ret->meta = meta;
+    return ret;
+  }
+
+  size_t integer_range::count() const
+  {
+    auto const s{ step->data };
+    if(s == 0)
+    {
+      throw std::runtime_error("[Integer-Range] Step shouldn't be 0");
+    }
+
+    auto const diff{ sub(end, start) };
+    auto const offset{ s > 0 ? -1 : 1 };
+
+    if((s > 0 && diff > std::numeric_limits<native_integer>::max() - s + offset)
+       || (s < 0 && diff < std::numeric_limits<native_integer>::min() - s + offset))
+    {
+      throw std::runtime_error("[Integer-Range] Overflow occurred in arithmetic");
+    }
+
+    return static_cast<size_t>((diff + offset + s) / s);
+  }
+}

--- a/compiler+runtime/src/cpp/jank/runtime/obj/iterator.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/iterator.cpp
@@ -75,7 +75,7 @@ namespace jank::runtime::obj
       &o);
   }
 
-  void iterator::to_string(fmt::memory_buffer &buff)
+  void iterator::to_string(util::string_builder &buff)
   {
     runtime::to_string(seq(), buff);
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/iterator.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/iterator.cpp
@@ -3,30 +3,30 @@
 #include <jank/runtime/core.hpp>
 #include <jank/runtime/visit.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::iterator::static_object(object_ptr const fn, object_ptr const start)
+  iterator::iterator(object_ptr const fn, object_ptr const start)
     : fn{ fn }
     , current{ start }
   {
   }
 
-  obj::iterator_ptr obj::iterator::seq()
+  iterator_ptr iterator::seq()
   {
     return this;
   }
 
-  obj::iterator_ptr obj::iterator::fresh_seq() const
+  iterator_ptr iterator::fresh_seq() const
   {
-    return make_box<obj::iterator>(fn, current);
+    return make_box<iterator>(fn, current);
   }
 
-  object_ptr obj::iterator::first() const
+  object_ptr iterator::first() const
   {
     return current;
   }
 
-  obj::iterator_ptr obj::iterator::next() const
+  iterator_ptr iterator::next() const
   {
     if(cached_next)
     {
@@ -34,13 +34,13 @@ namespace jank::runtime
     }
 
     auto const next(dynamic_call(fn, current));
-    auto const ret(make_box<obj::iterator>(fn, next));
+    auto const ret(make_box<iterator>(fn, next));
     cached_next = ret;
 
     return ret;
   }
 
-  obj::iterator_ptr obj::iterator::next_in_place()
+  iterator_ptr iterator::next_in_place()
   {
     if(cached_next)
     {
@@ -56,7 +56,7 @@ namespace jank::runtime
     return this;
   }
 
-  native_bool obj::iterator::equal(object const &o) const
+  native_bool iterator::equal(object const &o) const
   {
     return visit_seqable(
       [this](auto const typed_o) {
@@ -75,28 +75,28 @@ namespace jank::runtime
       &o);
   }
 
-  void obj::iterator::to_string(fmt::memory_buffer &buff)
+  void iterator::to_string(fmt::memory_buffer &buff)
   {
     runtime::to_string(seq(), buff);
   }
 
-  native_persistent_string obj::iterator::to_string()
+  native_persistent_string iterator::to_string()
   {
     return runtime::to_string(seq());
   }
 
-  native_persistent_string obj::iterator::to_code_string()
+  native_persistent_string iterator::to_code_string()
   {
     return runtime::to_code_string(seq());
   }
 
-  native_hash obj::iterator::to_hash() const
+  native_hash iterator::to_hash() const
   {
     return hash::ordered(&base);
   }
 
-  obj::cons_ptr obj::iterator::conj(object_ptr const head) const
+  cons_ptr iterator::conj(object_ptr const head) const
   {
-    return make_box<obj::cons>(head, this);
+    return make_box<cons>(head, this);
   }
 }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/jit_closure.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/jit_closure.cpp
@@ -1,3 +1,4 @@
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/jit_closure.hpp>
 #include <jank/runtime/obj/native_function_wrapper.hpp>
 #include <jank/runtime/obj/keyword.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/obj/jit_closure.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/jit_closure.cpp
@@ -1,5 +1,3 @@
-#include <magic_enum.hpp>
-
 #include <jank/runtime/obj/jit_closure.hpp>
 #include <jank/runtime/obj/native_function_wrapper.hpp>
 #include <jank/runtime/obj/keyword.hpp>
@@ -40,7 +38,7 @@ namespace jank::runtime::obj
       std::back_inserter(buff),
       "{} ({}@{})",
       (name->type == object_type::nil ? "unknown" : expect_object<persistent_string>(name)->data),
-      magic_enum::enum_name(base.type),
+      object_type_str(base.type),
       fmt::ptr(&base));
   }
 

--- a/compiler+runtime/src/cpp/jank/runtime/obj/jit_closure.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/jit_closure.cpp
@@ -2,8 +2,10 @@
 
 #include <jank/runtime/obj/jit_closure.hpp>
 #include <jank/runtime/obj/native_function_wrapper.hpp>
+#include <jank/runtime/obj/keyword.hpp>
 #include <jank/runtime/context.hpp>
 #include <jank/runtime/rtti.hpp>
+#include <jank/runtime/core/to_string.hpp>
 
 namespace jank::runtime::obj
 {

--- a/compiler+runtime/src/cpp/jank/runtime/obj/jit_closure.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/jit_closure.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/jit_closure.hpp>
 #include <jank/runtime/obj/native_function_wrapper.hpp>
@@ -26,12 +28,12 @@ namespace jank::runtime::obj
 
   native_persistent_string jit_closure::to_string()
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     to_string(buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
-  void jit_closure::to_string(fmt::memory_buffer &buff)
+  void jit_closure::to_string(util::string_builder &buff)
   {
     auto const name(
       get(meta.unwrap_or(nil::nil_const()), __rt_ctx->intern_keyword("name").expect_ok()));

--- a/compiler+runtime/src/cpp/jank/runtime/obj/jit_closure.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/jit_closure.cpp
@@ -5,62 +5,61 @@
 #include <jank/runtime/context.hpp>
 #include <jank/runtime/rtti.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::jit_closure::static_object(arity_flag_t const arity_flags, void * const context)
+  jit_closure::jit_closure(arity_flag_t const arity_flags, void * const context)
     : context{ context }
     , arity_flags{ arity_flags }
   {
   }
 
-  obj::jit_closure::static_object(object_ptr const meta)
+  jit_closure::jit_closure(object_ptr const meta)
     : meta{ meta }
   {
   }
 
-  native_bool obj::jit_closure::equal(object const &rhs) const
+  native_bool jit_closure::equal(object const &rhs) const
   {
     return &base == &rhs;
   }
 
-  native_persistent_string obj::jit_closure::to_string()
+  native_persistent_string jit_closure::to_string()
   {
     fmt::memory_buffer buff;
     to_string(buff);
     return native_persistent_string{ buff.data(), buff.size() };
   }
 
-  void obj::jit_closure::to_string(fmt::memory_buffer &buff)
+  void jit_closure::to_string(fmt::memory_buffer &buff)
   {
     auto const name(
-      get(meta.unwrap_or(obj::nil::nil_const()), __rt_ctx->intern_keyword("name").expect_ok()));
-    fmt::format_to(std::back_inserter(buff),
-                   "{} ({}@{})",
-                   (name->type == object_type::nil
-                      ? "unknown"
-                      : expect_object<obj::persistent_string>(name)->data),
-                   magic_enum::enum_name(base.type),
-                   fmt::ptr(&base));
+      get(meta.unwrap_or(nil::nil_const()), __rt_ctx->intern_keyword("name").expect_ok()));
+    fmt::format_to(
+      std::back_inserter(buff),
+      "{} ({}@{})",
+      (name->type == object_type::nil ? "unknown" : expect_object<persistent_string>(name)->data),
+      magic_enum::enum_name(base.type),
+      fmt::ptr(&base));
   }
 
-  native_persistent_string obj::jit_closure::to_code_string()
+  native_persistent_string jit_closure::to_code_string()
   {
     return to_string();
   }
 
-  native_hash obj::jit_closure::to_hash() const
+  native_hash jit_closure::to_hash() const
   {
     return static_cast<native_hash>(reinterpret_cast<uintptr_t>(this));
   }
 
-  obj::jit_closure_ptr obj::jit_closure::with_meta(object_ptr const m)
+  jit_closure_ptr jit_closure::with_meta(object_ptr const m)
   {
     auto const new_meta(behavior::detail::validate_meta(m));
     meta = new_meta;
     return this;
   }
 
-  object_ptr obj::jit_closure::call()
+  object_ptr jit_closure::call()
   {
     if(!arity_0)
     {
@@ -69,7 +68,7 @@ namespace jank::runtime
     return arity_0(context);
   }
 
-  object_ptr obj::jit_closure::call(object_ptr const a1)
+  object_ptr jit_closure::call(object_ptr const a1)
   {
     if(!arity_1)
     {
@@ -78,7 +77,7 @@ namespace jank::runtime
     return arity_1(context, a1);
   }
 
-  object_ptr obj::jit_closure::call(object_ptr const a1, object_ptr const a2)
+  object_ptr jit_closure::call(object_ptr const a1, object_ptr const a2)
   {
     if(!arity_2)
     {
@@ -87,7 +86,7 @@ namespace jank::runtime
     return arity_2(context, a1, a2);
   }
 
-  object_ptr obj::jit_closure::call(object_ptr const a1, object_ptr const a2, object_ptr const a3)
+  object_ptr jit_closure::call(object_ptr const a1, object_ptr const a2, object_ptr const a3)
   {
     if(!arity_3)
     {
@@ -96,10 +95,10 @@ namespace jank::runtime
     return arity_3(context, a1, a2, a3);
   }
 
-  object_ptr obj::jit_closure::call(object_ptr const a1,
-                                    object_ptr const a2,
-                                    object_ptr const a3,
-                                    object_ptr const a4)
+  object_ptr jit_closure::call(object_ptr const a1,
+                               object_ptr const a2,
+                               object_ptr const a3,
+                               object_ptr const a4)
   {
     if(!arity_4)
     {
@@ -108,11 +107,11 @@ namespace jank::runtime
     return arity_4(context, a1, a2, a3, a4);
   }
 
-  object_ptr obj::jit_closure::call(object_ptr const a1,
-                                    object_ptr const a2,
-                                    object_ptr const a3,
-                                    object_ptr const a4,
-                                    object_ptr const a5)
+  object_ptr jit_closure::call(object_ptr const a1,
+                               object_ptr const a2,
+                               object_ptr const a3,
+                               object_ptr const a4,
+                               object_ptr const a5)
   {
     if(!arity_5)
     {
@@ -121,12 +120,12 @@ namespace jank::runtime
     return arity_5(context, a1, a2, a3, a4, a5);
   }
 
-  object_ptr obj::jit_closure::call(object_ptr const a1,
-                                    object_ptr const a2,
-                                    object_ptr const a3,
-                                    object_ptr const a4,
-                                    object_ptr const a5,
-                                    object_ptr const a6)
+  object_ptr jit_closure::call(object_ptr const a1,
+                               object_ptr const a2,
+                               object_ptr const a3,
+                               object_ptr const a4,
+                               object_ptr const a5,
+                               object_ptr const a6)
   {
     if(!arity_6)
     {
@@ -135,13 +134,13 @@ namespace jank::runtime
     return arity_6(context, a1, a2, a3, a4, a5, a6);
   }
 
-  object_ptr obj::jit_closure::call(object_ptr const a1,
-                                    object_ptr const a2,
-                                    object_ptr const a3,
-                                    object_ptr const a4,
-                                    object_ptr const a5,
-                                    object_ptr const a6,
-                                    object_ptr const a7)
+  object_ptr jit_closure::call(object_ptr const a1,
+                               object_ptr const a2,
+                               object_ptr const a3,
+                               object_ptr const a4,
+                               object_ptr const a5,
+                               object_ptr const a6,
+                               object_ptr const a7)
   {
     if(!arity_7)
     {
@@ -150,14 +149,14 @@ namespace jank::runtime
     return arity_7(context, a1, a2, a3, a4, a5, a6, a7);
   }
 
-  object_ptr obj::jit_closure::call(object_ptr const a1,
-                                    object_ptr const a2,
-                                    object_ptr const a3,
-                                    object_ptr const a4,
-                                    object_ptr const a5,
-                                    object_ptr const a6,
-                                    object_ptr const a7,
-                                    object_ptr const a8)
+  object_ptr jit_closure::call(object_ptr const a1,
+                               object_ptr const a2,
+                               object_ptr const a3,
+                               object_ptr const a4,
+                               object_ptr const a5,
+                               object_ptr const a6,
+                               object_ptr const a7,
+                               object_ptr const a8)
   {
     if(!arity_8)
     {
@@ -166,15 +165,15 @@ namespace jank::runtime
     return arity_8(context, a1, a2, a3, a4, a5, a6, a7, a8);
   }
 
-  object_ptr obj::jit_closure::call(object_ptr const a1,
-                                    object_ptr const a2,
-                                    object_ptr const a3,
-                                    object_ptr const a4,
-                                    object_ptr const a5,
-                                    object_ptr const a6,
-                                    object_ptr const a7,
-                                    object_ptr const a8,
-                                    object_ptr const a9)
+  object_ptr jit_closure::call(object_ptr const a1,
+                               object_ptr const a2,
+                               object_ptr const a3,
+                               object_ptr const a4,
+                               object_ptr const a5,
+                               object_ptr const a6,
+                               object_ptr const a7,
+                               object_ptr const a8,
+                               object_ptr const a9)
   {
     if(!arity_9)
     {
@@ -183,16 +182,16 @@ namespace jank::runtime
     return arity_9(context, a1, a2, a3, a4, a5, a6, a7, a8, a9);
   }
 
-  object_ptr obj::jit_closure::call(object_ptr const a1,
-                                    object_ptr const a2,
-                                    object_ptr const a3,
-                                    object_ptr const a4,
-                                    object_ptr const a5,
-                                    object_ptr const a6,
-                                    object_ptr const a7,
-                                    object_ptr const a8,
-                                    object_ptr const a9,
-                                    object_ptr const a10)
+  object_ptr jit_closure::call(object_ptr const a1,
+                               object_ptr const a2,
+                               object_ptr const a3,
+                               object_ptr const a4,
+                               object_ptr const a5,
+                               object_ptr const a6,
+                               object_ptr const a7,
+                               object_ptr const a8,
+                               object_ptr const a9,
+                               object_ptr const a10)
   {
     if(!arity_10)
     {
@@ -201,12 +200,12 @@ namespace jank::runtime
     return arity_10(context, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10);
   }
 
-  behavior::callable::arity_flag_t obj::jit_closure::get_arity_flags() const
+  behavior::callable::arity_flag_t jit_closure::get_arity_flags() const
   {
     return arity_flags;
   }
 
-  object_ptr obj::jit_closure::this_object_ptr()
+  object_ptr jit_closure::this_object_ptr()
   {
     return &this->base;
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/jit_function.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/jit_function.cpp
@@ -6,61 +6,60 @@
 #include <jank/runtime/context.hpp>
 #include <jank/runtime/rtti.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::jit_function::static_object(arity_flag_t const arity_flags)
+  jit_function::jit_function(arity_flag_t const arity_flags)
     : arity_flags{ arity_flags }
   {
   }
 
-  obj::jit_function::static_object(object_ptr const meta)
+  jit_function::jit_function(object_ptr const meta)
     : meta{ meta }
   {
   }
 
-  native_bool obj::jit_function::equal(object const &rhs) const
+  native_bool jit_function::equal(object const &rhs) const
   {
     return &base == &rhs;
   }
 
-  native_persistent_string obj::jit_function::to_string()
+  native_persistent_string jit_function::to_string()
   {
     fmt::memory_buffer buff;
     to_string(buff);
     return native_persistent_string{ buff.data(), buff.size() };
   }
 
-  void obj::jit_function::to_string(fmt::memory_buffer &buff)
+  void jit_function::to_string(fmt::memory_buffer &buff)
   {
     auto const name(
-      get(meta.unwrap_or(obj::nil::nil_const()), __rt_ctx->intern_keyword("name").expect_ok()));
-    fmt::format_to(std::back_inserter(buff),
-                   "{} ({}@{})",
-                   (name->type == object_type::nil
-                      ? "unknown"
-                      : expect_object<obj::persistent_string>(name)->data),
-                   magic_enum::enum_name(base.type),
-                   fmt::ptr(&base));
+      get(meta.unwrap_or(nil::nil_const()), __rt_ctx->intern_keyword("name").expect_ok()));
+    fmt::format_to(
+      std::back_inserter(buff),
+      "{} ({}@{})",
+      (name->type == object_type::nil ? "unknown" : expect_object<persistent_string>(name)->data),
+      magic_enum::enum_name(base.type),
+      fmt::ptr(&base));
   }
 
-  native_persistent_string obj::jit_function::to_code_string()
+  native_persistent_string jit_function::to_code_string()
   {
     return to_string();
   }
 
-  native_hash obj::jit_function::to_hash() const
+  native_hash jit_function::to_hash() const
   {
     return static_cast<native_hash>(reinterpret_cast<uintptr_t>(this));
   }
 
-  obj::jit_function_ptr obj::jit_function::with_meta(object_ptr const m)
+  jit_function_ptr jit_function::with_meta(object_ptr const m)
   {
     auto const new_meta(behavior::detail::validate_meta(m));
     meta = new_meta;
     return this;
   }
 
-  object_ptr obj::jit_function::call()
+  object_ptr jit_function::call()
   {
     if(!arity_0)
     {
@@ -69,7 +68,7 @@ namespace jank::runtime
     return arity_0();
   }
 
-  object_ptr obj::jit_function::call(object_ptr const a1)
+  object_ptr jit_function::call(object_ptr const a1)
   {
     if(!arity_1)
     {
@@ -78,7 +77,7 @@ namespace jank::runtime
     return arity_1(a1);
   }
 
-  object_ptr obj::jit_function::call(object_ptr const a1, object_ptr const a2)
+  object_ptr jit_function::call(object_ptr const a1, object_ptr const a2)
   {
     if(!arity_2)
     {
@@ -87,7 +86,7 @@ namespace jank::runtime
     return arity_2(a1, a2);
   }
 
-  object_ptr obj::jit_function::call(object_ptr const a1, object_ptr const a2, object_ptr const a3)
+  object_ptr jit_function::call(object_ptr const a1, object_ptr const a2, object_ptr const a3)
   {
     if(!arity_3)
     {
@@ -96,10 +95,10 @@ namespace jank::runtime
     return arity_3(a1, a2, a3);
   }
 
-  object_ptr obj::jit_function::call(object_ptr const a1,
-                                     object_ptr const a2,
-                                     object_ptr const a3,
-                                     object_ptr const a4)
+  object_ptr jit_function::call(object_ptr const a1,
+                                object_ptr const a2,
+                                object_ptr const a3,
+                                object_ptr const a4)
   {
     if(!arity_4)
     {
@@ -108,11 +107,11 @@ namespace jank::runtime
     return arity_4(a1, a2, a3, a4);
   }
 
-  object_ptr obj::jit_function::call(object_ptr const a1,
-                                     object_ptr const a2,
-                                     object_ptr const a3,
-                                     object_ptr const a4,
-                                     object_ptr const a5)
+  object_ptr jit_function::call(object_ptr const a1,
+                                object_ptr const a2,
+                                object_ptr const a3,
+                                object_ptr const a4,
+                                object_ptr const a5)
   {
     if(!arity_5)
     {
@@ -121,12 +120,12 @@ namespace jank::runtime
     return arity_5(a1, a2, a3, a4, a5);
   }
 
-  object_ptr obj::jit_function::call(object_ptr const a1,
-                                     object_ptr const a2,
-                                     object_ptr const a3,
-                                     object_ptr const a4,
-                                     object_ptr const a5,
-                                     object_ptr const a6)
+  object_ptr jit_function::call(object_ptr const a1,
+                                object_ptr const a2,
+                                object_ptr const a3,
+                                object_ptr const a4,
+                                object_ptr const a5,
+                                object_ptr const a6)
   {
     if(!arity_6)
     {
@@ -135,13 +134,13 @@ namespace jank::runtime
     return arity_6(a1, a2, a3, a4, a5, a6);
   }
 
-  object_ptr obj::jit_function::call(object_ptr const a1,
-                                     object_ptr const a2,
-                                     object_ptr const a3,
-                                     object_ptr const a4,
-                                     object_ptr const a5,
-                                     object_ptr const a6,
-                                     object_ptr const a7)
+  object_ptr jit_function::call(object_ptr const a1,
+                                object_ptr const a2,
+                                object_ptr const a3,
+                                object_ptr const a4,
+                                object_ptr const a5,
+                                object_ptr const a6,
+                                object_ptr const a7)
   {
     if(!arity_7)
     {
@@ -150,14 +149,14 @@ namespace jank::runtime
     return arity_7(a1, a2, a3, a4, a5, a6, a7);
   }
 
-  object_ptr obj::jit_function::call(object_ptr const a1,
-                                     object_ptr const a2,
-                                     object_ptr const a3,
-                                     object_ptr const a4,
-                                     object_ptr const a5,
-                                     object_ptr const a6,
-                                     object_ptr const a7,
-                                     object_ptr const a8)
+  object_ptr jit_function::call(object_ptr const a1,
+                                object_ptr const a2,
+                                object_ptr const a3,
+                                object_ptr const a4,
+                                object_ptr const a5,
+                                object_ptr const a6,
+                                object_ptr const a7,
+                                object_ptr const a8)
   {
     if(!arity_8)
     {
@@ -166,15 +165,15 @@ namespace jank::runtime
     return arity_8(a1, a2, a3, a4, a5, a6, a7, a8);
   }
 
-  object_ptr obj::jit_function::call(object_ptr const a1,
-                                     object_ptr const a2,
-                                     object_ptr const a3,
-                                     object_ptr const a4,
-                                     object_ptr const a5,
-                                     object_ptr const a6,
-                                     object_ptr const a7,
-                                     object_ptr const a8,
-                                     object_ptr const a9)
+  object_ptr jit_function::call(object_ptr const a1,
+                                object_ptr const a2,
+                                object_ptr const a3,
+                                object_ptr const a4,
+                                object_ptr const a5,
+                                object_ptr const a6,
+                                object_ptr const a7,
+                                object_ptr const a8,
+                                object_ptr const a9)
   {
     if(!arity_9)
     {
@@ -183,16 +182,16 @@ namespace jank::runtime
     return arity_9(a1, a2, a3, a4, a5, a6, a7, a8, a9);
   }
 
-  object_ptr obj::jit_function::call(object_ptr const a1,
-                                     object_ptr const a2,
-                                     object_ptr const a3,
-                                     object_ptr const a4,
-                                     object_ptr const a5,
-                                     object_ptr const a6,
-                                     object_ptr const a7,
-                                     object_ptr const a8,
-                                     object_ptr const a9,
-                                     object_ptr const a10)
+  object_ptr jit_function::call(object_ptr const a1,
+                                object_ptr const a2,
+                                object_ptr const a3,
+                                object_ptr const a4,
+                                object_ptr const a5,
+                                object_ptr const a6,
+                                object_ptr const a7,
+                                object_ptr const a8,
+                                object_ptr const a9,
+                                object_ptr const a10)
   {
     if(!arity_10)
     {
@@ -201,12 +200,12 @@ namespace jank::runtime
     return arity_10(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10);
   }
 
-  behavior::callable::arity_flag_t obj::jit_function::get_arity_flags() const
+  behavior::callable::arity_flag_t jit_function::get_arity_flags() const
   {
     return arity_flags;
   }
 
-  object_ptr obj::jit_function::this_object_ptr()
+  object_ptr jit_function::this_object_ptr()
   {
     return &this->base;
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/jit_function.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/jit_function.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/jit_function.hpp>
 #include <jank/runtime/obj/native_function_wrapper.hpp>
@@ -25,12 +27,12 @@ namespace jank::runtime::obj
 
   native_persistent_string jit_function::to_string()
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     to_string(buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
-  void jit_function::to_string(fmt::memory_buffer &buff)
+  void jit_function::to_string(util::string_builder &buff)
   {
     auto const name(
       get(meta.unwrap_or(nil::nil_const()), __rt_ctx->intern_keyword("name").expect_ok()));

--- a/compiler+runtime/src/cpp/jank/runtime/obj/jit_function.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/jit_function.cpp
@@ -1,5 +1,3 @@
-#include <magic_enum.hpp>
-
 #include <jank/runtime/obj/jit_function.hpp>
 #include <jank/runtime/obj/native_function_wrapper.hpp>
 #include <jank/runtime/obj/keyword.hpp>
@@ -39,7 +37,7 @@ namespace jank::runtime::obj
       std::back_inserter(buff),
       "{} ({}@{})",
       (name->type == object_type::nil ? "unknown" : expect_object<persistent_string>(name)->data),
-      magic_enum::enum_name(base.type),
+      object_type_str(base.type),
       fmt::ptr(&base));
   }
 

--- a/compiler+runtime/src/cpp/jank/runtime/obj/jit_function.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/jit_function.cpp
@@ -2,6 +2,7 @@
 
 #include <jank/runtime/obj/jit_function.hpp>
 #include <jank/runtime/obj/native_function_wrapper.hpp>
+#include <jank/runtime/obj/keyword.hpp>
 #include <jank/runtime/core/to_string.hpp>
 #include <jank/runtime/context.hpp>
 #include <jank/runtime/rtti.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/obj/jit_function.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/jit_function.cpp
@@ -1,3 +1,4 @@
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/jit_function.hpp>
 #include <jank/runtime/obj/native_function_wrapper.hpp>
 #include <jank/runtime/obj/keyword.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/obj/keyword.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/keyword.cpp
@@ -1,18 +1,19 @@
 #include <jank/runtime/obj/keyword.hpp>
+#include <jank/runtime/obj/symbol.hpp>
 #include <jank/runtime/rtti.hpp>
 #include <jank/runtime/core/seq.hpp>
 
 namespace jank::runtime::obj
 {
   keyword::keyword(detail::must_be_interned, native_persistent_string_view const &s)
-    : sym{ s }
+    : sym{ make_box<obj::symbol>(s) }
   {
   }
 
   keyword::keyword(detail::must_be_interned,
                    native_persistent_string_view const &ns,
                    native_persistent_string_view const &n)
-    : sym{ ns, n }
+    : sym{ make_box<obj::symbol>(ns, n) }
   {
   }
 
@@ -30,13 +31,13 @@ namespace jank::runtime::obj
 
   void keyword::to_string(fmt::memory_buffer &buff) const
   {
-    to_string_impl(sym, buff);
+    to_string_impl(*sym, buff);
   }
 
   native_persistent_string keyword::to_string() const
   {
     fmt::memory_buffer buff;
-    to_string_impl(sym, buff);
+    to_string_impl(*sym, buff);
     return native_persistent_string{ buff.data(), buff.size() };
   }
 
@@ -47,7 +48,7 @@ namespace jank::runtime::obj
 
   native_hash keyword::to_hash() const
   {
-    return sym.to_hash() + 0x9e3779b9;
+    return sym->to_hash() + 0x9e3779b9;
   }
 
   native_integer keyword::compare(object const &o) const
@@ -57,17 +58,17 @@ namespace jank::runtime::obj
 
   native_integer keyword::compare(keyword const &s) const
   {
-    return sym.compare(s.sym);
+    return sym->compare(*s.sym);
   }
 
   native_persistent_string const &keyword::get_name() const
   {
-    return sym.name;
+    return sym->name;
   }
 
   native_persistent_string const &keyword::get_namespace() const
   {
-    return sym.ns;
+    return sym->ns;
   }
 
   object_ptr keyword::call(object_ptr const m)
@@ -82,6 +83,6 @@ namespace jank::runtime::obj
 
   bool keyword::operator==(keyword const &rhs) const
   {
-    return sym == rhs.sym;
+    return *sym == *rhs.sym;
   }
 }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/keyword.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/keyword.cpp
@@ -2,85 +2,85 @@
 #include <jank/runtime/rtti.hpp>
 #include <jank/runtime/core/seq.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::keyword::static_object(detail::must_be_interned, native_persistent_string_view const &s)
+  keyword::keyword(detail::must_be_interned, native_persistent_string_view const &s)
     : sym{ s }
   {
   }
 
-  obj::keyword::static_object(detail::must_be_interned,
-                              native_persistent_string_view const &ns,
-                              native_persistent_string_view const &n)
+  keyword::keyword(detail::must_be_interned,
+                   native_persistent_string_view const &ns,
+                   native_persistent_string_view const &n)
     : sym{ ns, n }
   {
   }
 
   /* Keywords are interned, so we can always count on identity equality. */
-  native_bool obj::keyword::equal(object const &o) const
+  native_bool keyword::equal(object const &o) const
   {
     return &base == &o;
   }
 
-  static void to_string_impl(obj::symbol const &sym, fmt::memory_buffer &buff)
+  static void to_string_impl(symbol const &sym, fmt::memory_buffer &buff)
   {
     std::back_inserter(buff) = ':';
     sym.to_string(buff);
   }
 
-  void obj::keyword::to_string(fmt::memory_buffer &buff) const
+  void keyword::to_string(fmt::memory_buffer &buff) const
   {
     to_string_impl(sym, buff);
   }
 
-  native_persistent_string obj::keyword::to_string() const
+  native_persistent_string keyword::to_string() const
   {
     fmt::memory_buffer buff;
     to_string_impl(sym, buff);
     return native_persistent_string{ buff.data(), buff.size() };
   }
 
-  native_persistent_string obj::keyword::to_code_string() const
+  native_persistent_string keyword::to_code_string() const
   {
     return to_string();
   }
 
-  native_hash obj::keyword::to_hash() const
+  native_hash keyword::to_hash() const
   {
     return sym.to_hash() + 0x9e3779b9;
   }
 
-  native_integer obj::keyword::compare(object const &o) const
+  native_integer keyword::compare(object const &o) const
   {
-    return compare(*expect_object<obj::keyword>(&o));
+    return compare(*expect_object<keyword>(&o));
   }
 
-  native_integer obj::keyword::compare(obj::keyword const &s) const
+  native_integer keyword::compare(keyword const &s) const
   {
     return sym.compare(s.sym);
   }
 
-  native_persistent_string const &obj::keyword::get_name() const
+  native_persistent_string const &keyword::get_name() const
   {
     return sym.name;
   }
 
-  native_persistent_string const &obj::keyword::get_namespace() const
+  native_persistent_string const &keyword::get_namespace() const
   {
     return sym.ns;
   }
 
-  object_ptr obj::keyword::call(object_ptr const m)
+  object_ptr keyword::call(object_ptr const m)
   {
     return runtime::get(m, this);
   }
 
-  object_ptr obj::keyword::call(object_ptr const m, object_ptr const fallback)
+  object_ptr keyword::call(object_ptr const m, object_ptr const fallback)
   {
     return runtime::get(m, this, fallback);
   }
 
-  bool obj::keyword::operator==(obj::keyword const &rhs) const
+  bool keyword::operator==(keyword const &rhs) const
   {
     return sym == rhs.sym;
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/keyword.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/keyword.cpp
@@ -23,22 +23,22 @@ namespace jank::runtime::obj
     return &base == &o;
   }
 
-  static void to_string_impl(symbol const &sym, fmt::memory_buffer &buff)
+  static void to_string_impl(symbol const &sym, util::string_builder &buff)
   {
     std::back_inserter(buff) = ':';
     sym.to_string(buff);
   }
 
-  void keyword::to_string(fmt::memory_buffer &buff) const
+  void keyword::to_string(util::string_builder &buff) const
   {
     to_string_impl(*sym, buff);
   }
 
   native_persistent_string keyword::to_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     to_string_impl(*sym, buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
   native_persistent_string keyword::to_code_string() const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/lazy_sequence.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/lazy_sequence.cpp
@@ -1,9 +1,12 @@
 #include <jank/runtime/obj/lazy_sequence.hpp>
 #include <jank/runtime/obj/persistent_list.hpp>
 #include <jank/runtime/obj/nil.hpp>
+#include <jank/runtime/obj/cons.hpp>
 #include <jank/runtime/behavior/callable.hpp>
 #include <jank/runtime/behavior/metadatable.hpp>
 #include <jank/runtime/rtti.hpp>
+#include <jank/runtime/core/seq.hpp>
+#include <jank/runtime/core/to_string.hpp>
 
 namespace jank::runtime::obj
 {

--- a/compiler+runtime/src/cpp/jank/runtime/obj/lazy_sequence.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/lazy_sequence.cpp
@@ -81,7 +81,7 @@ namespace jank::runtime::obj
     return sequence_equal(this, &o);
   }
 
-  void lazy_sequence::to_string(fmt::memory_buffer &buff) const
+  void lazy_sequence::to_string(util::string_builder &buff) const
   {
     runtime::to_string(seq(), buff);
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/lazy_sequence.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/lazy_sequence.cpp
@@ -5,66 +5,66 @@
 #include <jank/runtime/behavior/metadatable.hpp>
 #include <jank/runtime/rtti.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::lazy_sequence::static_object(object_ptr const fn)
+  lazy_sequence::lazy_sequence(object_ptr const fn)
     : fn{ fn }
   {
     assert(fn);
   }
 
-  obj::lazy_sequence::static_object(object_ptr const fn, object_ptr const sequence)
+  lazy_sequence::lazy_sequence(object_ptr const fn, object_ptr const sequence)
     : fn{ fn }
     , sequence{ sequence }
   {
   }
 
-  obj::lazy_sequence_ptr obj::lazy_sequence::seq() const
+  lazy_sequence_ptr lazy_sequence::seq() const
   {
     resolve_seq();
     return sequence ? this : nullptr;
   }
 
-  obj::lazy_sequence_ptr obj::lazy_sequence::fresh_seq() const
+  lazy_sequence_ptr lazy_sequence::fresh_seq() const
   {
-    auto ret(make_box<obj::lazy_sequence>(fn, sequence));
+    auto ret(make_box<lazy_sequence>(fn, sequence));
     ret->fn_result = fn_result;
     return ret;
   }
 
-  object_ptr obj::lazy_sequence::first() const
+  object_ptr lazy_sequence::first() const
   {
     resolve_seq();
     if(sequence)
     {
       return runtime::first(sequence);
     }
-    return obj::nil::nil_const();
+    return nil::nil_const();
   }
 
-  obj::lazy_sequence_ptr obj::lazy_sequence::next() const
+  lazy_sequence_ptr lazy_sequence::next() const
   {
     resolve_seq();
     if(sequence)
     {
       auto const n(runtime::next(sequence));
-      if(n == obj::nil::nil_const())
+      if(n == nil::nil_const())
       {
         return nullptr;
       }
-      return make_box<obj::lazy_sequence>(nullptr, n);
+      return make_box<lazy_sequence>(nullptr, n);
     }
     return nullptr;
   }
 
-  obj::lazy_sequence_ptr obj::lazy_sequence::next_in_place()
+  lazy_sequence_ptr lazy_sequence::next_in_place()
   {
     resolve_seq();
     if(sequence)
     {
       /* We don't know we own this sequence, so we can't use next_in_place. */
       sequence = runtime::next(sequence);
-      if(sequence == obj::nil::nil_const())
+      if(sequence == nil::nil_const())
       {
         sequence = nullptr;
       }
@@ -73,27 +73,27 @@ namespace jank::runtime
     return nullptr;
   }
 
-  native_bool obj::lazy_sequence::equal(object const &o) const
+  native_bool lazy_sequence::equal(object const &o) const
   {
     return sequence_equal(this, &o);
   }
 
-  void obj::lazy_sequence::to_string(fmt::memory_buffer &buff) const
+  void lazy_sequence::to_string(fmt::memory_buffer &buff) const
   {
     runtime::to_string(seq(), buff);
   }
 
-  native_persistent_string obj::lazy_sequence::to_string() const
+  native_persistent_string lazy_sequence::to_string() const
   {
     return runtime::to_string(seq());
   }
 
-  native_persistent_string obj::lazy_sequence::to_code_string() const
+  native_persistent_string lazy_sequence::to_code_string() const
   {
     return runtime::to_code_string(seq());
   }
 
-  native_hash obj::lazy_sequence::to_hash() const
+  native_hash lazy_sequence::to_hash() const
   {
     auto const s(seq());
     if(!s)
@@ -103,19 +103,19 @@ namespace jank::runtime
     return hash::ordered(s);
   }
 
-  obj::cons_ptr obj::lazy_sequence::conj(object_ptr const head) const
+  cons_ptr lazy_sequence::conj(object_ptr const head) const
   {
     resolve_seq();
-    return make_box<obj::cons>(head, sequence ? this : nullptr);
+    return make_box<cons>(head, sequence ? this : nullptr);
   }
 
-  object_ptr obj::lazy_sequence::resolve_fn() const
+  object_ptr lazy_sequence::resolve_fn() const
   {
     if(fn)
     {
       fn_result = dynamic_call(fn);
       fn = nullptr;
-      if(fn_result == obj::nil::nil_const())
+      if(fn_result == nil::nil_const())
       {
         fn_result = nullptr;
       }
@@ -127,7 +127,7 @@ namespace jank::runtime
     return sequence;
   }
 
-  object_ptr obj::lazy_sequence::resolve_seq() const
+  object_ptr lazy_sequence::resolve_seq() const
   {
     resolve_fn();
     if(fn_result)
@@ -136,12 +136,12 @@ namespace jank::runtime
       fn_result = nullptr;
       while(lazy && lazy->type == object_type::lazy_sequence)
       {
-        lazy = expect_object<obj::lazy_sequence>(lazy)->resolve_fn();
+        lazy = expect_object<lazy_sequence>(lazy)->resolve_fn();
       }
       if(lazy)
       {
         sequence = runtime::seq(lazy);
-        if(sequence == obj::nil::nil_const())
+        if(sequence == nil::nil_const())
         {
           sequence = nullptr;
         }
@@ -150,7 +150,7 @@ namespace jank::runtime
     return sequence;
   }
 
-  obj::lazy_sequence_ptr obj::lazy_sequence::with_meta(object_ptr const m) const
+  lazy_sequence_ptr lazy_sequence::with_meta(object_ptr const m) const
   {
     auto const meta(behavior::detail::validate_meta(m));
     auto ret(fresh_seq());

--- a/compiler+runtime/src/cpp/jank/runtime/obj/multi_function.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/multi_function.cpp
@@ -1,4 +1,7 @@
 #include <jank/runtime/obj/multi_function.hpp>
+#include <jank/runtime/obj/persistent_hash_set.hpp>
+#include <jank/runtime/obj/persistent_vector_sequence.hpp>
+#include <jank/runtime/obj/persistent_hash_map.hpp>
 #include <jank/runtime/context.hpp>
 #include <jank/runtime/rtti.hpp>
 #include <jank/runtime/core.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/obj/multi_function.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/multi_function.cpp
@@ -5,6 +5,7 @@
 #include <jank/runtime/context.hpp>
 #include <jank/runtime/rtti.hpp>
 #include <jank/runtime/core.hpp>
+#include <jank/native_persistent_string/fmt.hpp>
 
 namespace jank::runtime::obj
 {

--- a/compiler+runtime/src/cpp/jank/runtime/obj/multi_function.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/multi_function.cpp
@@ -3,35 +3,35 @@
 #include <jank/runtime/rtti.hpp>
 #include <jank/runtime/core.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::multi_function::static_object(object_ptr const name,
-                                     object_ptr const dispatch,
-                                     object_ptr const default_,
-                                     object_ptr const hierarchy)
+  multi_function::multi_function(object_ptr const name,
+                                 object_ptr const dispatch,
+                                 object_ptr const default_,
+                                 object_ptr const hierarchy)
     : dispatch{ dispatch }
     , default_dispatch_value{ default_ }
     , hierarchy{ hierarchy }
-    , method_table{ obj::persistent_hash_map::empty() }
-    , method_cache{ obj::persistent_hash_map::empty() }
-    , prefer_table{ obj::persistent_hash_map::empty() }
-    , name{ try_object<obj::symbol>(name) }
+    , method_table{ persistent_hash_map::empty() }
+    , method_cache{ persistent_hash_map::empty() }
+    , prefer_table{ persistent_hash_map::empty() }
+    , name{ try_object<symbol>(name) }
   {
   }
 
-  native_bool obj::multi_function::equal(object const &rhs) const
+  native_bool multi_function::equal(object const &rhs) const
   {
     return &base == &rhs;
   }
 
-  native_persistent_string obj::multi_function::to_string()
+  native_persistent_string multi_function::to_string()
   {
     fmt::memory_buffer buff;
     to_string(buff);
     return native_persistent_string{ buff.data(), buff.size() };
   }
 
-  void obj::multi_function::to_string(fmt::memory_buffer &buff)
+  void multi_function::to_string(fmt::memory_buffer &buff)
   {
     fmt::format_to(std::back_inserter(buff),
                    "{} ({}@{})",
@@ -40,60 +40,59 @@ namespace jank::runtime
                    fmt::ptr(&base));
   }
 
-  native_persistent_string obj::multi_function::to_code_string()
+  native_persistent_string multi_function::to_code_string()
   {
     return to_string();
   }
 
-  native_hash obj::multi_function::to_hash() const
+  native_hash multi_function::to_hash() const
   {
     return static_cast<native_hash>(reinterpret_cast<uintptr_t>(this));
   }
 
-  object_ptr obj::multi_function::call()
+  object_ptr multi_function::call()
   {
     return dynamic_call(get_fn(dynamic_call(dispatch)));
   }
 
-  object_ptr obj::multi_function::call(object_ptr const a1)
+  object_ptr multi_function::call(object_ptr const a1)
   {
     return dynamic_call(get_fn(dynamic_call(dispatch, a1)), a1);
   }
 
-  object_ptr obj::multi_function::call(object_ptr const a1, object_ptr const a2)
+  object_ptr multi_function::call(object_ptr const a1, object_ptr const a2)
   {
     return dynamic_call(get_fn(dynamic_call(dispatch, a1, a2)), a1, a2);
   }
 
-  object_ptr
-  obj::multi_function::call(object_ptr const a1, object_ptr const a2, object_ptr const a3)
+  object_ptr multi_function::call(object_ptr const a1, object_ptr const a2, object_ptr const a3)
   {
     return dynamic_call(get_fn(dynamic_call(dispatch, a1, a2, a3)), a1, a2, a3);
   }
 
-  object_ptr obj::multi_function::call(object_ptr const a1,
-                                       object_ptr const a2,
-                                       object_ptr const a3,
-                                       object_ptr const a4)
+  object_ptr multi_function::call(object_ptr const a1,
+                                  object_ptr const a2,
+                                  object_ptr const a3,
+                                  object_ptr const a4)
   {
     return dynamic_call(get_fn(dynamic_call(dispatch, a1, a2, a3, a4)), a1, a2, a3, a4);
   }
 
-  object_ptr obj::multi_function::call(object_ptr const a1,
-                                       object_ptr const a2,
-                                       object_ptr const a3,
-                                       object_ptr const a4,
-                                       object_ptr const a5)
+  object_ptr multi_function::call(object_ptr const a1,
+                                  object_ptr const a2,
+                                  object_ptr const a3,
+                                  object_ptr const a4,
+                                  object_ptr const a5)
   {
     return dynamic_call(get_fn(dynamic_call(dispatch, a1, a2, a3, a4, a5)), a1, a2, a3, a4, a5);
   }
 
-  object_ptr obj::multi_function::call(object_ptr const a1,
-                                       object_ptr const a2,
-                                       object_ptr const a3,
-                                       object_ptr const a4,
-                                       object_ptr const a5,
-                                       object_ptr const a6)
+  object_ptr multi_function::call(object_ptr const a1,
+                                  object_ptr const a2,
+                                  object_ptr const a3,
+                                  object_ptr const a4,
+                                  object_ptr const a5,
+                                  object_ptr const a6)
   {
     return dynamic_call(get_fn(dynamic_call(dispatch, a1, a2, a3, a4, a5, a6)),
                         a1,
@@ -104,13 +103,13 @@ namespace jank::runtime
                         a6);
   }
 
-  object_ptr obj::multi_function::call(object_ptr const a1,
-                                       object_ptr const a2,
-                                       object_ptr const a3,
-                                       object_ptr const a4,
-                                       object_ptr const a5,
-                                       object_ptr const a6,
-                                       object_ptr const a7)
+  object_ptr multi_function::call(object_ptr const a1,
+                                  object_ptr const a2,
+                                  object_ptr const a3,
+                                  object_ptr const a4,
+                                  object_ptr const a5,
+                                  object_ptr const a6,
+                                  object_ptr const a7)
   {
     return dynamic_call(get_fn(dynamic_call(dispatch, a1, a2, a3, a4, a5, a6, a7)),
                         a1,
@@ -122,14 +121,14 @@ namespace jank::runtime
                         a7);
   }
 
-  object_ptr obj::multi_function::call(object_ptr const a1,
-                                       object_ptr const a2,
-                                       object_ptr const a3,
-                                       object_ptr const a4,
-                                       object_ptr const a5,
-                                       object_ptr const a6,
-                                       object_ptr const a7,
-                                       object_ptr const a8)
+  object_ptr multi_function::call(object_ptr const a1,
+                                  object_ptr const a2,
+                                  object_ptr const a3,
+                                  object_ptr const a4,
+                                  object_ptr const a5,
+                                  object_ptr const a6,
+                                  object_ptr const a7,
+                                  object_ptr const a8)
   {
     return dynamic_call(get_fn(dynamic_call(dispatch, a1, a2, a3, a4, a5, a6, a7, a8)),
                         a1,
@@ -142,15 +141,15 @@ namespace jank::runtime
                         a8);
   }
 
-  object_ptr obj::multi_function::call(object_ptr const a1,
-                                       object_ptr const a2,
-                                       object_ptr const a3,
-                                       object_ptr const a4,
-                                       object_ptr const a5,
-                                       object_ptr const a6,
-                                       object_ptr const a7,
-                                       object_ptr const a8,
-                                       object_ptr const a9)
+  object_ptr multi_function::call(object_ptr const a1,
+                                  object_ptr const a2,
+                                  object_ptr const a3,
+                                  object_ptr const a4,
+                                  object_ptr const a5,
+                                  object_ptr const a6,
+                                  object_ptr const a7,
+                                  object_ptr const a8,
+                                  object_ptr const a9)
   {
     return dynamic_call(get_fn(dynamic_call(dispatch, a1, a2, a3, a4, a5, a6, a7, a8, a9)),
                         a1,
@@ -164,16 +163,16 @@ namespace jank::runtime
                         a9);
   }
 
-  object_ptr obj::multi_function::call(object_ptr const a1,
-                                       object_ptr const a2,
-                                       object_ptr const a3,
-                                       object_ptr const a4,
-                                       object_ptr const a5,
-                                       object_ptr const a6,
-                                       object_ptr const a7,
-                                       object_ptr const a8,
-                                       object_ptr const a9,
-                                       object_ptr const a10)
+  object_ptr multi_function::call(object_ptr const a1,
+                                  object_ptr const a2,
+                                  object_ptr const a3,
+                                  object_ptr const a4,
+                                  object_ptr const a5,
+                                  object_ptr const a6,
+                                  object_ptr const a7,
+                                  object_ptr const a8,
+                                  object_ptr const a9,
+                                  object_ptr const a10)
   {
     return dynamic_call(get_fn(dynamic_call(dispatch, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)),
                         a1,
@@ -188,20 +187,20 @@ namespace jank::runtime
                         a10);
   }
 
-  object_ptr obj::multi_function::this_object_ptr()
+  object_ptr multi_function::this_object_ptr()
   {
     return &this->base;
   }
 
-  obj::multi_function_ptr obj::multi_function::reset()
+  multi_function_ptr multi_function::reset()
   {
     std::lock_guard<std::recursive_mutex> const locked{ data_lock };
     cached_hierarchy = nullptr;
-    method_table = prefer_table = method_cache = obj::persistent_hash_map::empty();
+    method_table = prefer_table = method_cache = persistent_hash_map::empty();
     return this;
   }
 
-  obj::persistent_hash_map_ptr obj::multi_function::reset_cache()
+  persistent_hash_map_ptr multi_function::reset_cache()
   {
     std::lock_guard<std::recursive_mutex> const locked{ data_lock };
     cached_hierarchy = hierarchy;
@@ -209,8 +208,8 @@ namespace jank::runtime
     return method_cache;
   }
 
-  obj::multi_function_ptr
-  obj::multi_function::add_method(object_ptr const dispatch_val, object_ptr const method)
+  multi_function_ptr
+  multi_function::add_method(object_ptr const dispatch_val, object_ptr const method)
   {
     std::lock_guard<std::recursive_mutex> const locked{ data_lock };
 
@@ -219,7 +218,7 @@ namespace jank::runtime
     return this;
   }
 
-  obj::multi_function_ptr obj::multi_function::remove_method(object_ptr const dispatch_val)
+  multi_function_ptr multi_function::remove_method(object_ptr const dispatch_val)
   {
     std::lock_guard<std::recursive_mutex> const locked{ data_lock };
     method_table = method_table->dissoc(dispatch_val);
@@ -227,7 +226,7 @@ namespace jank::runtime
     return this;
   }
 
-  obj::multi_function_ptr obj::multi_function::prefer_method(object_ptr const x, object_ptr const y)
+  multi_function_ptr multi_function::prefer_method(object_ptr const x, object_ptr const y)
   {
     std::lock_guard<std::recursive_mutex> const locked{ data_lock };
 
@@ -247,13 +246,12 @@ namespace jank::runtime
     return this;
   }
 
-  native_bool obj::multi_function::is_preferred(object_ptr const hierarchy,
-                                                object_ptr const x,
-                                                object_ptr const y) const
+  native_bool multi_function::is_preferred(object_ptr const hierarchy,
+                                           object_ptr const x,
+                                           object_ptr const y) const
   {
     auto const x_prefs(prefer_table->get(x));
-    if(x_prefs != obj::nil::nil_const()
-       && expect_object<obj::persistent_hash_set>(x_prefs)->contains(y))
+    if(x_prefs != nil::nil_const() && expect_object<persistent_hash_set>(x_prefs)->contains(y))
     {
       return true;
     }
@@ -263,7 +261,7 @@ namespace jank::runtime
     };
 
     for(auto it(fresh_seq(dynamic_call(parents, hierarchy, y)));
-        it != nullptr && it != obj::nil::nil_const();
+        it != nullptr && it != nil::nil_const();
         it = next_in_place(it))
     {
       if(is_preferred(hierarchy, x, first(it)))
@@ -273,7 +271,7 @@ namespace jank::runtime
     }
 
     for(auto it(fresh_seq(dynamic_call(parents, hierarchy, x)));
-        it != nullptr && it != obj::nil::nil_const();
+        it != nullptr && it != nil::nil_const();
         it = next_in_place(it))
     {
       if(is_preferred(hierarchy, first(it), y))
@@ -286,7 +284,7 @@ namespace jank::runtime
   }
 
   native_bool
-  obj::multi_function::is_a(object_ptr const hierarchy, object_ptr const x, object_ptr const y)
+  multi_function::is_a(object_ptr const hierarchy, object_ptr const x, object_ptr const y)
   {
     static object_ptr const isa{
       __rt_ctx->intern_var("clojure.core", "isa?").expect_ok()->deref()
@@ -294,17 +292,17 @@ namespace jank::runtime
     return truthy(dynamic_call(isa, deref(hierarchy), x, y));
   }
 
-  native_bool obj::multi_function::is_dominant(object_ptr const hierarchy,
-                                               object_ptr const x,
-                                               object_ptr const y) const
+  native_bool multi_function::is_dominant(object_ptr const hierarchy,
+                                          object_ptr const x,
+                                          object_ptr const y) const
   {
     return is_preferred(hierarchy, x, y) || is_a(hierarchy, x, y);
   }
 
-  object_ptr obj::multi_function::get_fn(object_ptr const dispatch_val)
+  object_ptr multi_function::get_fn(object_ptr const dispatch_val)
   {
     auto const target(get_method(dispatch_val));
-    if(target == obj::nil::nil_const())
+    if(target == nil::nil_const())
     {
       throw std::runtime_error{ fmt::format("No method in multimethod '{}' for dispatch value: {}",
                                             runtime::to_string(name),
@@ -313,7 +311,7 @@ namespace jank::runtime
     return target;
   }
 
-  object_ptr obj::multi_function::get_method(object_ptr const dispatch_val)
+  object_ptr multi_function::get_method(object_ptr const dispatch_val)
   {
     if(cached_hierarchy != deref(hierarchy))
     {
@@ -321,7 +319,7 @@ namespace jank::runtime
     }
 
     auto const target(method_cache->get(dispatch_val));
-    if(target != obj::nil::nil_const())
+    if(target != nil::nil_const())
     {
       return target;
     }
@@ -329,12 +327,12 @@ namespace jank::runtime
     return find_and_cache_best_method(dispatch_val);
   }
 
-  object_ptr obj::multi_function::find_and_cache_best_method(object_ptr const dispatch_val)
+  object_ptr multi_function::find_and_cache_best_method(object_ptr const dispatch_val)
   {
     /* TODO: Clojure uses a RW lock here for better parallelism. */
     std::lock_guard<std::recursive_mutex> const locked{ data_lock };
-    object_ptr best_value{ obj::nil::nil_const() };
-    obj::persistent_vector_sequence_ptr best_entry{};
+    object_ptr best_value{ nil::nil_const() };
+    persistent_vector_sequence_ptr best_entry{};
 
     for(auto it(fresh_seq(method_table)); it != nullptr; it = it->next_in_place())
     {
@@ -368,7 +366,7 @@ namespace jank::runtime
     else
     {
       best_value = method_table->get(default_dispatch_value);
-      if(best_value == obj::nil::nil_const())
+      if(best_value == nil::nil_const())
       {
         return best_value;
       }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/multi_function.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/multi_function.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include <jank/runtime/obj/multi_function.hpp>
 #include <jank/runtime/obj/persistent_hash_set.hpp>
 #include <jank/runtime/obj/persistent_vector_sequence.hpp>
@@ -30,12 +32,12 @@ namespace jank::runtime::obj
 
   native_persistent_string multi_function::to_string()
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     to_string(buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
-  void multi_function::to_string(fmt::memory_buffer &buff)
+  void multi_function::to_string(util::string_builder &buff)
   {
     fmt::format_to(std::back_inserter(buff),
                    "{} ({}@{})",

--- a/compiler+runtime/src/cpp/jank/runtime/obj/multi_function.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/multi_function.cpp
@@ -39,7 +39,7 @@ namespace jank::runtime::obj
     fmt::format_to(std::back_inserter(buff),
                    "{} ({}@{})",
                    name->to_string(),
-                   magic_enum::enum_name(base.type),
+                   object_type_str(base.type),
                    fmt::ptr(&base));
   }
 

--- a/compiler+runtime/src/cpp/jank/runtime/obj/native_array_sequence.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/native_array_sequence.cpp
@@ -2,9 +2,9 @@
 #include <jank/runtime/core/to_string.hpp>
 #include <jank/runtime/core/seq_ext.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::native_array_sequence::static_object(object_ptr * const arr, size_t const size)
+  native_array_sequence::native_array_sequence(object_ptr * const arr, size_t const size)
     : arr{ arr }
     , size{ size }
   {
@@ -12,9 +12,9 @@ namespace jank::runtime
     assert(size > 0);
   }
 
-  obj::native_array_sequence::static_object(object_ptr * const arr,
-                                            size_t const index,
-                                            size_t const size)
+  native_array_sequence::native_array_sequence(object_ptr * const arr,
+                                               size_t const index,
+                                               size_t const size)
     : arr{ arr }
     , index{ index }
     , size{ size }
@@ -24,60 +24,60 @@ namespace jank::runtime
   }
 
   /* behavior::objectable */
-  native_bool obj::native_array_sequence::equal(object const &o) const
+  native_bool native_array_sequence::equal(object const &o) const
   {
     return runtime::equal(o, arr + index, arr + size);
   }
 
-  void obj::native_array_sequence::to_string(fmt::memory_buffer &buff) const
+  void native_array_sequence::to_string(fmt::memory_buffer &buff) const
   {
     runtime::to_string(arr + index, arr + size, "(", ')', buff);
   }
 
-  native_persistent_string obj::native_array_sequence::to_string() const
+  native_persistent_string native_array_sequence::to_string() const
   {
     fmt::memory_buffer buff;
     runtime::to_string(arr + index, arr + size, "(", ')', buff);
     return native_persistent_string{ buff.data(), buff.size() };
   }
 
-  native_persistent_string obj::native_array_sequence::to_code_string() const
+  native_persistent_string native_array_sequence::to_code_string() const
   {
     fmt::memory_buffer buff;
     runtime::to_code_string(arr + index, arr + size, "(", ')', buff);
     return native_persistent_string{ buff.data(), buff.size() };
   }
 
-  native_hash obj::native_array_sequence::to_hash() const
+  native_hash native_array_sequence::to_hash() const
   {
     return hash::ordered(arr + index, arr + size);
   }
 
   /* behavior::seqable */
-  obj::native_array_sequence_ptr obj::native_array_sequence::seq()
+  native_array_sequence_ptr native_array_sequence::seq()
   {
     return this;
   }
 
-  obj::native_array_sequence_ptr obj::native_array_sequence::fresh_seq()
+  native_array_sequence_ptr native_array_sequence::fresh_seq()
   {
-    return make_box<obj::native_array_sequence>(arr, index, size);
+    return make_box<native_array_sequence>(arr, index, size);
   }
 
   /* behavior::countable */
-  size_t obj::native_array_sequence::count() const
+  size_t native_array_sequence::count() const
   {
     return size - index;
   }
 
   /* behavior::sequence */
-  object_ptr obj::native_array_sequence::first() const
+  object_ptr native_array_sequence::first() const
   {
     assert(index < size);
     return arr[index];
   }
 
-  obj::native_array_sequence_ptr obj::native_array_sequence::next() const
+  native_array_sequence_ptr native_array_sequence::next() const
   {
     auto n(index);
     ++n;
@@ -87,10 +87,10 @@ namespace jank::runtime
       return nullptr;
     }
 
-    return make_box<obj::native_array_sequence>(arr, n, size);
+    return make_box<native_array_sequence>(arr, n, size);
   }
 
-  obj::native_array_sequence_ptr obj::native_array_sequence::next_in_place()
+  native_array_sequence_ptr native_array_sequence::next_in_place()
   {
     ++index;
 
@@ -102,8 +102,8 @@ namespace jank::runtime
     return this;
   }
 
-  obj::cons_ptr obj::native_array_sequence::conj(object_ptr const head)
+  cons_ptr native_array_sequence::conj(object_ptr const head)
   {
-    return make_box<obj::cons>(head, this);
+    return make_box<cons>(head, this);
   }
 }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/native_array_sequence.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/native_array_sequence.cpp
@@ -29,23 +29,23 @@ namespace jank::runtime::obj
     return runtime::equal(o, arr + index, arr + size);
   }
 
-  void native_array_sequence::to_string(fmt::memory_buffer &buff) const
+  void native_array_sequence::to_string(util::string_builder &buff) const
   {
     runtime::to_string(arr + index, arr + size, "(", ')', buff);
   }
 
   native_persistent_string native_array_sequence::to_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     runtime::to_string(arr + index, arr + size, "(", ')', buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
   native_persistent_string native_array_sequence::to_code_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     runtime::to_code_string(arr + index, arr + size, "(", ')', buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
   native_hash native_array_sequence::to_hash() const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/native_function_wrapper.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/native_function_wrapper.cpp
@@ -4,24 +4,24 @@
 #include <jank/runtime/context.hpp>
 #include <jank/runtime/core/seq.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::native_function_wrapper::static_object(obj::detail::function_type &&d)
+  native_function_wrapper::native_function_wrapper(detail::function_type &&d)
     : data{ std::move(d) }
   {
   }
 
-  obj::native_function_wrapper::static_object(obj::detail::function_type const &d)
+  native_function_wrapper::native_function_wrapper(detail::function_type const &d)
     : data{ d }
   {
   }
 
-  native_bool obj::native_function_wrapper::equal(object const &o) const
+  native_bool native_function_wrapper::equal(object const &o) const
   {
     return &base == &o;
   }
 
-  void obj::native_function_wrapper::to_string(fmt::memory_buffer &buff) const
+  void native_function_wrapper::to_string(fmt::memory_buffer &buff) const
   {
     fmt::format_to(std::back_inserter(buff),
                    "{}@{}",
@@ -29,19 +29,19 @@ namespace jank::runtime
                    fmt::ptr(&base));
   }
 
-  native_persistent_string obj::native_function_wrapper::to_string() const
+  native_persistent_string native_function_wrapper::to_string() const
   {
     fmt::memory_buffer buff;
     to_string(buff);
     return native_persistent_string{ buff.data(), buff.size() };
   }
 
-  native_persistent_string obj::native_function_wrapper::to_code_string() const
+  native_persistent_string native_function_wrapper::to_code_string() const
   {
     return to_string();
   }
 
-  native_hash obj::native_function_wrapper::to_hash() const
+  native_hash native_function_wrapper::to_hash() const
   {
     return static_cast<native_hash>(reinterpret_cast<uintptr_t>(this));
   }
@@ -59,11 +59,11 @@ namespace jank::runtime
   };
 
   template <typename... Args>
-  static object_ptr apply_function(obj::native_function_wrapper const &f, Args &&...args)
+  static object_ptr apply_function(native_function_wrapper const &f, Args &&...args)
   {
     constexpr size_t arg_count{ sizeof...(Args) };
     using arity = typename build_arity<arg_count>::type;
-    using function_type = obj::detail::function_type::value_type<arity>;
+    using function_type = detail::function_type::value_type<arity>;
 
     auto const * const func_ptr(f.data.template get<function_type>());
     if(!func_ptr)
@@ -73,7 +73,7 @@ namespace jank::runtime
       {
         auto const name_kw(__rt_ctx->intern_keyword("name").expect_ok());
         auto const name_meta(runtime::get(f.meta.unwrap(), name_kw));
-        if(name_meta != obj::nil::nil_const())
+        if(name_meta != nil::nil_const())
         {
           name = to_string(name_meta);
         }
@@ -84,112 +84,110 @@ namespace jank::runtime
     return (*func_ptr)(std::forward<Args>(args)...);
   }
 
-  object_ptr obj::native_function_wrapper::call()
+  object_ptr native_function_wrapper::call()
   {
     return apply_function(*this);
   }
 
-  object_ptr obj::native_function_wrapper::call(object_ptr arg1)
+  object_ptr native_function_wrapper::call(object_ptr arg1)
   {
     return apply_function(*this, arg1);
   }
 
-  object_ptr obj::native_function_wrapper::call(object_ptr arg1, object_ptr arg2)
+  object_ptr native_function_wrapper::call(object_ptr arg1, object_ptr arg2)
   {
     return apply_function(*this, arg1, arg2);
   }
 
-  object_ptr obj::native_function_wrapper::call(object_ptr arg1, object_ptr arg2, object_ptr arg3)
+  object_ptr native_function_wrapper::call(object_ptr arg1, object_ptr arg2, object_ptr arg3)
   {
     return apply_function(*this, arg1, arg2, arg3);
   }
 
-  object_ptr obj::native_function_wrapper::call(object_ptr arg1,
-                                                object_ptr arg2,
-                                                object_ptr arg3,
-                                                object_ptr arg4)
+  object_ptr
+  native_function_wrapper::call(object_ptr arg1, object_ptr arg2, object_ptr arg3, object_ptr arg4)
   {
     return apply_function(*this, arg1, arg2, arg3, arg4);
   }
 
-  object_ptr obj::native_function_wrapper::call(object_ptr arg1,
-                                                object_ptr arg2,
-                                                object_ptr arg3,
-                                                object_ptr arg4,
-                                                object_ptr arg5)
+  object_ptr native_function_wrapper::call(object_ptr arg1,
+                                           object_ptr arg2,
+                                           object_ptr arg3,
+                                           object_ptr arg4,
+                                           object_ptr arg5)
   {
     return apply_function(*this, arg1, arg2, arg3, arg4, arg5);
   }
 
-  object_ptr obj::native_function_wrapper::call(object_ptr arg1,
-                                                object_ptr arg2,
-                                                object_ptr arg3,
-                                                object_ptr arg4,
-                                                object_ptr arg5,
-                                                object_ptr arg6)
+  object_ptr native_function_wrapper::call(object_ptr arg1,
+                                           object_ptr arg2,
+                                           object_ptr arg3,
+                                           object_ptr arg4,
+                                           object_ptr arg5,
+                                           object_ptr arg6)
   {
     return apply_function(*this, arg1, arg2, arg3, arg4, arg5, arg6);
   }
 
-  object_ptr obj::native_function_wrapper::call(object_ptr arg1,
-                                                object_ptr arg2,
-                                                object_ptr arg3,
-                                                object_ptr arg4,
-                                                object_ptr arg5,
-                                                object_ptr arg6,
-                                                object_ptr arg7)
+  object_ptr native_function_wrapper::call(object_ptr arg1,
+                                           object_ptr arg2,
+                                           object_ptr arg3,
+                                           object_ptr arg4,
+                                           object_ptr arg5,
+                                           object_ptr arg6,
+                                           object_ptr arg7)
   {
     return apply_function(*this, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
   }
 
-  object_ptr obj::native_function_wrapper::call(object_ptr arg1,
-                                                object_ptr arg2,
-                                                object_ptr arg3,
-                                                object_ptr arg4,
-                                                object_ptr arg5,
-                                                object_ptr arg6,
-                                                object_ptr arg7,
-                                                object_ptr arg8)
+  object_ptr native_function_wrapper::call(object_ptr arg1,
+                                           object_ptr arg2,
+                                           object_ptr arg3,
+                                           object_ptr arg4,
+                                           object_ptr arg5,
+                                           object_ptr arg6,
+                                           object_ptr arg7,
+                                           object_ptr arg8)
   {
     return apply_function(*this, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
   }
 
-  object_ptr obj::native_function_wrapper::call(object_ptr arg1,
-                                                object_ptr arg2,
-                                                object_ptr arg3,
-                                                object_ptr arg4,
-                                                object_ptr arg5,
-                                                object_ptr arg6,
-                                                object_ptr arg7,
-                                                object_ptr arg8,
-                                                object_ptr arg9)
+  object_ptr native_function_wrapper::call(object_ptr arg1,
+                                           object_ptr arg2,
+                                           object_ptr arg3,
+                                           object_ptr arg4,
+                                           object_ptr arg5,
+                                           object_ptr arg6,
+                                           object_ptr arg7,
+                                           object_ptr arg8,
+                                           object_ptr arg9)
   {
     return apply_function(*this, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
   }
 
-  object_ptr obj::native_function_wrapper::call(object_ptr arg1,
-                                                object_ptr arg2,
-                                                object_ptr arg3,
-                                                object_ptr arg4,
-                                                object_ptr arg5,
-                                                object_ptr arg6,
-                                                object_ptr arg7,
-                                                object_ptr arg8,
-                                                object_ptr arg9,
-                                                object_ptr arg10)
+  object_ptr native_function_wrapper::call(object_ptr arg1,
+                                           object_ptr arg2,
+                                           object_ptr arg3,
+                                           object_ptr arg4,
+                                           object_ptr arg5,
+                                           object_ptr arg6,
+                                           object_ptr arg7,
+                                           object_ptr arg8,
+                                           object_ptr arg9,
+                                           object_ptr arg10)
   {
     return apply_function(*this, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
   }
 
-  obj::native_function_wrapper_ptr obj::native_function_wrapper::with_meta(object_ptr const m) const
+  native_function_wrapper_ptr native_function_wrapper::with_meta(object_ptr const m) const
   {
     auto const meta(behavior::detail::validate_meta(m));
-    auto ret(make_box<obj::native_function_wrapper>(data));
+    auto ret(make_box<native_function_wrapper>(data));
     ret->meta = meta;
     return ret;
   }
 
-  object_ptr obj::native_function_wrapper::this_object_ptr()
+  object_ptr native_function_wrapper::this_object_ptr()
   {
     return &this->base;
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/native_function_wrapper.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/native_function_wrapper.cpp
@@ -1,8 +1,10 @@
 #include <magic_enum.hpp>
 
 #include <jank/runtime/obj/native_function_wrapper.hpp>
+#include <jank/runtime/obj/keyword.hpp>
 #include <jank/runtime/context.hpp>
 #include <jank/runtime/core/seq.hpp>
+#include <jank/runtime/core/to_string.hpp>
 
 namespace jank::runtime::obj
 {

--- a/compiler+runtime/src/cpp/jank/runtime/obj/native_function_wrapper.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/native_function_wrapper.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/native_function_wrapper.hpp>
 #include <jank/runtime/obj/keyword.hpp>
@@ -22,16 +24,16 @@ namespace jank::runtime::obj
     return &base == &o;
   }
 
-  void native_function_wrapper::to_string(fmt::memory_buffer &buff) const
+  void native_function_wrapper::to_string(util::string_builder &buff) const
   {
     fmt::format_to(std::back_inserter(buff), "{}@{}", object_type_str(base.type), fmt::ptr(&base));
   }
 
   native_persistent_string native_function_wrapper::to_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     to_string(buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
   native_persistent_string native_function_wrapper::to_code_string() const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/native_function_wrapper.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/native_function_wrapper.cpp
@@ -1,3 +1,4 @@
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/native_function_wrapper.hpp>
 #include <jank/runtime/obj/keyword.hpp>
 #include <jank/runtime/context.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/obj/native_function_wrapper.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/native_function_wrapper.cpp
@@ -1,5 +1,3 @@
-#include <magic_enum.hpp>
-
 #include <jank/runtime/obj/native_function_wrapper.hpp>
 #include <jank/runtime/obj/keyword.hpp>
 #include <jank/runtime/context.hpp>
@@ -25,10 +23,7 @@ namespace jank::runtime::obj
 
   void native_function_wrapper::to_string(fmt::memory_buffer &buff) const
   {
-    fmt::format_to(std::back_inserter(buff),
-                   "{}@{}",
-                   magic_enum::enum_name(base.type),
-                   fmt::ptr(&base));
+    fmt::format_to(std::back_inserter(buff), "{}@{}", object_type_str(base.type), fmt::ptr(&base));
   }
 
   native_persistent_string native_function_wrapper::to_string() const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/native_pointer_wrapper.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/native_pointer_wrapper.cpp
@@ -3,25 +3,25 @@
 #include <jank/runtime/obj/native_pointer_wrapper.hpp>
 #include <jank/runtime/rtti.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::native_pointer_wrapper::static_object(void * const d)
+  native_pointer_wrapper::native_pointer_wrapper(void * const d)
     : data{ d }
   {
   }
 
-  native_bool obj::native_pointer_wrapper::equal(object const &o) const
+  native_bool native_pointer_wrapper::equal(object const &o) const
   {
     if(o.type != object_type::native_pointer_wrapper)
     {
       return false;
     }
 
-    auto const c(expect_object<obj::native_pointer_wrapper>(&o));
+    auto const c(expect_object<native_pointer_wrapper>(&o));
     return data == c->data;
   }
 
-  void obj::native_pointer_wrapper::to_string(fmt::memory_buffer &buff) const
+  void native_pointer_wrapper::to_string(fmt::memory_buffer &buff) const
   {
     fmt::format_to(std::back_inserter(buff),
                    "{}@{}",
@@ -29,19 +29,19 @@ namespace jank::runtime
                    fmt::ptr(&base));
   }
 
-  native_persistent_string obj::native_pointer_wrapper::to_string() const
+  native_persistent_string native_pointer_wrapper::to_string() const
   {
     fmt::memory_buffer buff;
     to_string(buff);
     return native_persistent_string{ buff.data(), buff.size() };
   }
 
-  native_persistent_string obj::native_pointer_wrapper::to_code_string() const
+  native_persistent_string native_pointer_wrapper::to_code_string() const
   {
     return to_string();
   }
 
-  native_hash obj::native_pointer_wrapper::to_hash() const
+  native_hash native_pointer_wrapper::to_hash() const
   {
     return static_cast<native_hash>(reinterpret_cast<uintptr_t>(data));
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/native_pointer_wrapper.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/native_pointer_wrapper.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include <jank/runtime/obj/native_pointer_wrapper.hpp>
 #include <jank/runtime/rtti.hpp>
 
@@ -19,16 +21,16 @@ namespace jank::runtime::obj
     return data == c->data;
   }
 
-  void native_pointer_wrapper::to_string(fmt::memory_buffer &buff) const
+  void native_pointer_wrapper::to_string(util::string_builder &buff) const
   {
     fmt::format_to(std::back_inserter(buff), "{}@{}", object_type_str(base.type), fmt::ptr(&base));
   }
 
   native_persistent_string native_pointer_wrapper::to_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     to_string(buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
   native_persistent_string native_pointer_wrapper::to_code_string() const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/native_pointer_wrapper.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/native_pointer_wrapper.cpp
@@ -1,5 +1,3 @@
-#include <magic_enum.hpp>
-
 #include <jank/runtime/obj/native_pointer_wrapper.hpp>
 #include <jank/runtime/rtti.hpp>
 
@@ -23,10 +21,7 @@ namespace jank::runtime::obj
 
   void native_pointer_wrapper::to_string(fmt::memory_buffer &buff) const
   {
-    fmt::format_to(std::back_inserter(buff),
-                   "{}@{}",
-                   magic_enum::enum_name(base.type),
-                   fmt::ptr(&base));
+    fmt::format_to(std::back_inserter(buff), "{}@{}", object_type_str(base.type), fmt::ptr(&base));
   }
 
   native_persistent_string native_pointer_wrapper::to_string() const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/native_vector_sequence.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/native_vector_sequence.cpp
@@ -31,23 +31,23 @@ namespace jank::runtime::obj
     return runtime::equal(o, data.begin(), data.end());
   }
 
-  void native_vector_sequence::to_string(fmt::memory_buffer &buff) const
+  void native_vector_sequence::to_string(util::string_builder &buff) const
   {
     runtime::to_string(data.begin(), data.end(), "(", ')', buff);
   }
 
   native_persistent_string native_vector_sequence::to_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     runtime::to_string(data.begin(), data.end(), "(", ')', buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
   native_persistent_string native_vector_sequence::to_code_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     runtime::to_code_string(data.begin(), data.end(), "(", ')', buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
   native_hash native_vector_sequence::to_hash()

--- a/compiler+runtime/src/cpp/jank/runtime/obj/native_vector_sequence.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/native_vector_sequence.cpp
@@ -2,22 +2,23 @@
 #include <jank/runtime/core.hpp>
 #include <jank/runtime/core/seq_ext.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::native_vector_sequence::static_object(native_vector<object_ptr> const &data, size_t index)
+  native_vector_sequence::native_vector_sequence(native_vector<object_ptr> const &data,
+                                                 size_t index)
     : data{ data }
     , index{ index }
   {
     assert(!this->data.empty());
   }
 
-  obj::native_vector_sequence::static_object(native_vector<object_ptr> &&data)
+  native_vector_sequence::native_vector_sequence(native_vector<object_ptr> &&data)
     : data{ std::move(data) }
   {
     assert(!this->data.empty());
   }
 
-  obj::native_vector_sequence::static_object(native_vector<object_ptr> &&data, size_t index)
+  native_vector_sequence::native_vector_sequence(native_vector<object_ptr> &&data, size_t index)
     : data{ std::move(data) }
     , index{ index }
   {
@@ -25,60 +26,60 @@ namespace jank::runtime
   }
 
   /* behavior::objectable */
-  native_bool obj::native_vector_sequence::equal(object const &o) const
+  native_bool native_vector_sequence::equal(object const &o) const
   {
     return runtime::equal(o, data.begin(), data.end());
   }
 
-  void obj::native_vector_sequence::to_string(fmt::memory_buffer &buff) const
+  void native_vector_sequence::to_string(fmt::memory_buffer &buff) const
   {
     runtime::to_string(data.begin(), data.end(), "(", ')', buff);
   }
 
-  native_persistent_string obj::native_vector_sequence::to_string() const
+  native_persistent_string native_vector_sequence::to_string() const
   {
     fmt::memory_buffer buff;
     runtime::to_string(data.begin(), data.end(), "(", ')', buff);
     return native_persistent_string{ buff.data(), buff.size() };
   }
 
-  native_persistent_string obj::native_vector_sequence::to_code_string() const
+  native_persistent_string native_vector_sequence::to_code_string() const
   {
     fmt::memory_buffer buff;
     runtime::to_code_string(data.begin(), data.end(), "(", ')', buff);
     return native_persistent_string{ buff.data(), buff.size() };
   }
 
-  native_hash obj::native_vector_sequence::to_hash()
+  native_hash native_vector_sequence::to_hash()
   {
     return hash::ordered(data.begin(), data.end());
   }
 
   /* behavior::seqable */
-  obj::native_vector_sequence_ptr obj::native_vector_sequence::seq()
+  native_vector_sequence_ptr native_vector_sequence::seq()
   {
     return data.empty() ? nullptr : this;
   }
 
-  obj::native_vector_sequence_ptr obj::native_vector_sequence::fresh_seq()
+  native_vector_sequence_ptr native_vector_sequence::fresh_seq()
   {
-    return data.empty() ? nullptr : make_box<obj::native_vector_sequence>(data, index);
+    return data.empty() ? nullptr : make_box<native_vector_sequence>(data, index);
   }
 
   /* behavior::countable */
-  size_t obj::native_vector_sequence::count() const
+  size_t native_vector_sequence::count() const
   {
     return data.size() - index;
   }
 
   /* behavior::sequence */
-  object_ptr obj::native_vector_sequence::first() const
+  object_ptr native_vector_sequence::first() const
   {
     assert(index < data.size());
     return data[index];
   }
 
-  obj::native_vector_sequence_ptr obj::native_vector_sequence::next() const
+  native_vector_sequence_ptr native_vector_sequence::next() const
   {
     auto n(index);
     ++n;
@@ -88,10 +89,10 @@ namespace jank::runtime
       return nullptr;
     }
 
-    return make_box<obj::native_vector_sequence>(data, n);
+    return make_box<native_vector_sequence>(data, n);
   }
 
-  obj::native_vector_sequence_ptr obj::native_vector_sequence::next_in_place()
+  native_vector_sequence_ptr native_vector_sequence::next_in_place()
   {
     ++index;
 
@@ -103,8 +104,8 @@ namespace jank::runtime
     return this;
   }
 
-  obj::cons_ptr obj::native_vector_sequence::conj(object_ptr const head)
+  cons_ptr native_vector_sequence::conj(object_ptr const head)
   {
-    return make_box<obj::cons>(head, data.empty() ? nullptr : this);
+    return make_box<cons>(head, data.empty() ? nullptr : this);
   }
 }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/nil.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/nil.cpp
@@ -1,3 +1,5 @@
+#include <fmt/compile.h>
+
 #include <jank/runtime/obj/nil.hpp>
 #include <jank/runtime/obj/persistent_array_map.hpp>
 #include <jank/runtime/obj/cons.hpp>
@@ -26,7 +28,7 @@ namespace jank::runtime::obj
     return to_string();
   }
 
-  void nil::to_string(fmt::memory_buffer &buff) const
+  void nil::to_string(util::string_builder &buff) const
   {
     fmt::format_to(std::back_inserter(buff), "nil");
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/nil.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/nil.cpp
@@ -1,5 +1,6 @@
 #include <jank/runtime/obj/nil.hpp>
 #include <jank/runtime/obj/persistent_array_map.hpp>
+#include <jank/runtime/obj/cons.hpp>
 
 namespace jank::runtime::obj
 {

--- a/compiler+runtime/src/cpp/jank/runtime/obj/nil.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/nil.cpp
@@ -1,106 +1,106 @@
 #include <jank/runtime/obj/nil.hpp>
 #include <jank/runtime/obj/persistent_array_map.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::nil_ptr obj::nil::nil_const()
+  nil_ptr nil::nil_const()
   {
-    static obj::nil r{};
+    static nil r{};
     return &r;
   }
 
-  native_bool obj::nil::equal(object const &o) const
+  native_bool nil::equal(object const &o) const
   {
     return &o == &base;
   }
 
-  native_persistent_string const &obj::nil::to_string() const
+  native_persistent_string const &nil::to_string() const
   {
     static native_persistent_string const s{ "nil" };
     return s;
   }
 
-  native_persistent_string const &obj::nil::to_code_string() const
+  native_persistent_string const &nil::to_code_string() const
   {
     return to_string();
   }
 
-  void obj::nil::to_string(fmt::memory_buffer &buff) const
+  void nil::to_string(fmt::memory_buffer &buff) const
   {
     fmt::format_to(std::back_inserter(buff), "nil");
   }
 
-  native_hash obj::nil::to_hash() const
+  native_hash nil::to_hash() const
   {
     return 0;
   }
 
-  native_integer obj::nil::compare(object const &o) const
+  native_integer nil::compare(object const &o) const
   {
     return (o.type == object_type::nil ? 0 : -1);
   }
 
-  native_integer obj::nil::compare(obj::nil const &) const
+  native_integer nil::compare(nil const &) const
   {
     return 0;
   }
 
-  object_ptr obj::nil::get(object_ptr const)
+  object_ptr nil::get(object_ptr const)
   {
     return &base;
   }
 
-  object_ptr obj::nil::get(object_ptr const, object_ptr const fallback)
+  object_ptr nil::get(object_ptr const, object_ptr const fallback)
   {
     return fallback;
   }
 
-  object_ptr obj::nil::get_entry(object_ptr)
+  object_ptr nil::get_entry(object_ptr)
   {
     return &base;
   }
 
-  native_bool obj::nil::contains(object_ptr) const
+  native_bool nil::contains(object_ptr) const
   {
     return false;
   }
 
-  obj::persistent_array_map_ptr obj::nil::assoc(object_ptr const key, object_ptr const val) const
+  persistent_array_map_ptr nil::assoc(object_ptr const key, object_ptr const val) const
   {
-    return obj::persistent_array_map::create_unique(key, val);
+    return persistent_array_map::create_unique(key, val);
   }
 
-  obj::nil_ptr obj::nil::dissoc(object_ptr const) const
-  {
-    return this;
-  }
-
-  obj::nil_ptr obj::nil::seq()
-  {
-    return nullptr;
-  }
-
-  obj::nil_ptr obj::nil::fresh_seq() const
-  {
-    return nullptr;
-  }
-
-  obj::nil_ptr obj::nil::first() const
+  nil_ptr nil::dissoc(object_ptr const) const
   {
     return this;
   }
 
-  obj::nil_ptr obj::nil::next() const
+  nil_ptr nil::seq()
   {
     return nullptr;
   }
 
-  obj::cons_ptr obj::nil::conj(object_ptr const head) const
+  nil_ptr nil::fresh_seq() const
   {
-    return make_box<obj::cons>(head, nullptr);
+    return nullptr;
   }
 
-  obj::nil_ptr obj::nil::next_in_place()
+  nil_ptr nil::first() const
+  {
+    return this;
+  }
+
+  nil_ptr nil::next() const
+  {
+    return nullptr;
+  }
+
+  cons_ptr nil::conj(object_ptr const head) const
+  {
+    return make_box<cons>(head, nullptr);
+  }
+
+  nil_ptr nil::next_in_place()
   {
     return nullptr;
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/number.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/number.cpp
@@ -3,34 +3,34 @@
 #include <jank/runtime/obj/number.hpp>
 #include <jank/runtime/visit.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
   /***** boolean *****/
-  obj::boolean_ptr obj::boolean::true_const()
+  boolean_ptr boolean::true_const()
   {
-    static obj::boolean r{ true };
+    static boolean r{ true };
     return &r;
   }
 
-  obj::boolean_ptr obj::boolean::false_const()
+  boolean_ptr boolean::false_const()
   {
-    static obj::boolean r{ false };
+    static boolean r{ false };
     return &r;
   }
 
-  obj::boolean::static_object(native_bool const d)
+  boolean::boolean(native_bool const d)
     : data{ d }
   {
   }
 
-  native_bool obj::boolean::equal(object const &o) const
+  native_bool boolean::equal(object const &o) const
   {
     if(o.type != object_type::boolean)
     {
       return false;
     }
 
-    auto const b(expect_object<obj::boolean>(&o));
+    auto const b(expect_object<boolean>(&o));
     return data == b->data;
   }
 
@@ -39,29 +39,29 @@ namespace jank::runtime
     format_to(std::back_inserter(buff), FMT_COMPILE("{}"), data ? "true" : "false");
   }
 
-  void obj::boolean::to_string(fmt::memory_buffer &buff) const
+  void boolean::to_string(fmt::memory_buffer &buff) const
   {
     to_string_impl(data, buff);
   }
 
-  native_persistent_string obj::boolean::to_string() const
+  native_persistent_string boolean::to_string() const
   {
     fmt::memory_buffer buff;
     to_string_impl(data, buff);
     return native_persistent_string{ buff.data(), buff.size() };
   }
 
-  native_persistent_string obj::boolean::to_code_string() const
+  native_persistent_string boolean::to_code_string() const
   {
     return to_string();
   }
 
-  native_hash obj::boolean::to_hash() const
+  native_hash boolean::to_hash() const
   {
     return data ? 1231 : 1237;
   }
 
-  native_integer obj::boolean::compare(object const &o) const
+  native_integer boolean::compare(object const &o) const
   {
     return visit_number_like(
       [this](auto const typed_o) -> native_integer {
@@ -73,49 +73,49 @@ namespace jank::runtime
       &o);
   }
 
-  native_integer obj::boolean::compare(obj::boolean const &o) const
+  native_integer boolean::compare(boolean const &o) const
   {
     return (data > o.data) - (data < o.data);
   }
 
   /***** integer *****/
-  obj::integer::static_object(native_integer const d)
+  integer::integer(native_integer const d)
     : data{ d }
   {
   }
 
-  native_bool obj::integer::equal(object const &o) const
+  native_bool integer::equal(object const &o) const
   {
     if(o.type != object_type::integer)
     {
       return false;
     }
 
-    auto const i(expect_object<obj::integer>(&o));
+    auto const i(expect_object<integer>(&o));
     return data == i->data;
   }
 
-  native_persistent_string obj::integer::to_string() const
+  native_persistent_string integer::to_string() const
   {
     return fmt::format(FMT_COMPILE("{}"), data);
   }
 
-  void obj::integer::to_string(fmt::memory_buffer &buff) const
+  void integer::to_string(fmt::memory_buffer &buff) const
   {
     fmt::format_to(std::back_inserter(buff), FMT_COMPILE("{}"), data);
   }
 
-  native_persistent_string obj::integer::to_code_string() const
+  native_persistent_string integer::to_code_string() const
   {
     return to_string();
   }
 
-  native_hash obj::integer::to_hash() const
+  native_hash integer::to_hash() const
   {
     return hash::integer(data);
   }
 
-  native_integer obj::integer::compare(object const &o) const
+  native_integer integer::compare(object const &o) const
   {
     return visit_number_like(
       [this](auto const typed_o) -> native_integer {
@@ -127,60 +127,60 @@ namespace jank::runtime
       &o);
   }
 
-  native_integer obj::integer::compare(obj::integer const &o) const
+  native_integer integer::compare(integer const &o) const
   {
     return (data > o.data) - (data < o.data);
   }
 
-  native_integer obj::integer::to_integer() const
+  native_integer integer::to_integer() const
   {
     return data;
   }
 
-  native_real obj::integer::to_real() const
+  native_real integer::to_real() const
   {
     return static_cast<native_real>(data);
   }
 
   /***** real *****/
-  obj::real::static_object(native_real const d)
+  real::real(native_real const d)
     : data{ d }
   {
   }
 
-  native_bool obj::real::equal(object const &o) const
+  native_bool real::equal(object const &o) const
   {
     if(o.type != object_type::real)
     {
       return false;
     }
 
-    auto const r(expect_object<obj::real>(&o));
+    auto const r(expect_object<real>(&o));
     std::hash<native_real> const hasher{};
     return hasher(data) == hasher(r->data);
   }
 
-  native_persistent_string obj::real::to_string() const
+  native_persistent_string real::to_string() const
   {
     return fmt::format(FMT_COMPILE("{}"), data);
   }
 
-  void obj::real::to_string(fmt::memory_buffer &buff) const
+  void real::to_string(fmt::memory_buffer &buff) const
   {
     fmt::format_to(std::back_inserter(buff), FMT_COMPILE("{}"), data);
   }
 
-  native_persistent_string obj::real::to_code_string() const
+  native_persistent_string real::to_code_string() const
   {
     return to_string();
   }
 
-  native_hash obj::real::to_hash() const
+  native_hash real::to_hash() const
   {
     return hash::real(data);
   }
 
-  native_integer obj::real::compare(object const &o) const
+  native_integer real::compare(object const &o) const
   {
     return visit_number_like(
       [this](auto const typed_o) -> native_integer {
@@ -192,17 +192,17 @@ namespace jank::runtime
       &o);
   }
 
-  native_integer obj::real::compare(obj::real const &o) const
+  native_integer real::compare(real const &o) const
   {
     return (data > o.data) - (data < o.data);
   }
 
-  native_integer obj::real::to_integer() const
+  native_integer real::to_integer() const
   {
     return static_cast<native_integer>(data);
   }
 
-  native_real obj::real::to_real() const
+  native_real real::to_real() const
   {
     return data;
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/number.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/number.cpp
@@ -1,4 +1,4 @@
-#include <fmt/compile.h>
+#include <fmt/format.h>
 
 #include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/number.hpp>
@@ -35,21 +35,16 @@ namespace jank::runtime::obj
     return data == b->data;
   }
 
-  static void to_string_impl(bool const data, fmt::memory_buffer &buff)
+  void boolean::to_string(util::string_builder &buff) const
   {
-    format_to(std::back_inserter(buff), FMT_COMPILE("{}"), data ? "true" : "false");
-  }
-
-  void boolean::to_string(fmt::memory_buffer &buff) const
-  {
-    to_string_impl(data, buff);
+    buff(data);
   }
 
   native_persistent_string boolean::to_string() const
   {
-    fmt::memory_buffer buff;
-    to_string_impl(data, buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    util::string_builder buff;
+    buff(data);
+    return buff.release();
   }
 
   native_persistent_string boolean::to_code_string() const
@@ -98,12 +93,13 @@ namespace jank::runtime::obj
 
   native_persistent_string integer::to_string() const
   {
-    return fmt::format(FMT_COMPILE("{}"), data);
+    util::string_builder sb;
+    return sb(data).release();
   }
 
-  void integer::to_string(fmt::memory_buffer &buff) const
+  void integer::to_string(util::string_builder &buff) const
   {
-    fmt::format_to(std::back_inserter(buff), FMT_COMPILE("{}"), data);
+    buff(data);
   }
 
   native_persistent_string integer::to_code_string() const
@@ -163,12 +159,13 @@ namespace jank::runtime::obj
 
   native_persistent_string real::to_string() const
   {
-    return fmt::format(FMT_COMPILE("{}"), data);
+    util::string_builder sb;
+    return sb(data).release();
   }
 
-  void real::to_string(fmt::memory_buffer &buff) const
+  void real::to_string(util::string_builder &buff) const
   {
-    fmt::format_to(std::back_inserter(buff), FMT_COMPILE("{}"), data);
+    buff(data);
   }
 
   native_persistent_string real::to_code_string() const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/number.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/number.cpp
@@ -1,5 +1,6 @@
 #include <fmt/compile.h>
 
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/number.hpp>
 #include <jank/runtime/visit.hpp>
 

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_array_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_array_map.cpp
@@ -6,35 +6,35 @@
 #include <jank/runtime/core/to_string.hpp>
 #include <jank/runtime/rtti.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::persistent_array_map::static_object(value_type &&d)
+  persistent_array_map::persistent_array_map(value_type &&d)
     : data{ std::move(d) }
   {
   }
 
-  obj::persistent_array_map::static_object(value_type const &d)
+  persistent_array_map::persistent_array_map(value_type const &d)
     : data{ d }
   {
   }
 
-  obj::persistent_array_map::static_object(object_ptr const meta, value_type &&d)
+  persistent_array_map::persistent_array_map(object_ptr const meta, value_type &&d)
     : data{ std::move(d) }
   {
     this->meta = meta;
   }
 
-  object_ptr obj::persistent_array_map::get(object_ptr const key) const
+  object_ptr persistent_array_map::get(object_ptr const key) const
   {
     auto const res(data.find(key));
     if(res)
     {
       return res;
     }
-    return obj::nil::nil_const();
+    return nil::nil_const();
   }
 
-  object_ptr obj::persistent_array_map::get(object_ptr const key, object_ptr const fallback) const
+  object_ptr persistent_array_map::get(object_ptr const key, object_ptr const fallback) const
   {
     auto const res(data.find(key));
     if(res)
@@ -44,22 +44,22 @@ namespace jank::runtime
     return fallback;
   }
 
-  object_ptr obj::persistent_array_map::get_entry(object_ptr const key) const
+  object_ptr persistent_array_map::get_entry(object_ptr const key) const
   {
     auto const res(data.find(key));
     if(res)
     {
-      return make_box<obj::persistent_vector>(std::in_place, key, res);
+      return make_box<persistent_vector>(std::in_place, key, res);
     }
-    return obj::nil::nil_const();
+    return nil::nil_const();
   }
 
-  native_bool obj::persistent_array_map::contains(object_ptr const key) const
+  native_bool persistent_array_map::contains(object_ptr const key) const
   {
     return data.find(key);
   }
 
-  object_ptr obj::persistent_array_map::assoc(object_ptr const key, object_ptr const val) const
+  object_ptr persistent_array_map::assoc(object_ptr const key, object_ptr const val) const
   {
     /* If we've hit the max array map size, it's time to promote to a hash map.
      *
@@ -68,26 +68,26 @@ namespace jank::runtime
      * promoting to a hash map.
      *
      * TODO: Benchmark if it's faster to have this behavior or to check first. */
-    if(data.size() == detail::native_persistent_array_map::max_size)
+    if(data.size() == runtime::detail::native_persistent_array_map::max_size)
     {
-      return make_box<obj::persistent_hash_map>(data, key, val);
+      return make_box<persistent_hash_map>(data, key, val);
     }
     else
     {
       auto copy(data.clone());
       copy.insert_or_assign(key, val);
-      return make_box<obj::persistent_array_map>(std::move(copy));
+      return make_box<persistent_array_map>(std::move(copy));
     }
   }
 
-  obj::persistent_array_map_ptr obj::persistent_array_map::dissoc(object_ptr const key) const
+  persistent_array_map_ptr persistent_array_map::dissoc(object_ptr const key) const
   {
     auto copy(data.clone());
     copy.erase(key);
-    return make_box<obj::persistent_array_map>(std::move(copy));
+    return make_box<persistent_array_map>(std::move(copy));
   }
 
-  object_ptr obj::persistent_array_map::conj(object_ptr const head) const
+  object_ptr persistent_array_map::conj(object_ptr const head) const
   {
     if(head->type == object_type::persistent_array_map
        || head->type == object_type::persistent_hash_map)
@@ -100,35 +100,35 @@ namespace jank::runtime
       throw std::runtime_error{ fmt::format("invalid map entry: {}", runtime::to_string(head)) };
     }
 
-    auto const vec(expect_object<obj::persistent_vector>(head));
+    auto const vec(expect_object<persistent_vector>(head));
     if(vec->count() != 2)
     {
       throw std::runtime_error{ fmt::format("invalid map entry: {}", runtime::to_string(head)) };
     }
 
-    if(data.size() == detail::native_persistent_array_map::max_size)
+    if(data.size() == runtime::detail::native_persistent_array_map::max_size)
     {
-      return make_box<obj::persistent_hash_map>(data, vec->data[0], vec->data[1]);
+      return make_box<persistent_hash_map>(data, vec->data[0], vec->data[1]);
     }
     else
     {
       auto copy(data.clone());
       copy.insert_or_assign(vec->data[0], vec->data[1]);
-      return make_box<obj::persistent_array_map>(std::move(copy));
+      return make_box<persistent_array_map>(std::move(copy));
     }
   }
 
-  object_ptr obj::persistent_array_map::call(object_ptr const o) const
+  object_ptr persistent_array_map::call(object_ptr const o) const
   {
     auto const found(data.find(o));
     if(!found)
     {
-      return obj::nil::nil_const();
+      return nil::nil_const();
     }
     return found;
   }
 
-  object_ptr obj::persistent_array_map::call(object_ptr const o, object_ptr const fallback) const
+  object_ptr persistent_array_map::call(object_ptr const o, object_ptr const fallback) const
   {
     auto const found(data.find(o));
     if(!found)

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_array_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_array_map.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/persistent_array_map.hpp>
 #include <jank/runtime/obj/persistent_hash_map.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_array_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_array_map.cpp
@@ -1,3 +1,4 @@
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/persistent_array_map.hpp>
 #include <jank/runtime/obj/persistent_hash_map.hpp>
 #include <jank/runtime/obj/persistent_vector.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_map.cpp
@@ -1,3 +1,4 @@
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/persistent_hash_map.hpp>
 #include <jank/runtime/obj/persistent_vector.hpp>
 #include <jank/runtime/obj/transient_hash_map.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_map.cpp
@@ -3,6 +3,7 @@
 #include <jank/runtime/obj/transient_hash_map.hpp>
 #include <jank/runtime/behavior/seqable.hpp>
 #include <jank/runtime/visit.hpp>
+#include <jank/runtime/core/seq.hpp>
 
 namespace jank::runtime::obj
 {

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_map.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/persistent_hash_map.hpp>
 #include <jank/runtime/obj/persistent_vector.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_map.cpp
@@ -4,13 +4,13 @@
 #include <jank/runtime/behavior/seqable.hpp>
 #include <jank/runtime/visit.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::persistent_hash_map::static_object(detail::native_persistent_array_map const &m,
-                                          object_ptr const key,
-                                          object_ptr const val)
+  persistent_hash_map::persistent_hash_map(runtime::detail::native_persistent_array_map const &m,
+                                           object_ptr const key,
+                                           object_ptr const val)
   {
-    detail::native_transient_hash_map transient;
+    runtime::detail::native_transient_hash_map transient;
     for(auto const &e : m)
     {
       transient.set(e.first, e.second);
@@ -19,27 +19,27 @@ namespace jank::runtime
     data = transient.persistent();
   }
 
-  obj::persistent_hash_map::static_object(value_type &&d)
+  persistent_hash_map::persistent_hash_map(value_type &&d)
     : data{ std::move(d) }
   {
   }
 
-  obj::persistent_hash_map::static_object(value_type const &d)
+  persistent_hash_map::persistent_hash_map(value_type const &d)
     : data{ d }
   {
   }
 
-  obj::persistent_hash_map::static_object(object_ptr const meta, value_type &&d)
+  persistent_hash_map::persistent_hash_map(object_ptr const meta, value_type &&d)
     : data{ std::move(d) }
   {
     this->meta = meta;
   }
 
-  obj::persistent_hash_map_ptr obj::persistent_hash_map::create_from_seq(object_ptr const seq)
+  persistent_hash_map_ptr persistent_hash_map::create_from_seq(object_ptr const seq)
   {
-    return make_box<obj::persistent_hash_map>(visit_seqable(
-      [](auto const typed_seq) -> obj::persistent_hash_map::value_type {
-        detail::native_transient_hash_map transient;
+    return make_box<persistent_hash_map>(visit_seqable(
+      [](auto const typed_seq) -> persistent_hash_map::value_type {
+        runtime::detail::native_transient_hash_map transient;
         for(auto it(typed_seq->fresh_seq()); it != nullptr; it = runtime::next_in_place(it))
         {
           auto const key(it->first());
@@ -54,23 +54,23 @@ namespace jank::runtime
         }
         return transient.persistent();
       },
-      [=]() -> obj::persistent_hash_map::value_type {
+      [=]() -> persistent_hash_map::value_type {
         throw std::runtime_error{ fmt::format("Not seqable: {}", runtime::to_string(seq)) };
       },
       seq));
   }
 
-  object_ptr obj::persistent_hash_map::get(object_ptr const key) const
+  object_ptr persistent_hash_map::get(object_ptr const key) const
   {
     auto const res(data.find(key));
     if(res)
     {
       return *res;
     }
-    return obj::nil::nil_const();
+    return nil::nil_const();
   }
 
-  object_ptr obj::persistent_hash_map::get(object_ptr const key, object_ptr const fallback) const
+  object_ptr persistent_hash_map::get(object_ptr const key, object_ptr const fallback) const
   {
     auto const res(data.find(key));
     if(res)
@@ -80,40 +80,40 @@ namespace jank::runtime
     return fallback;
   }
 
-  object_ptr obj::persistent_hash_map::get_entry(object_ptr const key) const
+  object_ptr persistent_hash_map::get_entry(object_ptr const key) const
   {
     auto const res(data.find(key));
     if(res)
     {
-      return make_box<obj::persistent_vector>(std::in_place, key, *res);
+      return make_box<persistent_vector>(std::in_place, key, *res);
     }
-    return obj::nil::nil_const();
+    return nil::nil_const();
   }
 
-  native_bool obj::persistent_hash_map::contains(object_ptr const key) const
+  native_bool persistent_hash_map::contains(object_ptr const key) const
   {
     return data.find(key);
   }
 
-  obj::persistent_hash_map_ptr
-  obj::persistent_hash_map::assoc(object_ptr const key, object_ptr const val) const
+  persistent_hash_map_ptr
+  persistent_hash_map::assoc(object_ptr const key, object_ptr const val) const
   {
     auto copy(data.set(key, val));
-    return make_box<obj::persistent_hash_map>(std::move(copy));
+    return make_box<persistent_hash_map>(std::move(copy));
   }
 
-  obj::persistent_hash_map_ptr obj::persistent_hash_map::dissoc(object_ptr const key) const
+  persistent_hash_map_ptr persistent_hash_map::dissoc(object_ptr const key) const
   {
     auto copy(data.erase(key));
-    return make_box<obj::persistent_hash_map>(std::move(copy));
+    return make_box<persistent_hash_map>(std::move(copy));
   }
 
-  obj::persistent_hash_map_ptr obj::persistent_hash_map::conj(object_ptr const head) const
+  persistent_hash_map_ptr persistent_hash_map::conj(object_ptr const head) const
   {
     if(head->type == object_type::persistent_array_map
        || head->type == object_type::persistent_hash_map)
     {
-      return expect_object<obj::persistent_hash_map>(runtime::merge(this, head));
+      return expect_object<persistent_hash_map>(runtime::merge(this, head));
     }
 
     if(head->type != object_type::persistent_vector)
@@ -121,28 +121,28 @@ namespace jank::runtime
       throw std::runtime_error{ fmt::format("invalid map entry: {}", runtime::to_string(head)) };
     }
 
-    auto const vec(expect_object<obj::persistent_vector>(head));
+    auto const vec(expect_object<persistent_vector>(head));
     if(vec->count() != 2)
     {
       throw std::runtime_error{ fmt::format("invalid map entry: {}", runtime::to_string(head)) };
     }
 
     auto copy(data.set(vec->data[0], vec->data[1]));
-    return make_box<obj::persistent_hash_map>(std::move(copy));
+    return make_box<persistent_hash_map>(std::move(copy));
   }
 
-  object_ptr obj::persistent_hash_map::call(object_ptr const o) const
+  object_ptr persistent_hash_map::call(object_ptr const o) const
   {
     return get(o);
   }
 
-  object_ptr obj::persistent_hash_map::call(object_ptr const o, object_ptr const fallback) const
+  object_ptr persistent_hash_map::call(object_ptr const o, object_ptr const fallback) const
   {
     return get(o, fallback);
   }
 
-  obj::transient_hash_map_ptr obj::persistent_hash_map::to_transient() const
+  transient_hash_map_ptr persistent_hash_map::to_transient() const
   {
-    return make_box<obj::transient_hash_map>(data);
+    return make_box<transient_hash_map>(data);
   }
 }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_set.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_set.cpp
@@ -1,30 +1,30 @@
 #include <jank/runtime/obj/persistent_hash_set.hpp>
 #include <jank/runtime/visit.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::persistent_hash_set::static_object(runtime::detail::native_persistent_hash_set &&d)
+  persistent_hash_set::persistent_hash_set(runtime::detail::native_persistent_hash_set &&d)
     : data{ std::move(d) }
   {
   }
 
-  obj::persistent_hash_set::static_object(runtime::detail::native_persistent_hash_set const &d)
+  persistent_hash_set::persistent_hash_set(runtime::detail::native_persistent_hash_set const &d)
     : data{ d }
   {
   }
 
-  obj::persistent_hash_set::static_object(object_ptr const meta,
-                                          runtime::detail::native_persistent_hash_set &&d)
+  persistent_hash_set::persistent_hash_set(object_ptr const meta,
+                                           runtime::detail::native_persistent_hash_set &&d)
     : data{ std::move(d) }
     , meta{ meta }
   {
   }
 
-  obj::persistent_hash_set_ptr obj::persistent_hash_set::create_from_seq(object_ptr const seq)
+  persistent_hash_set_ptr persistent_hash_set::create_from_seq(object_ptr const seq)
   {
-    return make_box<obj::persistent_hash_set>(visit_seqable(
-      [](auto const typed_seq) -> obj::persistent_hash_set::value_type {
-        detail::native_transient_hash_set transient;
+    return make_box<persistent_hash_set>(visit_seqable(
+      [](auto const typed_seq) -> persistent_hash_set::value_type {
+        runtime::detail::native_transient_hash_set transient;
         for(auto it(typed_seq->fresh_seq()); it != nullptr; it = runtime::next_in_place(it))
         {
           transient.insert(it->first());
@@ -34,7 +34,7 @@ namespace jank::runtime
       seq));
   }
 
-  native_bool obj::persistent_hash_set::equal(object const &o) const
+  native_bool persistent_hash_set::equal(object const &o) const
   {
     if(&o == &base)
     {
@@ -62,19 +62,19 @@ namespace jank::runtime
       &o);
   }
 
-  void obj::persistent_hash_set::to_string(fmt::memory_buffer &buff) const
+  void persistent_hash_set::to_string(fmt::memory_buffer &buff) const
   {
     runtime::to_string(data.begin(), data.end(), "#{", '}', buff);
   }
 
-  native_persistent_string obj::persistent_hash_set::to_string() const
+  native_persistent_string persistent_hash_set::to_string() const
   {
     fmt::memory_buffer buff;
     runtime::to_string(data.begin(), data.end(), "#{", '}', buff);
     return native_persistent_string{ buff.data(), buff.size() };
   }
 
-  native_persistent_string obj::persistent_hash_set::to_code_string() const
+  native_persistent_string persistent_hash_set::to_code_string() const
   {
     fmt::memory_buffer buff;
     runtime::to_code_string(data.begin(), data.end(), "#{", '}', buff);
@@ -82,69 +82,69 @@ namespace jank::runtime
   }
 
   /* TODO: Cache this. */
-  native_hash obj::persistent_hash_set::to_hash() const
+  native_hash persistent_hash_set::to_hash() const
   {
     return hash::unordered(data.begin(), data.end());
   }
 
-  obj::persistent_hash_set_sequence_ptr obj::persistent_hash_set::seq() const
+  persistent_hash_set_sequence_ptr persistent_hash_set::seq() const
   {
     return fresh_seq();
   }
 
-  obj::persistent_hash_set_sequence_ptr obj::persistent_hash_set::fresh_seq() const
+  persistent_hash_set_sequence_ptr persistent_hash_set::fresh_seq() const
   {
     if(data.empty())
     {
       return nullptr;
     }
-    return make_box<obj::persistent_hash_set_sequence>(this, data.begin(), data.end(), data.size());
+    return make_box<persistent_hash_set_sequence>(this, data.begin(), data.end(), data.size());
   }
 
-  size_t obj::persistent_hash_set::count() const
+  size_t persistent_hash_set::count() const
   {
     return data.size();
   }
 
-  obj::persistent_hash_set_ptr obj::persistent_hash_set::with_meta(object_ptr const m) const
+  persistent_hash_set_ptr persistent_hash_set::with_meta(object_ptr const m) const
   {
     auto const meta(behavior::detail::validate_meta(m));
-    auto ret(make_box<obj::persistent_hash_set>(data));
+    auto ret(make_box<persistent_hash_set>(data));
     ret->meta = meta;
     return ret;
   }
 
-  obj::persistent_hash_set_ptr obj::persistent_hash_set::conj(object_ptr const head) const
+  persistent_hash_set_ptr persistent_hash_set::conj(object_ptr const head) const
   {
     auto set(data.insert(head));
-    auto ret(make_box<obj::persistent_hash_set>(std::move(set)));
+    auto ret(make_box<persistent_hash_set>(std::move(set)));
     return ret;
   }
 
-  object_ptr obj::persistent_hash_set::call(object_ptr const o) const
+  object_ptr persistent_hash_set::call(object_ptr const o) const
   {
     auto const found(data.find(o));
     if(!found)
     {
-      return obj::nil::nil_const();
+      return nil::nil_const();
     }
     return *found;
   }
 
-  obj::transient_hash_set_ptr obj::persistent_hash_set::to_transient() const
+  transient_hash_set_ptr persistent_hash_set::to_transient() const
   {
-    return make_box<obj::transient_hash_set>(data);
+    return make_box<transient_hash_set>(data);
   }
 
-  native_bool obj::persistent_hash_set::contains(object_ptr const o) const
+  native_bool persistent_hash_set::contains(object_ptr const o) const
   {
     return data.find(o);
   }
 
-  obj::persistent_hash_set_ptr obj::persistent_hash_set::disj(object_ptr const o) const
+  persistent_hash_set_ptr persistent_hash_set::disj(object_ptr const o) const
   {
     auto set(data.erase(o));
-    auto ret(make_box<obj::persistent_hash_set>(std::move(set)));
+    auto ret(make_box<persistent_hash_set>(std::move(set)));
     return ret;
   }
 }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_set.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_set.cpp
@@ -69,23 +69,23 @@ namespace jank::runtime::obj
       &o);
   }
 
-  void persistent_hash_set::to_string(fmt::memory_buffer &buff) const
+  void persistent_hash_set::to_string(util::string_builder &buff) const
   {
     runtime::to_string(data.begin(), data.end(), "#{", '}', buff);
   }
 
   native_persistent_string persistent_hash_set::to_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     runtime::to_string(data.begin(), data.end(), "#{", '}', buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
   native_persistent_string persistent_hash_set::to_code_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     runtime::to_code_string(data.begin(), data.end(), "#{", '}', buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
   /* TODO: Cache this. */

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_set.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_set.cpp
@@ -1,5 +1,6 @@
 #include <jank/runtime/obj/persistent_hash_set.hpp>
 #include <jank/runtime/visit.hpp>
+#include <jank/runtime/core/seq.hpp>
 
 namespace jank::runtime::obj
 {

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_set.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_set.cpp
@@ -20,6 +20,12 @@ namespace jank::runtime::obj
   {
   }
 
+  persistent_hash_set_ptr persistent_hash_set::empty()
+  {
+    static auto const ret(make_box<persistent_hash_set>());
+    return ret;
+  }
+
   persistent_hash_set_ptr persistent_hash_set::create_from_seq(object_ptr const seq)
   {
     return make_box<persistent_hash_set>(visit_seqable(

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_list.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_list.cpp
@@ -1,3 +1,4 @@
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/persistent_list.hpp>
 #include <jank/runtime/visit.hpp>
 #include <jank/runtime/core/seq.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_list.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_list.cpp
@@ -2,29 +2,29 @@
 #include <jank/runtime/visit.hpp>
 #include <jank/runtime/core/seq_ext.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::persistent_list::static_object(runtime::detail::native_persistent_list const &d)
+  persistent_list::persistent_list(runtime::detail::native_persistent_list const &d)
     : data{ d }
   {
   }
 
-  obj::persistent_list::static_object(object_ptr const meta,
-                                      runtime::detail::native_persistent_list const &d)
+  persistent_list::persistent_list(object_ptr const meta,
+                                   runtime::detail::native_persistent_list const &d)
     : data{ d }
     , meta{ meta }
   {
   }
 
-  obj::persistent_list_ptr obj::persistent_list::create(object_ptr const s)
+  persistent_list_ptr persistent_list::create(object_ptr const s)
   {
     if(s == nullptr)
     {
-      return make_box<obj::persistent_list>();
+      return make_box<persistent_list>();
     }
 
     return visit_object(
-      [](auto const typed_s) -> obj::persistent_list_ptr {
+      [](auto const typed_s) -> persistent_list_ptr {
         using T = typename decltype(typed_s)::value_type;
 
         if constexpr(behavior::sequenceable<T>)
@@ -34,7 +34,7 @@ namespace jank::runtime
           {
             v.emplace_back(i->first());
           }
-          return make_box<obj::persistent_list>(
+          return make_box<persistent_list>(
             runtime::detail::native_persistent_list{ v.rbegin(), v.rend() });
         }
         else
@@ -45,29 +45,29 @@ namespace jank::runtime
       s);
   }
 
-  obj::persistent_list_ptr obj::persistent_list::create(obj::persistent_list_ptr const s)
+  persistent_list_ptr persistent_list::create(persistent_list_ptr const s)
   {
     return s;
   }
 
-  native_bool obj::persistent_list::equal(object const &o) const
+  native_bool persistent_list::equal(object const &o) const
   {
     return runtime::equal(o, data.begin(), data.end());
   }
 
-  void obj::persistent_list::to_string(fmt::memory_buffer &buff) const
+  void persistent_list::to_string(fmt::memory_buffer &buff) const
   {
     runtime::to_string(data.begin(), data.end(), "(", ')', buff);
   }
 
-  native_persistent_string obj::persistent_list::to_string() const
+  native_persistent_string persistent_list::to_string() const
   {
     fmt::memory_buffer buff;
     runtime::to_string(data.begin(), data.end(), "(", ')', buff);
     return native_persistent_string{ buff.data(), buff.size() };
   }
 
-  native_persistent_string obj::persistent_list::to_code_string() const
+  native_persistent_string persistent_list::to_code_string() const
   {
     fmt::memory_buffer buff;
     runtime::to_code_string(data.begin(), data.end(), "(", ')', buff);
@@ -75,90 +75,87 @@ namespace jank::runtime
   }
 
   /* TODO: Cache this. */
-  native_hash obj::persistent_list::to_hash() const
+  native_hash persistent_list::to_hash() const
   {
     return hash::ordered(data.begin(), data.end());
   }
 
-  obj::persistent_list_sequence_ptr obj::persistent_list::seq() const
+  persistent_list_sequence_ptr persistent_list::seq() const
   {
     if(data.empty())
     {
       return nullptr;
     }
-    return make_box<obj::persistent_list_sequence>(this, data.begin(), data.end(), data.size());
+    return make_box<persistent_list_sequence>(this, data.begin(), data.end(), data.size());
   }
 
-  obj::persistent_list_sequence_ptr obj::persistent_list::fresh_seq() const
+  persistent_list_sequence_ptr persistent_list::fresh_seq() const
   {
     if(data.empty())
     {
       return nullptr;
     }
-    return make_box<obj::persistent_list_sequence>(this, data.begin(), data.end(), data.size());
+    return make_box<persistent_list_sequence>(this, data.begin(), data.end(), data.size());
   }
 
-  size_t obj::persistent_list::count() const
+  size_t persistent_list::count() const
   {
     return data.size();
   }
 
-  obj::persistent_list_ptr obj::persistent_list::conj(object_ptr head) const
+  persistent_list_ptr persistent_list::conj(object_ptr head) const
   {
     auto l(data.conj(head));
-    auto ret(make_box<obj::persistent_list>(std::move(l)));
+    auto ret(make_box<persistent_list>(std::move(l)));
     return ret;
   }
 
-  object_ptr obj::persistent_list::first() const
+  object_ptr persistent_list::first() const
   {
     auto const first(data.first());
     if(first.is_none())
     {
-      return obj::nil::nil_const();
+      return nil::nil_const();
     }
     return first.unwrap();
   }
 
-  obj::persistent_list_sequence_ptr obj::persistent_list::next() const
+  persistent_list_sequence_ptr persistent_list::next() const
   {
     if(data.size() < 2)
     {
       return nullptr;
     }
-    return make_box<obj::persistent_list_sequence>(this,
-                                                   ++data.begin(),
-                                                   data.end(),
-                                                   data.size() - 1);
+    return make_box<persistent_list_sequence>(this, ++data.begin(), data.end(), data.size() - 1);
   }
 
-  obj::persistent_list_sequence_ptr obj::persistent_list::next_in_place() const
+  persistent_list_sequence_ptr persistent_list::next_in_place() const
   {
     /* In-place updates don't make sense for lists, since any call to fresh_seq would return
      * a list sequence. So we know, principally, that a list itself cannot be considered fresh. */
     return next();
   }
 
-  obj::persistent_list_ptr obj::persistent_list::with_meta(object_ptr const m) const
+  persistent_list_ptr persistent_list::with_meta(object_ptr const m) const
   {
     auto const meta(behavior::detail::validate_meta(m));
-    auto ret(make_box<obj::persistent_list>(data));
+    auto ret(make_box<persistent_list>(data));
     ret->meta = meta;
     return ret;
   }
 
-  object_ptr obj::persistent_list::peek() const
+  object_ptr persistent_list::peek() const
   {
-    return data.first().unwrap_or(obj::nil::nil_const());
+    return data.first().unwrap_or(nil::nil_const());
   }
 
-  obj::persistent_list_ptr obj::persistent_list::pop() const
+  persistent_list_ptr persistent_list::pop() const
   {
     if(data.empty())
     {
       throw std::runtime_error{ "cannot pop an empty list" };
     }
 
-    return make_box<obj::persistent_list>(data.rest());
+    return make_box<persistent_list>(data.rest());
   }
 }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_list.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_list.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/persistent_list.hpp>
 #include <jank/runtime/visit.hpp>
@@ -57,23 +59,23 @@ namespace jank::runtime::obj
     return runtime::equal(o, data.begin(), data.end());
   }
 
-  void persistent_list::to_string(fmt::memory_buffer &buff) const
+  void persistent_list::to_string(util::string_builder &buff) const
   {
     runtime::to_string(data.begin(), data.end(), "(", ')', buff);
   }
 
   native_persistent_string persistent_list::to_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     runtime::to_string(data.begin(), data.end(), "(", ')', buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
   native_persistent_string persistent_list::to_code_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     runtime::to_code_string(data.begin(), data.end(), "(", ')', buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
   /* TODO: Cache this. */

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_list.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_list.cpp
@@ -1,5 +1,6 @@
 #include <jank/runtime/obj/persistent_list.hpp>
 #include <jank/runtime/visit.hpp>
+#include <jank/runtime/core/seq.hpp>
 #include <jank/runtime/core/seq_ext.hpp>
 
 namespace jank::runtime::obj

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_sorted_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_sorted_map.cpp
@@ -2,6 +2,7 @@
 #include <jank/runtime/obj/persistent_vector.hpp>
 #include <jank/runtime/obj/transient_sorted_map.hpp>
 #include <jank/runtime/visit.hpp>
+#include <jank/runtime/core/seq.hpp>
 
 namespace jank::runtime::obj
 {

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_sorted_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_sorted_map.cpp
@@ -3,33 +3,33 @@
 #include <jank/runtime/obj/transient_sorted_map.hpp>
 #include <jank/runtime/visit.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::persistent_sorted_map::static_object(value_type &&d)
+  persistent_sorted_map::persistent_sorted_map(value_type &&d)
     : data{ std::move(d) }
   {
   }
 
-  obj::persistent_sorted_map::static_object(value_type const &d)
+  persistent_sorted_map::persistent_sorted_map(value_type const &d)
     : data{ d }
   {
   }
 
-  obj::persistent_sorted_map::static_object(object_ptr const meta, value_type &&d)
+  persistent_sorted_map::persistent_sorted_map(object_ptr const meta, value_type &&d)
     : data{ std::move(d) }
   {
     this->meta = meta;
   }
 
-  obj::persistent_sorted_map_ptr obj::persistent_sorted_map::create_from_seq(object_ptr const seq)
+  persistent_sorted_map_ptr persistent_sorted_map::create_from_seq(object_ptr const seq)
   {
-    return make_box<obj::persistent_sorted_map>(visit_object(
-      [](auto const typed_seq) -> obj::persistent_sorted_map::value_type {
+    return make_box<persistent_sorted_map>(visit_object(
+      [](auto const typed_seq) -> persistent_sorted_map::value_type {
         using T = typename decltype(typed_seq)::value_type;
 
         if constexpr(behavior::seqable<T>)
         {
-          detail::native_transient_sorted_map transient;
+          runtime::detail::native_transient_sorted_map transient;
           for(auto it(typed_seq->fresh_seq()); it != nullptr; it = runtime::next_in_place(it))
           {
             auto const key(it->first());
@@ -52,17 +52,17 @@ namespace jank::runtime
       seq));
   }
 
-  object_ptr obj::persistent_sorted_map::get(object_ptr const key) const
+  object_ptr persistent_sorted_map::get(object_ptr const key) const
   {
     auto const res(data.find(key));
     if(res != data.end())
     {
       return res->second;
     }
-    return obj::nil::nil_const();
+    return nil::nil_const();
   }
 
-  object_ptr obj::persistent_sorted_map::get(object_ptr const key, object_ptr const fallback) const
+  object_ptr persistent_sorted_map::get(object_ptr const key, object_ptr const fallback) const
   {
     auto const res(data.find(key));
     if(res != data.end())
@@ -72,40 +72,40 @@ namespace jank::runtime
     return fallback;
   }
 
-  object_ptr obj::persistent_sorted_map::get_entry(object_ptr const key) const
+  object_ptr persistent_sorted_map::get_entry(object_ptr const key) const
   {
     auto const res(data.find(key));
     if(res != data.end())
     {
-      return make_box<obj::persistent_vector>(std::in_place, key, res->second);
+      return make_box<persistent_vector>(std::in_place, key, res->second);
     }
-    return obj::nil::nil_const();
+    return nil::nil_const();
   }
 
-  native_bool obj::persistent_sorted_map::contains(object_ptr const key) const
+  native_bool persistent_sorted_map::contains(object_ptr const key) const
   {
     return data.find(key) != data.end();
   }
 
-  obj::persistent_sorted_map_ptr
-  obj::persistent_sorted_map::assoc(object_ptr const key, object_ptr const val) const
+  persistent_sorted_map_ptr
+  persistent_sorted_map::assoc(object_ptr const key, object_ptr const val) const
   {
     auto copy(data.insert_or_assign(key, val));
-    return make_box<obj::persistent_sorted_map>(std::move(copy));
+    return make_box<persistent_sorted_map>(std::move(copy));
   }
 
-  obj::persistent_sorted_map_ptr obj::persistent_sorted_map::dissoc(object_ptr const key) const
+  persistent_sorted_map_ptr persistent_sorted_map::dissoc(object_ptr const key) const
   {
     auto copy(data.erase_key(key));
-    return make_box<obj::persistent_sorted_map>(std::move(copy));
+    return make_box<persistent_sorted_map>(std::move(copy));
   }
 
-  obj::persistent_sorted_map_ptr obj::persistent_sorted_map::conj(object_ptr const head) const
+  persistent_sorted_map_ptr persistent_sorted_map::conj(object_ptr const head) const
   {
     if(head->type == object_type::persistent_array_map
        || head->type == object_type::persistent_sorted_map)
     {
-      return expect_object<obj::persistent_sorted_map>(runtime::merge(this, head));
+      return expect_object<persistent_sorted_map>(runtime::merge(this, head));
     }
 
     if(head->type != object_type::persistent_vector)
@@ -113,28 +113,28 @@ namespace jank::runtime
       throw std::runtime_error{ fmt::format("invalid map entry: {}", runtime::to_string(head)) };
     }
 
-    auto const vec(expect_object<obj::persistent_vector>(head));
+    auto const vec(expect_object<persistent_vector>(head));
     if(vec->count() != 2)
     {
       throw std::runtime_error{ fmt::format("invalid map entry: {}", runtime::to_string(head)) };
     }
 
     auto copy(data.insert_or_assign(vec->data[0], vec->data[1]));
-    return make_box<obj::persistent_sorted_map>(std::move(copy));
+    return make_box<persistent_sorted_map>(std::move(copy));
   }
 
-  object_ptr obj::persistent_sorted_map::call(object_ptr const o) const
+  object_ptr persistent_sorted_map::call(object_ptr const o) const
   {
     return get(o);
   }
 
-  object_ptr obj::persistent_sorted_map::call(object_ptr const o, object_ptr const fallback) const
+  object_ptr persistent_sorted_map::call(object_ptr const o, object_ptr const fallback) const
   {
     return get(o, fallback);
   }
 
-  obj::transient_sorted_map_ptr obj::persistent_sorted_map::to_transient() const
+  transient_sorted_map_ptr persistent_sorted_map::to_transient() const
   {
-    return make_box<obj::transient_sorted_map>(data);
+    return make_box<transient_sorted_map>(data);
   }
 }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_sorted_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_sorted_map.cpp
@@ -1,3 +1,4 @@
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/persistent_sorted_map.hpp>
 #include <jank/runtime/obj/persistent_vector.hpp>
 #include <jank/runtime/obj/transient_sorted_map.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_sorted_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_sorted_map.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/persistent_sorted_map.hpp>
 #include <jank/runtime/obj/persistent_vector.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_sorted_set.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_sorted_set.cpp
@@ -1,5 +1,6 @@
 #include <jank/runtime/obj/persistent_sorted_set.hpp>
 #include <jank/runtime/visit.hpp>
+#include <jank/runtime/core/seq.hpp>
 
 namespace jank::runtime::obj
 {

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_sorted_set.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_sorted_set.cpp
@@ -1,30 +1,31 @@
 #include <jank/runtime/obj/persistent_sorted_set.hpp>
 #include <jank/runtime/visit.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::persistent_sorted_set::static_object(runtime::detail::native_persistent_sorted_set &&d)
+  persistent_sorted_set::persistent_sorted_set(runtime::detail::native_persistent_sorted_set &&d)
     : data{ std::move(d) }
   {
   }
 
-  obj::persistent_sorted_set::static_object(runtime::detail::native_persistent_sorted_set const &d)
+  persistent_sorted_set::persistent_sorted_set(
+    runtime::detail::native_persistent_sorted_set const &d)
     : data{ d }
   {
   }
 
-  obj::persistent_sorted_set::static_object(object_ptr const meta,
-                                            runtime::detail::native_persistent_sorted_set &&d)
+  persistent_sorted_set::persistent_sorted_set(object_ptr const meta,
+                                               runtime::detail::native_persistent_sorted_set &&d)
     : data{ std::move(d) }
     , meta{ meta }
   {
   }
 
-  obj::persistent_sorted_set_ptr obj::persistent_sorted_set::create_from_seq(object_ptr const seq)
+  persistent_sorted_set_ptr persistent_sorted_set::create_from_seq(object_ptr const seq)
   {
-    return make_box<obj::persistent_sorted_set>(visit_seqable(
-      [](auto const typed_seq) -> obj::persistent_sorted_set::value_type {
-        detail::native_transient_sorted_set transient;
+    return make_box<persistent_sorted_set>(visit_seqable(
+      [](auto const typed_seq) -> persistent_sorted_set::value_type {
+        runtime::detail::native_transient_sorted_set transient;
         for(auto it(typed_seq->fresh_seq()); it != nullptr; it = runtime::next_in_place(it))
         {
           transient.insert_v(it->first());
@@ -34,7 +35,7 @@ namespace jank::runtime
       seq));
   }
 
-  native_bool obj::persistent_sorted_set::equal(object const &o) const
+  native_bool persistent_sorted_set::equal(object const &o) const
   {
     if(&o == &base)
     {
@@ -62,19 +63,19 @@ namespace jank::runtime
       &o);
   }
 
-  void obj::persistent_sorted_set::to_string(fmt::memory_buffer &buff) const
+  void persistent_sorted_set::to_string(fmt::memory_buffer &buff) const
   {
     runtime::to_string(data.begin(), data.end(), "#{", '}', buff);
   }
 
-  native_persistent_string obj::persistent_sorted_set::to_string() const
+  native_persistent_string persistent_sorted_set::to_string() const
   {
     fmt::memory_buffer buff;
     runtime::to_string(data.begin(), data.end(), "#{", '}', buff);
     return native_persistent_string{ buff.data(), buff.size() };
   }
 
-  native_persistent_string obj::persistent_sorted_set::to_code_string() const
+  native_persistent_string persistent_sorted_set::to_code_string() const
   {
     fmt::memory_buffer buff;
     runtime::to_code_string(data.begin(), data.end(), "#{", '}', buff);
@@ -82,72 +83,69 @@ namespace jank::runtime
   }
 
   /* TODO: Cache this. */
-  native_hash obj::persistent_sorted_set::to_hash() const
+  native_hash persistent_sorted_set::to_hash() const
   {
     return hash::unordered(data.begin(), data.end());
   }
 
-  obj::persistent_sorted_set_sequence_ptr obj::persistent_sorted_set::seq() const
+  persistent_sorted_set_sequence_ptr persistent_sorted_set::seq() const
   {
     return fresh_seq();
   }
 
-  obj::persistent_sorted_set_sequence_ptr obj::persistent_sorted_set::fresh_seq() const
+  persistent_sorted_set_sequence_ptr persistent_sorted_set::fresh_seq() const
   {
     if(data.empty())
     {
       return nullptr;
     }
-    return make_box<obj::persistent_sorted_set_sequence>(this,
-                                                         data.begin(),
-                                                         data.end(),
-                                                         data.size());
+    return make_box<persistent_sorted_set_sequence>(this, data.begin(), data.end(), data.size());
   }
 
-  size_t obj::persistent_sorted_set::count() const
+  size_t persistent_sorted_set::count() const
   {
     return data.size();
   }
 
-  obj::persistent_sorted_set_ptr obj::persistent_sorted_set::with_meta(object_ptr const m) const
+  persistent_sorted_set_ptr persistent_sorted_set::with_meta(object_ptr const m) const
   {
     auto const meta(behavior::detail::validate_meta(m));
-    auto ret(make_box<obj::persistent_sorted_set>(data));
+    auto ret(make_box<persistent_sorted_set>(data));
     ret->meta = meta;
     return ret;
   }
 
-  obj::persistent_sorted_set_ptr obj::persistent_sorted_set::conj(object_ptr const head) const
+  persistent_sorted_set_ptr persistent_sorted_set::conj(object_ptr const head) const
   {
     auto set(data.insert_v(head));
-    auto ret(make_box<obj::persistent_sorted_set>(std::move(set)));
+    auto ret(make_box<persistent_sorted_set>(std::move(set)));
     return ret;
   }
 
-  object_ptr obj::persistent_sorted_set::call(object_ptr const o)
+  object_ptr persistent_sorted_set::call(object_ptr const o)
   {
     auto const found(data.find(o));
     if(found != data.end())
     {
       return found.get();
     }
-    return obj::nil::nil_const();
+    return nil::nil_const();
   }
 
-  obj::transient_sorted_set_ptr obj::persistent_sorted_set::to_transient() const
+  transient_sorted_set_ptr persistent_sorted_set::to_transient() const
   {
-    return make_box<obj::transient_sorted_set>(data);
+    return make_box<transient_sorted_set>(data);
   }
 
-  native_bool obj::persistent_sorted_set::contains(object_ptr const o) const
+  native_bool persistent_sorted_set::contains(object_ptr const o) const
   {
     return data.find(o) != data.end();
   }
 
-  obj::persistent_sorted_set_ptr obj::persistent_sorted_set::disj(object_ptr const o) const
+  persistent_sorted_set_ptr persistent_sorted_set::disj(object_ptr const o) const
   {
     auto set(data.erase_key(o));
-    auto ret(make_box<obj::persistent_sorted_set>(std::move(set)));
+    auto ret(make_box<persistent_sorted_set>(std::move(set)));
     return ret;
   }
 }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_sorted_set.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_sorted_set.cpp
@@ -64,23 +64,23 @@ namespace jank::runtime::obj
       &o);
   }
 
-  void persistent_sorted_set::to_string(fmt::memory_buffer &buff) const
+  void persistent_sorted_set::to_string(util::string_builder &buff) const
   {
     runtime::to_string(data.begin(), data.end(), "#{", '}', buff);
   }
 
   native_persistent_string persistent_sorted_set::to_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     runtime::to_string(data.begin(), data.end(), "#{", '}', buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
   native_persistent_string persistent_sorted_set::to_code_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     runtime::to_code_string(data.begin(), data.end(), "#{", '}', buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
   /* TODO: Cache this. */

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string.cpp
@@ -1,5 +1,6 @@
 #include <fmt/compile.h>
 
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/persistent_string.hpp>
 #include <jank/runtime/obj/persistent_string_sequence.hpp>
 #include <jank/runtime/rtti.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string.cpp
@@ -5,67 +5,66 @@
 #include <jank/runtime/core/make_box.hpp>
 #include <jank/util/escape.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::persistent_string::static_object(native_persistent_string const &d)
+  persistent_string::persistent_string(native_persistent_string const &d)
     : data{ d }
   {
   }
 
-  obj::persistent_string::static_object(native_persistent_string &&d)
+  persistent_string::persistent_string(native_persistent_string &&d)
     : data{ std::move(d) }
   {
   }
 
-  native_bool obj::persistent_string::equal(object const &o) const
+  native_bool persistent_string::equal(object const &o) const
   {
     if(o.type != object_type::persistent_string)
     {
       return false;
     }
 
-    auto const s(expect_object<obj::persistent_string>(&o));
+    auto const s(expect_object<persistent_string>(&o));
     return data == s->data;
   }
 
-  native_persistent_string const &obj::persistent_string::to_string() const
+  native_persistent_string const &persistent_string::to_string() const
   {
     return data;
   }
 
-  void obj::persistent_string::to_string(fmt::memory_buffer &buff) const
+  void persistent_string::to_string(fmt::memory_buffer &buff) const
   {
     fmt::format_to(std::back_inserter(buff), FMT_COMPILE("{}"), data);
   }
 
-  native_persistent_string obj::persistent_string::to_code_string() const
+  native_persistent_string persistent_string::to_code_string() const
   {
     return fmt::format(R"("{}")", util::escape(to_string()));
   }
 
-  native_hash obj::persistent_string::to_hash() const
+  native_hash persistent_string::to_hash() const
   {
     return data.to_hash();
   }
 
-  native_integer obj::persistent_string::compare(object const &o) const
+  native_integer persistent_string::compare(object const &o) const
   {
-    return compare(*try_object<obj::persistent_string>(&o));
+    return compare(*try_object<persistent_string>(&o));
   }
 
-  native_integer obj::persistent_string::compare(obj::persistent_string const &s) const
+  native_integer persistent_string::compare(persistent_string const &s) const
   {
     return data.compare(s.data);
   }
 
-  result<obj::persistent_string_ptr, native_persistent_string>
-  obj::persistent_string::substring(native_integer start) const
+  string_result<persistent_string_ptr> persistent_string::substring(native_integer start) const
   {
     return substring(start, static_cast<native_integer>(data.size()));
   }
 
-  result<obj::persistent_string_ptr, native_persistent_string>
-  obj::persistent_string::substring(native_integer const start, native_integer const end) const
+  string_result<persistent_string_ptr>
+  persistent_string::substring(native_integer const start, native_integer const end) const
   {
     if(start < 0)
     {
@@ -87,7 +86,7 @@ namespace jank::runtime
     return ok(make_box(data.substr(start, end)));
   }
 
-  native_integer obj::persistent_string::first_index_of(object_ptr const m) const
+  native_integer persistent_string::first_index_of(object_ptr const m) const
   {
     auto const s(runtime::to_string(m));
     auto const found(data.find(s));
@@ -98,7 +97,7 @@ namespace jank::runtime
     return static_cast<native_integer>(found);
   }
 
-  native_integer obj::persistent_string::last_index_of(object_ptr const m) const
+  native_integer persistent_string::last_index_of(object_ptr const m) const
   {
     auto const s(runtime::to_string(m));
     auto const found(data.rfind(s));
@@ -109,26 +108,26 @@ namespace jank::runtime
     return static_cast<native_integer>(found);
   }
 
-  size_t obj::persistent_string::count() const
+  size_t persistent_string::count() const
   {
     return data.size();
   }
 
-  obj::persistent_string_sequence_ptr obj::persistent_string::seq() const
+  persistent_string_sequence_ptr persistent_string::seq() const
   {
     if(data.empty())
     {
       return nullptr;
     }
-    return make_box<obj::persistent_string_sequence>(const_cast<obj::persistent_string *>(this));
+    return make_box<persistent_string_sequence>(const_cast<persistent_string *>(this));
   }
 
-  obj::persistent_string_sequence_ptr obj::persistent_string::fresh_seq() const
+  persistent_string_sequence_ptr persistent_string::fresh_seq() const
   {
     if(data.empty())
     {
       return nullptr;
     }
-    return make_box<obj::persistent_string_sequence>(const_cast<obj::persistent_string *>(this));
+    return make_box<persistent_string_sequence>(const_cast<persistent_string *>(this));
   }
 }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string.cpp
@@ -1,8 +1,10 @@
 #include <fmt/compile.h>
 
 #include <jank/runtime/obj/persistent_string.hpp>
+#include <jank/runtime/obj/persistent_string_sequence.hpp>
 #include <jank/runtime/rtti.hpp>
 #include <jank/runtime/core/make_box.hpp>
+#include <jank/runtime/core/to_string.hpp>
 #include <jank/util/escape.hpp>
 
 namespace jank::runtime::obj

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string.cpp
@@ -1,4 +1,4 @@
-#include <fmt/compile.h>
+#include <fmt/format.h>
 
 #include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/persistent_string.hpp>
@@ -36,14 +36,15 @@ namespace jank::runtime::obj
     return data;
   }
 
-  void persistent_string::to_string(fmt::memory_buffer &buff) const
+  void persistent_string::to_string(util::string_builder &buff) const
   {
-    fmt::format_to(std::back_inserter(buff), FMT_COMPILE("{}"), data);
+    buff(data);
   }
 
   native_persistent_string persistent_string::to_code_string() const
   {
-    return fmt::format(R"("{}")", util::escape(to_string()));
+    util::string_builder sb;
+    return sb('"')(util::escape(data))('"').release();
   }
 
   native_hash persistent_string::to_hash() const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string_sequence.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string_sequence.cpp
@@ -25,23 +25,23 @@ namespace jank::runtime::obj
     return runtime::equal(o, str->data.begin() + index, str->data.end());
   }
 
-  void persistent_string_sequence::to_string(fmt::memory_buffer &buff) const
+  void persistent_string_sequence::to_string(util::string_builder &buff) const
   {
     runtime::to_string(str->data.begin() + index, str->data.end(), "(", ')', buff);
   }
 
   native_persistent_string persistent_string_sequence::to_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     runtime::to_string(str->data.begin() + index, str->data.end(), "(", ')', buff);
-    return { buff.data(), buff.size() };
+    return buff.release();
   }
 
   native_persistent_string persistent_string_sequence::to_code_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     runtime::to_code_string(str->data.begin() + index, str->data.end(), "(", ')', buff);
-    return { buff.data(), buff.size() };
+    return buff.release();
   }
 
   native_hash persistent_string_sequence::to_hash() const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string_sequence.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string_sequence.cpp
@@ -3,15 +3,16 @@
 #include <jank/runtime/core/seq_ext.hpp>
 #include <jank/runtime/core/make_box.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::persistent_string_sequence::static_object(obj::persistent_string_ptr const s)
+  persistent_string_sequence::persistent_string_sequence(persistent_string_ptr const s)
     : str{ s }
   {
     assert(!s->data.empty());
   }
 
-  obj::persistent_string_sequence::static_object(obj::persistent_string_ptr const s, size_t const i)
+  persistent_string_sequence::persistent_string_sequence(persistent_string_ptr const s,
+                                                         size_t const i)
     : str{ s }
     , index{ i }
   {
@@ -19,59 +20,59 @@ namespace jank::runtime
   }
 
   /* behavior::objectable */
-  native_bool obj::persistent_string_sequence::equal(object const &o) const
+  native_bool persistent_string_sequence::equal(object const &o) const
   {
     return runtime::equal(o, str->data.begin() + index, str->data.end());
   }
 
-  void obj::persistent_string_sequence::to_string(fmt::memory_buffer &buff) const
+  void persistent_string_sequence::to_string(fmt::memory_buffer &buff) const
   {
     runtime::to_string(str->data.begin() + index, str->data.end(), "(", ')', buff);
   }
 
-  native_persistent_string obj::persistent_string_sequence::to_string() const
+  native_persistent_string persistent_string_sequence::to_string() const
   {
     fmt::memory_buffer buff;
     runtime::to_string(str->data.begin() + index, str->data.end(), "(", ')', buff);
     return { buff.data(), buff.size() };
   }
 
-  native_persistent_string obj::persistent_string_sequence::to_code_string() const
+  native_persistent_string persistent_string_sequence::to_code_string() const
   {
     fmt::memory_buffer buff;
     runtime::to_code_string(str->data.begin() + index, str->data.end(), "(", ')', buff);
     return { buff.data(), buff.size() };
   }
 
-  native_hash obj::persistent_string_sequence::to_hash() const
+  native_hash persistent_string_sequence::to_hash() const
   {
     return hash::ordered(str->data.begin() + index, str->data.end());
   }
 
   /* behavior::countable */
-  size_t obj::persistent_string_sequence::count() const
+  size_t persistent_string_sequence::count() const
   {
     return str->data.size() - index;
   }
 
   /* behavior::seqable */
-  obj::persistent_string_sequence_ptr obj::persistent_string_sequence::seq()
+  persistent_string_sequence_ptr persistent_string_sequence::seq()
   {
     return this;
   }
 
-  obj::persistent_string_sequence_ptr obj::persistent_string_sequence::fresh_seq() const
+  persistent_string_sequence_ptr persistent_string_sequence::fresh_seq() const
   {
-    return make_box<obj::persistent_string_sequence>(str, index);
+    return make_box<persistent_string_sequence>(str, index);
   }
 
   /* behavior::sequenceable */
-  object_ptr obj::persistent_string_sequence::first() const
+  object_ptr persistent_string_sequence::first() const
   {
     return make_box(str->data[index]);
   }
 
-  obj::persistent_string_sequence_ptr obj::persistent_string_sequence::next() const
+  persistent_string_sequence_ptr persistent_string_sequence::next() const
   {
     auto n(index);
     ++n;
@@ -81,10 +82,10 @@ namespace jank::runtime
       return nullptr;
     }
 
-    return make_box<obj::persistent_string_sequence>(str, n);
+    return make_box<persistent_string_sequence>(str, n);
   }
 
-  obj::persistent_string_sequence_ptr obj::persistent_string_sequence::next_in_place()
+  persistent_string_sequence_ptr persistent_string_sequence::next_in_place()
   {
     ++index;
 
@@ -96,8 +97,8 @@ namespace jank::runtime
     return this;
   }
 
-  obj::cons_ptr obj::persistent_string_sequence::conj(object_ptr const head)
+  cons_ptr persistent_string_sequence::conj(object_ptr const head)
   {
-    return make_box<obj::cons>(head, this);
+    return make_box<cons>(head, this);
   }
 }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_vector.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_vector.cpp
@@ -1,3 +1,4 @@
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/persistent_vector.hpp>
 #include <jank/runtime/obj/transient_vector.hpp>
 #include <jank/runtime/visit.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_vector.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_vector.cpp
@@ -1,6 +1,7 @@
 #include <jank/runtime/obj/persistent_vector.hpp>
 #include <jank/runtime/obj/transient_vector.hpp>
 #include <jank/runtime/visit.hpp>
+#include <jank/runtime/core/seq.hpp>
 #include <jank/runtime/core/seq_ext.hpp>
 #include <jank/runtime/behavior/sequential.hpp>
 

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_vector.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_vector.cpp
@@ -4,34 +4,34 @@
 #include <jank/runtime/core/seq_ext.hpp>
 #include <jank/runtime/behavior/sequential.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::persistent_vector::static_object(runtime::detail::native_persistent_vector &&d)
+  persistent_vector::persistent_vector(runtime::detail::native_persistent_vector &&d)
     : data{ std::move(d) }
   {
   }
 
-  obj::persistent_vector::static_object(runtime::detail::native_persistent_vector const &d)
+  persistent_vector::persistent_vector(runtime::detail::native_persistent_vector const &d)
     : data{ d }
   {
   }
 
-  obj::persistent_vector::static_object(object_ptr const meta,
-                                        runtime::detail::native_persistent_vector &&d)
+  persistent_vector::persistent_vector(object_ptr const meta,
+                                       runtime::detail::native_persistent_vector &&d)
     : data{ std::move(d) }
     , meta{ meta }
   {
   }
 
-  obj::persistent_vector_ptr obj::persistent_vector::create(object_ptr const s)
+  persistent_vector_ptr persistent_vector::create(object_ptr const s)
   {
     if(s == nullptr)
     {
-      return make_box<obj::persistent_vector>();
+      return make_box<persistent_vector>();
     }
 
     return visit_object(
-      [](auto const typed_s) -> obj::persistent_vector_ptr {
+      [](auto const typed_s) -> persistent_vector_ptr {
         using T = typename decltype(typed_s)::value_type;
 
         if constexpr(behavior::sequenceable<T>)
@@ -41,7 +41,7 @@ namespace jank::runtime
           {
             v.push_back(i->first());
           }
-          return make_box<obj::persistent_vector>(v.persistent());
+          return make_box<persistent_vector>(v.persistent());
         }
         else
         {
@@ -51,13 +51,19 @@ namespace jank::runtime
       s);
   }
 
-  native_bool obj::persistent_vector::equal(object const &o) const
+  persistent_vector_ptr persistent_vector::empty()
+  {
+    static auto const ret(make_box<persistent_vector>());
+    return ret;
+  }
+
+  native_bool persistent_vector::equal(object const &o) const
   {
     if(&o == &base)
     {
       return true;
     }
-    if(auto const v = dyn_cast<obj::persistent_vector>(&o))
+    if(auto const v = dyn_cast<persistent_vector>(&o))
     {
       if(data.size() != v->data.size())
       {
@@ -106,26 +112,26 @@ namespace jank::runtime
     }
   }
 
-  void obj::persistent_vector::to_string(fmt::memory_buffer &buff) const
+  void persistent_vector::to_string(fmt::memory_buffer &buff) const
   {
     runtime::to_string(data.begin(), data.end(), "[", ']', buff);
   }
 
-  native_persistent_string obj::persistent_vector::to_string() const
+  native_persistent_string persistent_vector::to_string() const
   {
     fmt::memory_buffer buff;
     runtime::to_string(data.begin(), data.end(), "[", ']', buff);
     return native_persistent_string{ buff.data(), buff.size() };
   }
 
-  native_persistent_string obj::persistent_vector::to_code_string() const
+  native_persistent_string persistent_vector::to_code_string() const
   {
     fmt::memory_buffer buff;
     runtime::to_code_string(data.begin(), data.end(), "[", ']', buff);
     return native_persistent_string{ buff.data(), buff.size() };
   }
 
-  native_hash obj::persistent_vector::to_hash() const
+  native_hash persistent_vector::to_hash() const
   {
     if(hash != 0)
     {
@@ -135,14 +141,13 @@ namespace jank::runtime
     return hash = hash::ordered(data.begin(), data.end());
   }
 
-  native_integer obj::persistent_vector::compare(object const &o) const
+  native_integer persistent_vector::compare(object const &o) const
   {
-    return visit_type<obj::persistent_vector>(
-      [this](auto const typed_o) { return compare(*typed_o); },
-      &o);
+    return visit_type<persistent_vector>([this](auto const typed_o) { return compare(*typed_o); },
+                                         &o);
   }
 
-  native_integer obj::persistent_vector::compare(obj::persistent_vector const &v) const
+  native_integer persistent_vector::compare(persistent_vector const &v) const
   {
     auto const size(data.size());
     auto const v_size(v.data.size());
@@ -168,71 +173,71 @@ namespace jank::runtime
     return 0;
   }
 
-  obj::persistent_vector_sequence_ptr obj::persistent_vector::seq() const
+  persistent_vector_sequence_ptr persistent_vector::seq() const
   {
     if(data.empty())
     {
       return nullptr;
     }
-    return make_box<obj::persistent_vector_sequence>(const_cast<obj::persistent_vector *>(this));
+    return make_box<persistent_vector_sequence>(const_cast<persistent_vector *>(this));
   }
 
-  obj::persistent_vector_sequence_ptr obj::persistent_vector::fresh_seq() const
+  persistent_vector_sequence_ptr persistent_vector::fresh_seq() const
   {
     if(data.empty())
     {
       return nullptr;
     }
-    return make_box<obj::persistent_vector_sequence>(const_cast<obj::persistent_vector *>(this));
+    return make_box<persistent_vector_sequence>(const_cast<persistent_vector *>(this));
   }
 
-  size_t obj::persistent_vector::count() const
+  size_t persistent_vector::count() const
   {
     return data.size();
   }
 
-  obj::persistent_vector_ptr obj::persistent_vector::conj(object_ptr head) const
+  persistent_vector_ptr persistent_vector::conj(object_ptr head) const
   {
     auto vec(data.push_back(head));
-    auto ret(make_box<obj::persistent_vector>(std::move(vec)));
+    auto ret(make_box<persistent_vector>(std::move(vec)));
     return ret;
   }
 
-  obj::transient_vector_ptr obj::persistent_vector::to_transient() const
+  transient_vector_ptr persistent_vector::to_transient() const
   {
-    return make_box<obj::transient_vector>(data);
+    return make_box<transient_vector>(data);
   }
 
-  obj::persistent_vector_ptr obj::persistent_vector::with_meta(object_ptr const m) const
+  persistent_vector_ptr persistent_vector::with_meta(object_ptr const m) const
   {
     auto const meta(behavior::detail::validate_meta(m));
-    auto ret(make_box<obj::persistent_vector>(data));
+    auto ret(make_box<persistent_vector>(data));
     ret->meta = meta;
     return ret;
   }
 
-  object_ptr obj::persistent_vector::get(object_ptr const key) const
+  object_ptr persistent_vector::get(object_ptr const key) const
   {
     if(key->type == object_type::integer)
     {
-      auto const i(static_cast<size_t>(expect_object<obj::integer>(key)->data));
+      auto const i(static_cast<size_t>(expect_object<integer>(key)->data));
       if(data.size() <= i)
       {
-        return obj::nil::nil_const();
+        return nil::nil_const();
       }
       return data[i];
     }
     else
     {
-      return obj::nil::nil_const();
+      return nil::nil_const();
     }
   }
 
-  object_ptr obj::persistent_vector::get(object_ptr const key, object_ptr const fallback) const
+  object_ptr persistent_vector::get(object_ptr const key, object_ptr const fallback) const
   {
     if(key->type == object_type::integer)
     {
-      auto const i(expect_object<obj::integer>(key)->data);
+      auto const i(expect_object<integer>(key)->data);
       if(i < 0 || data.size() <= static_cast<size_t>(i))
       {
         return fallback;
@@ -245,29 +250,29 @@ namespace jank::runtime
     }
   }
 
-  object_ptr obj::persistent_vector::get_entry(object_ptr const key) const
+  object_ptr persistent_vector::get_entry(object_ptr const key) const
   {
     if(key->type == object_type::integer)
     {
-      auto const i(expect_object<obj::integer>(key)->data);
+      auto const i(expect_object<integer>(key)->data);
       if(i < 0 || data.size() <= static_cast<size_t>(i))
       {
-        return obj::nil::nil_const();
+        return nil::nil_const();
       }
       /* TODO: Map entry type? */
-      return make_box<obj::persistent_vector>(std::in_place, key, data[i]);
+      return make_box<persistent_vector>(std::in_place, key, data[i]);
     }
     else
     {
-      return obj::nil::nil_const();
+      return nil::nil_const();
     }
   }
 
-  native_bool obj::persistent_vector::contains(object_ptr const key) const
+  native_bool persistent_vector::contains(object_ptr const key) const
   {
     if(key->type == object_type::integer)
     {
-      auto const i(expect_object<obj::integer>(key)->data);
+      auto const i(expect_object<integer>(key)->data);
       return i >= 0 && static_cast<size_t>(i) < data.size();
     }
     else
@@ -276,31 +281,31 @@ namespace jank::runtime
     }
   }
 
-  object_ptr obj::persistent_vector::peek() const
+  object_ptr persistent_vector::peek() const
   {
     if(data.empty())
     {
-      return obj::nil::nil_const();
+      return nil::nil_const();
     }
 
     return data[data.size() - 1];
   }
 
-  obj::persistent_vector_ptr obj::persistent_vector::pop() const
+  persistent_vector_ptr persistent_vector::pop() const
   {
     if(data.empty())
     {
       throw std::runtime_error{ "cannot pop an empty vector" };
     }
 
-    return make_box<obj::persistent_vector>(data.take(data.size() - 1));
+    return make_box<persistent_vector>(data.take(data.size() - 1));
   }
 
-  object_ptr obj::persistent_vector::nth(object_ptr const index) const
+  object_ptr persistent_vector::nth(object_ptr const index) const
   {
     if(index->type == object_type::integer)
     {
-      auto const i(static_cast<size_t>(expect_object<obj::integer>(index)->data));
+      auto const i(static_cast<size_t>(expect_object<integer>(index)->data));
       if(data.size() <= i)
       {
         throw std::runtime_error{
@@ -316,7 +321,7 @@ namespace jank::runtime
     }
   }
 
-  object_ptr obj::persistent_vector::nth(object_ptr const index, object_ptr const fallback) const
+  object_ptr persistent_vector::nth(object_ptr const index, object_ptr const fallback) const
   {
     return get(index, fallback);
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_vector.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_vector.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/persistent_vector.hpp>
 #include <jank/runtime/obj/transient_vector.hpp>
@@ -114,23 +116,23 @@ namespace jank::runtime::obj
     }
   }
 
-  void persistent_vector::to_string(fmt::memory_buffer &buff) const
+  void persistent_vector::to_string(util::string_builder &buff) const
   {
     runtime::to_string(data.begin(), data.end(), "[", ']', buff);
   }
 
   native_persistent_string persistent_vector::to_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     runtime::to_string(data.begin(), data.end(), "[", ']', buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
   native_persistent_string persistent_vector::to_code_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     runtime::to_code_string(data.begin(), data.end(), "[", ']', buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
   native_hash persistent_vector::to_hash() const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_vector_sequence.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_vector_sequence.cpp
@@ -3,15 +3,16 @@
 #include <jank/runtime/core.hpp>
 #include <jank/runtime/core/seq_ext.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::persistent_vector_sequence::static_object(obj::persistent_vector_ptr const v)
+  persistent_vector_sequence::persistent_vector_sequence(persistent_vector_ptr const v)
     : vec{ v }
   {
     assert(!v->data.empty());
   }
 
-  obj::persistent_vector_sequence::static_object(obj::persistent_vector_ptr const v, size_t const i)
+  persistent_vector_sequence::persistent_vector_sequence(persistent_vector_ptr const v,
+                                                         size_t const i)
     : vec{ v }
     , index{ i }
   {
@@ -20,45 +21,41 @@ namespace jank::runtime
   }
 
   /* behavior::objectable */
-  native_bool obj::persistent_vector_sequence::equal(object const &o) const
+  native_bool persistent_vector_sequence::equal(object const &o) const
   {
     return runtime::equal(
       o,
-      vec->data.begin()
-        + static_cast<decltype(obj::persistent_vector::data)::difference_type>(index),
+      vec->data.begin() + static_cast<decltype(persistent_vector::data)::difference_type>(index),
       vec->data.end());
   }
 
-  void obj::persistent_vector_sequence::to_string(fmt::memory_buffer &buff) const
+  void persistent_vector_sequence::to_string(fmt::memory_buffer &buff) const
   {
-    runtime::to_string(
-      vec->data.begin()
-        + static_cast<decltype(obj::persistent_vector::data)::difference_type>(index),
-      vec->data.end(),
-      "(",
-      ')',
-      buff);
+    runtime::to_string(vec->data.begin()
+                         + static_cast<decltype(persistent_vector::data)::difference_type>(index),
+                       vec->data.end(),
+                       "(",
+                       ')',
+                       buff);
   }
 
-  native_persistent_string obj::persistent_vector_sequence::to_string() const
+  native_persistent_string persistent_vector_sequence::to_string() const
   {
     fmt::memory_buffer buff;
-    runtime::to_string(
-      vec->data.begin()
-        + static_cast<decltype(obj::persistent_vector::data)::difference_type>(index),
-      vec->data.end(),
-      "(",
-      ')',
-      buff);
+    runtime::to_string(vec->data.begin()
+                         + static_cast<decltype(persistent_vector::data)::difference_type>(index),
+                       vec->data.end(),
+                       "(",
+                       ')',
+                       buff);
     return { buff.data(), buff.size() };
   }
 
-  native_persistent_string obj::persistent_vector_sequence::to_code_string() const
+  native_persistent_string persistent_vector_sequence::to_code_string() const
   {
     fmt::memory_buffer buff;
     runtime::to_code_string(
-      vec->data.begin()
-        + static_cast<decltype(obj::persistent_vector::data)::difference_type>(index),
+      vec->data.begin() + static_cast<decltype(persistent_vector::data)::difference_type>(index),
       vec->data.end(),
       "(",
       ')',
@@ -66,38 +63,37 @@ namespace jank::runtime
     return { buff.data(), buff.size() };
   }
 
-  native_hash obj::persistent_vector_sequence::to_hash() const
+  native_hash persistent_vector_sequence::to_hash() const
   {
-    return hash::ordered(
-      vec->data.begin()
-        + static_cast<decltype(obj::persistent_vector::data)::difference_type>(index),
-      vec->data.end());
+    return hash::ordered(vec->data.begin()
+                           + static_cast<decltype(persistent_vector::data)::difference_type>(index),
+                         vec->data.end());
   }
 
   /* behavior::countable */
-  size_t obj::persistent_vector_sequence::count() const
+  size_t persistent_vector_sequence::count() const
   {
     return vec->data.size() - index;
   }
 
   /* behavior::seqable */
-  obj::persistent_vector_sequence_ptr obj::persistent_vector_sequence::seq()
+  persistent_vector_sequence_ptr persistent_vector_sequence::seq()
   {
     return this;
   }
 
-  obj::persistent_vector_sequence_ptr obj::persistent_vector_sequence::fresh_seq() const
+  persistent_vector_sequence_ptr persistent_vector_sequence::fresh_seq() const
   {
-    return make_box<obj::persistent_vector_sequence>(vec, index);
+    return make_box<persistent_vector_sequence>(vec, index);
   }
 
   /* behavior::sequenceable */
-  object_ptr obj::persistent_vector_sequence::first() const
+  object_ptr persistent_vector_sequence::first() const
   {
     return vec->data[index];
   }
 
-  obj::persistent_vector_sequence_ptr obj::persistent_vector_sequence::next() const
+  persistent_vector_sequence_ptr persistent_vector_sequence::next() const
   {
     auto n(index);
     ++n;
@@ -107,10 +103,10 @@ namespace jank::runtime
       return nullptr;
     }
 
-    return make_box<obj::persistent_vector_sequence>(vec, n);
+    return make_box<persistent_vector_sequence>(vec, n);
   }
 
-  obj::persistent_vector_sequence_ptr obj::persistent_vector_sequence::next_in_place()
+  persistent_vector_sequence_ptr persistent_vector_sequence::next_in_place()
   {
     ++index;
 
@@ -122,8 +118,8 @@ namespace jank::runtime
     return this;
   }
 
-  obj::cons_ptr obj::persistent_vector_sequence::conj(object_ptr const head)
+  cons_ptr persistent_vector_sequence::conj(object_ptr const head)
   {
-    return make_box<obj::cons>(head, this);
+    return make_box<cons>(head, this);
   }
 }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_vector_sequence.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_vector_sequence.cpp
@@ -29,7 +29,7 @@ namespace jank::runtime::obj
       vec->data.end());
   }
 
-  void persistent_vector_sequence::to_string(fmt::memory_buffer &buff) const
+  void persistent_vector_sequence::to_string(util::string_builder &buff) const
   {
     runtime::to_string(vec->data.begin()
                          + static_cast<decltype(persistent_vector::data)::difference_type>(index),
@@ -41,26 +41,26 @@ namespace jank::runtime::obj
 
   native_persistent_string persistent_vector_sequence::to_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     runtime::to_string(vec->data.begin()
                          + static_cast<decltype(persistent_vector::data)::difference_type>(index),
                        vec->data.end(),
                        "(",
                        ')',
                        buff);
-    return { buff.data(), buff.size() };
+    return buff.release();
   }
 
   native_persistent_string persistent_vector_sequence::to_code_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     runtime::to_code_string(
       vec->data.begin() + static_cast<decltype(persistent_vector::data)::difference_type>(index),
       vec->data.end(),
       "(",
       ')',
       buff);
-    return { buff.data(), buff.size() };
+    return buff.release();
   }
 
   native_hash persistent_vector_sequence::to_hash() const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/range.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/range.cpp
@@ -220,7 +220,7 @@ namespace jank::runtime::obj
       &o);
   }
 
-  void range::to_string(fmt::memory_buffer &buff)
+  void range::to_string(util::string_builder &buff)
   {
     runtime::to_string(seq(), buff);
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/range.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/range.cpp
@@ -2,6 +2,7 @@
 #include <jank/runtime/obj/number.hpp>
 #include <jank/runtime/core/math.hpp>
 #include <jank/runtime/core/make_box.hpp>
+#include <jank/runtime/core/seq.hpp>
 #include <jank/runtime/visit.hpp>
 #include <jank/runtime/behavior/metadatable.hpp>
 

--- a/compiler+runtime/src/cpp/jank/runtime/obj/ratio.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/ratio.cpp
@@ -1,8 +1,6 @@
 #include <limits>
 #include <numeric>
 
-#include <fmt/compile.h>
-
 #include <jank/runtime/obj/ratio.hpp>
 #include <jank/runtime/visit.hpp>
 
@@ -64,16 +62,16 @@ namespace jank::runtime::obj
     return data.to_integer();
   }
 
-  void ratio::to_string(fmt::memory_buffer &buff) const
+  void ratio::to_string(util::string_builder &buff) const
   {
-    format_to(std::back_inserter(buff), FMT_COMPILE("{}/{}"), data.numerator, data.denominator);
+    buff(data.numerator)('/')(data.denominator);
   }
 
   native_persistent_string ratio::to_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     to_string(buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
   native_persistent_string ratio::to_code_string() const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/ratio.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/ratio.cpp
@@ -6,11 +6,11 @@
 #include <jank/runtime/obj/ratio.hpp>
 #include <jank/runtime/visit.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
   static constexpr auto epsilon{ std::numeric_limits<native_real>::epsilon() };
 
-  obj::ratio_data::ratio_data(native_integer const numerator, native_integer const denominator)
+  ratio_data::ratio_data(native_integer const numerator, native_integer const denominator)
     : numerator{ numerator }
     , denominator{ denominator }
   {
@@ -29,84 +29,84 @@ namespace jank::runtime
     }
   }
 
-  obj::ratio::static_object(obj::ratio_data const &data)
+  ratio::ratio(ratio_data const &data)
     : data{ data }
   {
   }
 
-  object_ptr obj::ratio::create(native_integer const numerator, native_integer const denominator)
+  object_ptr ratio::create(native_integer const numerator, native_integer const denominator)
   {
-    obj::ratio_data const data{ numerator, denominator };
+    ratio_data const data{ numerator, denominator };
     if(data.denominator == 1)
     {
-      return make_box<obj::integer>(data.numerator);
+      return make_box<integer>(data.numerator);
     }
-    return make_box<obj::ratio>(data);
+    return make_box<ratio>(data);
   }
 
-  native_real obj::ratio_data::to_real() const
+  native_real ratio_data::to_real() const
   {
     return static_cast<native_real>(numerator) / static_cast<native_real>(denominator);
   }
 
-  native_integer obj::ratio_data::to_integer() const
+  native_integer ratio_data::to_integer() const
   {
     return numerator / denominator;
   }
 
-  native_real obj::ratio::to_real() const
+  native_real ratio::to_real() const
   {
     return data.to_real();
   }
 
-  native_integer obj::ratio::to_integer() const
+  native_integer ratio::to_integer() const
   {
     return data.to_integer();
   }
 
-  void obj::ratio::to_string(fmt::memory_buffer &buff) const
+  void ratio::to_string(fmt::memory_buffer &buff) const
   {
     format_to(std::back_inserter(buff), FMT_COMPILE("{}/{}"), data.numerator, data.denominator);
   }
 
-  native_persistent_string obj::ratio::to_string() const
+  native_persistent_string ratio::to_string() const
   {
     fmt::memory_buffer buff;
     to_string(buff);
     return native_persistent_string{ buff.data(), buff.size() };
   }
 
-  native_persistent_string obj::ratio::to_code_string() const
+  native_persistent_string ratio::to_code_string() const
   {
     return to_string();
   }
 
-  native_hash obj::ratio::to_hash() const
+  native_hash ratio::to_hash() const
   {
     return hash::combine(hash::integer(data.numerator), hash::integer(data.denominator));
   }
 
-  native_bool obj::ratio::equal(object const &o) const
+  native_bool ratio::equal(object const &o) const
   {
     if(o.type == object_type::integer)
     {
-      return data == expect_object<obj::integer>(&o)->data;
+      return data == expect_object<integer>(&o)->data;
     }
 
     if(o.type == object_type::real)
     {
-      return data == expect_object<obj::real>(&o)->data;
+      return data == expect_object<real>(&o)->data;
     }
 
     if(o.type == object_type::ratio)
     {
-      return data == expect_object<obj::ratio>(&o)->data;
+      return data == expect_object<ratio>(&o)->data;
     }
 
     return false;
   }
 
-  native_integer obj::ratio::compare(object const &o) const
+  native_integer ratio::compare(object const &o) const
   {
     return visit_number_like(
       [this](auto const typed_o) -> native_integer {
@@ -115,443 +115,437 @@ namespace jank::runtime
       &o);
   }
 
-  native_integer obj::ratio::compare(static_object const &o) const
+  native_integer ratio::compare(ratio const &o) const
   {
     return (data > o.data) - (data < o.data);
   }
 
-  namespace obj
+  object_ptr operator+(ratio_data const &l, ratio_data const &r)
   {
-    object_ptr operator+(obj::ratio_data const &l, obj::ratio_data const &r)
-    {
-      auto const denom{ l.denominator * r.denominator };
-      auto const num{ (l.numerator * r.denominator) + (r.numerator * l.denominator) };
-      return obj::ratio::create(num, denom);
-    }
-
-    obj::ratio_ptr operator+(obj::integer_ptr const l, obj::ratio_data const &r)
-    {
-      return l->data + r;
-    }
-
-    obj::ratio_ptr operator+(obj::ratio_data const &l, obj::integer_ptr const r)
-    {
-      return r + l;
-    }
-
-    native_real operator+(obj::real_ptr const l, obj::ratio_data const &r)
-    {
-      return l->data + r.to_real();
-    }
-
-    native_real operator+(obj::ratio_data const &l, obj::real_ptr const r)
-    {
-      return l.to_real() + r->data;
-    }
-
-    native_real operator+(obj::ratio_data const &l, native_real const r)
-    {
-      return l.to_real() + r;
-    }
-
-    native_real operator+(native_real const l, obj::ratio_data const &r)
-    {
-      return l + r.to_real();
-    }
-
-    obj::ratio_ptr operator+(obj::ratio_data const &l, native_integer const r)
-    {
-      return make_box<obj::ratio>(
-        obj::ratio_data(l.numerator + (r * l.denominator), l.denominator));
-    }
-
-    obj::ratio_ptr operator+(native_integer const l, obj::ratio_data const &r)
-    {
-      return r + l;
-    }
-
-    object_ptr operator-(obj::ratio_data const &l, obj::ratio_data const &r)
-    {
-      auto const denom{ l.denominator * r.denominator };
-      auto const num{ (l.numerator * r.denominator) - (r.numerator * l.denominator) };
-      return obj::ratio::create(num, denom);
-    }
-
-    obj::ratio_ptr operator-(obj::integer_ptr const l, obj::ratio_data const &r)
-    {
-      return l->data - r;
-    }
-
-    obj::ratio_ptr operator-(obj::ratio_data const &l, obj::integer_ptr const r)
-    {
-      return l - r->data;
-    }
-
-    native_real operator-(obj::real_ptr const l, obj::ratio_data const &r)
-    {
-      return l->data - r.to_real();
-    }
-
-    native_real operator-(obj::ratio_data const &l, obj::real_ptr const r)
-    {
-      return l.to_real() - r->data;
-    }
-
-    native_real operator-(obj::ratio_data const &l, native_real const r)
-    {
-      return l.to_real() - r;
-    }
-
-    native_real operator-(native_real const l, obj::ratio_data const &r)
-    {
-      return l - r.to_real();
-    }
-
-    obj::ratio_ptr operator-(obj::ratio_data const &l, native_integer const r)
-    {
-      return make_box<obj::ratio>(
-        obj::ratio_data(l.numerator - (r * l.denominator), l.denominator));
-    }
-
-    obj::ratio_ptr operator-(native_integer const l, obj::ratio_data const &r)
-    {
-      return make_box<obj::ratio>(
-        obj::ratio_data((l * r.denominator) - r.numerator, r.denominator));
-    }
-
-    object_ptr operator*(obj::ratio_data const &l, obj::ratio_data const &r)
-    {
-      return obj::ratio::create(l.numerator * r.numerator, l.denominator * r.denominator);
-    }
-
-    object_ptr operator*(obj::integer_ptr const l, obj::ratio_data const &r)
-    {
-      return obj::ratio_data(l->data, 1ll) * r;
-    }
-
-    object_ptr operator*(obj::ratio_data const &l, obj::integer_ptr const r)
-    {
-      return l * obj::ratio_data(r->data, 1ll);
-    }
-
-    native_real operator*(obj::real_ptr const l, obj::ratio_data const &r)
-    {
-      return l->data * r.to_real();
-    }
-
-    native_real operator*(obj::ratio_data const &l, obj::real_ptr const r)
-    {
-      return l.to_real() * r->data;
-    }
-
-    native_real operator*(obj::ratio_data const &l, native_real const r)
-    {
-      return l.to_real() * r;
-    }
-
-    native_real operator*(native_real const l, obj::ratio_data const &r)
-    {
-      return l * r.to_real();
-    }
-
-    object_ptr operator*(obj::ratio_data const &l, native_integer const r)
-    {
-      return l * obj::ratio_data(r, 1ll);
-    }
-
-    object_ptr operator*(native_integer const l, obj::ratio_data const &r)
-    {
-      return r * l;
-    }
-
-    object_ptr operator/(obj::ratio_data const &l, obj::ratio_data const &r)
-    {
-      return obj::ratio::create(l.numerator * r.denominator, l.denominator * r.numerator);
-    }
-
-    object_ptr operator/(obj::integer_ptr const l, obj::ratio_data const &r)
-    {
-      return obj::ratio_data(l->data, 1ll) / r;
-    }
-
-    obj::ratio_ptr operator/(obj::ratio_data const &l, obj::integer_ptr const r)
-    {
-      return l / r->data;
-    }
-
-    native_real operator/(obj::real_ptr const l, obj::ratio_data const &r)
-    {
-      return l->data / r.to_real();
-    }
-
-    native_real operator/(obj::ratio_data const &l, obj::real_ptr const r)
-    {
-      return l.to_real() / r->data;
-    }
-
-    native_real operator/(obj::ratio_data const &l, native_real const r)
-    {
-      return l.to_real() / r;
-    }
-
-    native_real operator/(native_real const l, obj::ratio_data const &r)
-    {
-      return l / r.to_real();
-    }
-
-    obj::ratio_ptr operator/(obj::ratio_data const &l, native_integer const r)
-    {
-      return make_box<obj::ratio>(obj::ratio_data(l.numerator, l.denominator * r));
-    }
-
-    object_ptr operator/(native_integer const l, obj::ratio_data const &r)
-    {
-      return obj::ratio_data(l, 1ll) / r;
-    }
-
-    native_bool operator==(obj::ratio_data const &l, obj::ratio_data const &r)
-    {
-      return l.numerator == r.numerator && l.denominator == r.denominator;
-    }
-
-    native_bool operator==(obj::integer_ptr const l, obj::ratio_data const &r)
-    {
-      return l->data * r.denominator == r.numerator;
-    }
-
-    native_bool operator==(obj::ratio_data const &l, obj::integer_ptr const r)
-    {
-      return l.numerator == r->data * l.denominator;
-    }
-
-    native_bool operator==(obj::real_ptr const l, obj::ratio_data const &r)
-    {
-      return std::fabs(l->data - r) < epsilon;
-    }
-
-    native_bool operator==(obj::ratio_data const &l, obj::real_ptr const r)
-    {
-      return r == l;
-    }
-
-    native_bool operator==(obj::ratio_data const &l, native_real const r)
-    {
-      return std::fabs(l - r) < epsilon;
-    }
-
-    native_bool operator==(native_real const l, obj::ratio_data const &r)
-    {
-      return r == l;
-    }
-
-    native_bool operator==(obj::ratio_data const &l, native_integer const r)
-    {
-      return l.numerator == r * l.denominator;
-    }
-
-    native_bool operator==(native_integer const l, obj::ratio_data const &r)
-    {
-      return l * r.denominator == r.numerator;
-    }
-
-    native_bool operator<(obj::ratio_data const &l, obj::ratio_data const &r)
-    {
-      return l.numerator * r.denominator < r.numerator * l.denominator;
-    }
-
-    native_bool operator<=(obj::ratio_data const &l, obj::ratio_data const &r)
-    {
-      return l.numerator * r.denominator <= r.numerator * l.denominator;
-    }
-
-    native_bool operator<(obj::integer_ptr const l, obj::ratio_data const &r)
-    {
-      return l->data * r.denominator < r.numerator;
-    }
-
-    native_bool operator<(obj::ratio_data const &l, obj::integer_ptr const r)
-    {
-      return l.numerator < r->data * l.denominator;
-    }
-
-    native_bool operator<=(obj::integer_ptr const l, obj::ratio_data const &r)
-    {
-      return l->data * r.denominator <= r.numerator;
-    }
-
-    native_bool operator<=(obj::ratio_data const &l, obj::integer_ptr const r)
-    {
-      return l.numerator <= r->data * l.denominator;
-    }
-
-    native_bool operator<(obj::real_ptr const l, obj::ratio_data const &r)
-    {
-      return l->data < r.to_real();
-    }
-
-    native_bool operator<(obj::ratio_data const &l, obj::real_ptr const r)
-    {
-      return l.to_real() < r->data;
-    }
-
-    native_bool operator<=(obj::real_ptr const l, obj::ratio_data const &r)
-    {
-      return l->data <= r.to_real();
-    }
-
-    native_bool operator<=(obj::ratio_data const &l, obj::real_ptr const r)
-    {
-      return l.to_real() <= r->data;
-    }
-
-    native_bool operator<(obj::ratio_data const &l, native_real const r)
-    {
-      return l.to_real() < r;
-    }
-
-    native_bool operator<(native_real const l, obj::ratio_data const &r)
-    {
-      return l < r.to_real();
-    }
-
-    native_bool operator<=(obj::ratio_data const &l, native_real const r)
-    {
-      return l.to_real() <= r;
-    }
-
-    native_bool operator<=(native_real const l, obj::ratio_data const &r)
-    {
-      return l <= r.to_real();
-    }
-
-    native_bool operator<(obj::ratio_data const &l, native_integer const r)
-    {
-      return l.numerator < r * l.denominator;
-    }
-
-    native_bool operator<(native_integer const l, obj::ratio_data const &r)
-    {
-      return l * r.denominator < r.numerator;
-    }
-
-    native_bool operator<=(obj::ratio_data const &l, native_integer const r)
-    {
-      return l.numerator <= r * l.denominator;
-    }
-
-    native_bool operator<=(native_integer const l, obj::ratio_data const &r)
-    {
-      return l * r.denominator <= r.numerator;
-    }
-
-    native_bool operator>(obj::ratio_data const &l, obj::ratio_data const &r)
-    {
-      return l.numerator * r.denominator > r.numerator * l.denominator;
-    }
-
-    native_bool operator>(obj::integer_ptr const l, obj::ratio_data const &r)
-    {
-      return l->data * r.denominator > r.numerator;
-    }
-
-    native_bool operator>(obj::ratio_data const &l, obj::integer_ptr const r)
-    {
-      return l.numerator > r->data * l.denominator;
-    }
-
-    native_bool operator>(obj::real_ptr const l, obj::ratio_data const &r)
-    {
-      return l->data > r.to_real();
-    }
-
-    native_bool operator>(obj::ratio_data const &l, obj::real_ptr const r)
-    {
-      return l.to_real() > r->data;
-    }
-
-    native_bool operator>(obj::ratio_data const &l, native_real const r)
-    {
-      return l.to_real() > r;
-    }
-
-    native_bool operator>(native_real const l, obj::ratio_data const &r)
-    {
-      return l > r.to_real();
-    }
-
-    native_bool operator>(obj::ratio_data const &l, native_integer const r)
-    {
-      return l.numerator > r * l.denominator;
-    }
-
-    native_bool operator>(native_integer const l, obj::ratio_data const &r)
-    {
-      return l * r.denominator > r.numerator;
-    }
-
-    native_bool operator>=(obj::ratio_data const &l, obj::ratio_data const &r)
-    {
-      return l.numerator * r.denominator >= r.numerator * l.denominator;
-    }
-
-    native_bool operator>=(obj::integer_ptr const l, obj::ratio_data const &r)
-    {
-      return l->data * r.denominator >= r.numerator;
-    }
-
-    native_bool operator>=(obj::ratio_data const &l, obj::integer_ptr const r)
-    {
-      return l.numerator >= r->data * l.denominator;
-    }
-
-    native_bool operator>=(obj::real_ptr const l, obj::ratio_data const &r)
-    {
-      return l->data >= r.to_real();
-    }
-
-    native_bool operator>=(obj::ratio_data const &l, obj::real_ptr const r)
-    {
-      return l.to_real() >= r->data;
-    }
-
-    native_bool operator>=(obj::ratio_data const &l, native_real const r)
-    {
-      return l.to_real() >= r;
-    }
-
-    native_bool operator>=(native_real const l, obj::ratio_data const &r)
-    {
-      return l >= r.to_real();
-    }
-
-    native_bool operator>=(obj::ratio_data const &l, native_integer const r)
-    {
-      return l.numerator >= r * l.denominator;
-    }
-
-    native_bool operator>=(native_integer const l, obj::ratio_data const &r)
-    {
-      return l * r.denominator >= r.numerator;
-    }
-
-    native_bool operator>(native_bool l, obj::ratio_data const &r)
-    {
-      return (l ? 1ll : 0ll) > r;
-    }
-
-    native_bool operator<(native_bool l, obj::ratio_data const &r)
-    {
-      return (l ? 1ll : 0ll) < r;
-    }
-
-    native_bool operator>(obj::ratio_data const &l, native_bool const r)
-    {
-      return l > (r ? 1ll : 0ll);
-    }
-
-    native_bool operator<(obj::ratio_data const &l, native_bool const r)
-    {
-      return l < (r ? 1ll : 0ll);
-    }
+    auto const denom{ l.denominator * r.denominator };
+    auto const num{ (l.numerator * r.denominator) + (r.numerator * l.denominator) };
+    return ratio::create(num, denom);
+  }
+
+  ratio_ptr operator+(integer_ptr const l, ratio_data const &r)
+  {
+    return l->data + r;
+  }
+
+  ratio_ptr operator+(ratio_data const &l, integer_ptr const r)
+  {
+    return r + l;
+  }
+
+  native_real operator+(real_ptr const l, ratio_data const &r)
+  {
+    return l->data + r.to_real();
+  }
+
+  native_real operator+(ratio_data const &l, real_ptr const r)
+  {
+    return l.to_real() + r->data;
+  }
+
+  native_real operator+(ratio_data const &l, native_real const r)
+  {
+    return l.to_real() + r;
+  }
+
+  native_real operator+(native_real const l, ratio_data const &r)
+  {
+    return l + r.to_real();
+  }
+
+  ratio_ptr operator+(ratio_data const &l, native_integer const r)
+  {
+    return make_box<ratio>(ratio_data(l.numerator + (r * l.denominator), l.denominator));
+  }
+
+  ratio_ptr operator+(native_integer const l, ratio_data const &r)
+  {
+    return r + l;
+  }
+
+  object_ptr operator-(ratio_data const &l, ratio_data const &r)
+  {
+    auto const denom{ l.denominator * r.denominator };
+    auto const num{ (l.numerator * r.denominator) - (r.numerator * l.denominator) };
+    return ratio::create(num, denom);
+  }
+
+  ratio_ptr operator-(integer_ptr const l, ratio_data const &r)
+  {
+    return l->data - r;
+  }
+
+  ratio_ptr operator-(ratio_data const &l, integer_ptr const r)
+  {
+    return l - r->data;
+  }
+
+  native_real operator-(real_ptr const l, ratio_data const &r)
+  {
+    return l->data - r.to_real();
+  }
+
+  native_real operator-(ratio_data const &l, real_ptr const r)
+  {
+    return l.to_real() - r->data;
+  }
+
+  native_real operator-(ratio_data const &l, native_real const r)
+  {
+    return l.to_real() - r;
+  }
+
+  native_real operator-(native_real const l, ratio_data const &r)
+  {
+    return l - r.to_real();
+  }
+
+  ratio_ptr operator-(ratio_data const &l, native_integer const r)
+  {
+    return make_box<ratio>(ratio_data(l.numerator - (r * l.denominator), l.denominator));
+  }
+
+  ratio_ptr operator-(native_integer const l, ratio_data const &r)
+  {
+    return make_box<ratio>(ratio_data((l * r.denominator) - r.numerator, r.denominator));
+  }
+
+  object_ptr operator*(ratio_data const &l, ratio_data const &r)
+  {
+    return ratio::create(l.numerator * r.numerator, l.denominator * r.denominator);
+  }
+
+  object_ptr operator*(integer_ptr const l, ratio_data const &r)
+  {
+    return ratio_data(l->data, 1ll) * r;
+  }
+
+  object_ptr operator*(ratio_data const &l, integer_ptr const r)
+  {
+    return l * ratio_data(r->data, 1ll);
+  }
+
+  native_real operator*(real_ptr const l, ratio_data const &r)
+  {
+    return l->data * r.to_real();
+  }
+
+  native_real operator*(ratio_data const &l, real_ptr const r)
+  {
+    return l.to_real() * r->data;
+  }
+
+  native_real operator*(ratio_data const &l, native_real const r)
+  {
+    return l.to_real() * r;
+  }
+
+  native_real operator*(native_real const l, ratio_data const &r)
+  {
+    return l * r.to_real();
+  }
+
+  object_ptr operator*(ratio_data const &l, native_integer const r)
+  {
+    return l * ratio_data(r, 1ll);
+  }
+
+  object_ptr operator*(native_integer const l, ratio_data const &r)
+  {
+    return r * l;
+  }
+
+  object_ptr operator/(ratio_data const &l, ratio_data const &r)
+  {
+    return ratio::create(l.numerator * r.denominator, l.denominator * r.numerator);
+  }
+
+  object_ptr operator/(integer_ptr const l, ratio_data const &r)
+  {
+    return ratio_data(l->data, 1ll) / r;
+  }
+
+  ratio_ptr operator/(ratio_data const &l, integer_ptr const r)
+  {
+    return l / r->data;
+  }
+
+  native_real operator/(real_ptr const l, ratio_data const &r)
+  {
+    return l->data / r.to_real();
+  }
+
+  native_real operator/(ratio_data const &l, real_ptr const r)
+  {
+    return l.to_real() / r->data;
+  }
+
+  native_real operator/(ratio_data const &l, native_real const r)
+  {
+    return l.to_real() / r;
+  }
+
+  native_real operator/(native_real const l, ratio_data const &r)
+  {
+    return l / r.to_real();
+  }
+
+  ratio_ptr operator/(ratio_data const &l, native_integer const r)
+  {
+    return make_box<ratio>(ratio_data(l.numerator, l.denominator * r));
+  }
+
+  object_ptr operator/(native_integer const l, ratio_data const &r)
+  {
+    return ratio_data(l, 1ll) / r;
+  }
+
+  native_bool operator==(ratio_data const &l, ratio_data const &r)
+  {
+    return l.numerator == r.numerator && l.denominator == r.denominator;
+  }
+
+  native_bool operator==(integer_ptr const l, ratio_data const &r)
+  {
+    return l->data * r.denominator == r.numerator;
+  }
+
+  native_bool operator==(ratio_data const &l, integer_ptr const r)
+  {
+    return l.numerator == r->data * l.denominator;
+  }
+
+  native_bool operator==(real_ptr const l, ratio_data const &r)
+  {
+    return std::fabs(l->data - r) < epsilon;
+  }
+
+  native_bool operator==(ratio_data const &l, real_ptr const r)
+  {
+    return r == l;
+  }
+
+  native_bool operator==(ratio_data const &l, native_real const r)
+  {
+    return std::fabs(l - r) < epsilon;
+  }
+
+  native_bool operator==(native_real const l, ratio_data const &r)
+  {
+    return r == l;
+  }
+
+  native_bool operator==(ratio_data const &l, native_integer const r)
+  {
+    return l.numerator == r * l.denominator;
+  }
+
+  native_bool operator==(native_integer const l, ratio_data const &r)
+  {
+    return l * r.denominator == r.numerator;
+  }
+
+  native_bool operator<(ratio_data const &l, ratio_data const &r)
+  {
+    return l.numerator * r.denominator < r.numerator * l.denominator;
+  }
+
+  native_bool operator<=(ratio_data const &l, ratio_data const &r)
+  {
+    return l.numerator * r.denominator <= r.numerator * l.denominator;
+  }
+
+  native_bool operator<(integer_ptr const l, ratio_data const &r)
+  {
+    return l->data * r.denominator < r.numerator;
+  }
+
+  native_bool operator<(ratio_data const &l, integer_ptr const r)
+  {
+    return l.numerator < r->data * l.denominator;
+  }
+
+  native_bool operator<=(integer_ptr const l, ratio_data const &r)
+  {
+    return l->data * r.denominator <= r.numerator;
+  }
+
+  native_bool operator<=(ratio_data const &l, integer_ptr const r)
+  {
+    return l.numerator <= r->data * l.denominator;
+  }
+
+  native_bool operator<(real_ptr const l, ratio_data const &r)
+  {
+    return l->data < r.to_real();
+  }
+
+  native_bool operator<(ratio_data const &l, real_ptr const r)
+  {
+    return l.to_real() < r->data;
+  }
+
+  native_bool operator<=(real_ptr const l, ratio_data const &r)
+  {
+    return l->data <= r.to_real();
+  }
+
+  native_bool operator<=(ratio_data const &l, real_ptr const r)
+  {
+    return l.to_real() <= r->data;
+  }
+
+  native_bool operator<(ratio_data const &l, native_real const r)
+  {
+    return l.to_real() < r;
+  }
+
+  native_bool operator<(native_real const l, ratio_data const &r)
+  {
+    return l < r.to_real();
+  }
+
+  native_bool operator<=(ratio_data const &l, native_real const r)
+  {
+    return l.to_real() <= r;
+  }
+
+  native_bool operator<=(native_real const l, ratio_data const &r)
+  {
+    return l <= r.to_real();
+  }
+
+  native_bool operator<(ratio_data const &l, native_integer const r)
+  {
+    return l.numerator < r * l.denominator;
+  }
+
+  native_bool operator<(native_integer const l, ratio_data const &r)
+  {
+    return l * r.denominator < r.numerator;
+  }
+
+  native_bool operator<=(ratio_data const &l, native_integer const r)
+  {
+    return l.numerator <= r * l.denominator;
+  }
+
+  native_bool operator<=(native_integer const l, ratio_data const &r)
+  {
+    return l * r.denominator <= r.numerator;
+  }
+
+  native_bool operator>(ratio_data const &l, ratio_data const &r)
+  {
+    return l.numerator * r.denominator > r.numerator * l.denominator;
+  }
+
+  native_bool operator>(integer_ptr const l, ratio_data const &r)
+  {
+    return l->data * r.denominator > r.numerator;
+  }
+
+  native_bool operator>(ratio_data const &l, integer_ptr const r)
+  {
+    return l.numerator > r->data * l.denominator;
+  }
+
+  native_bool operator>(real_ptr const l, ratio_data const &r)
+  {
+    return l->data > r.to_real();
+  }
+
+  native_bool operator>(ratio_data const &l, real_ptr const r)
+  {
+    return l.to_real() > r->data;
+  }
+
+  native_bool operator>(ratio_data const &l, native_real const r)
+  {
+    return l.to_real() > r;
+  }
+
+  native_bool operator>(native_real const l, ratio_data const &r)
+  {
+    return l > r.to_real();
+  }
+
+  native_bool operator>(ratio_data const &l, native_integer const r)
+  {
+    return l.numerator > r * l.denominator;
+  }
+
+  native_bool operator>(native_integer const l, ratio_data const &r)
+  {
+    return l * r.denominator > r.numerator;
+  }
+
+  native_bool operator>=(ratio_data const &l, ratio_data const &r)
+  {
+    return l.numerator * r.denominator >= r.numerator * l.denominator;
+  }
+
+  native_bool operator>=(integer_ptr const l, ratio_data const &r)
+  {
+    return l->data * r.denominator >= r.numerator;
+  }
+
+  native_bool operator>=(ratio_data const &l, integer_ptr const r)
+  {
+    return l.numerator >= r->data * l.denominator;
+  }
+
+  native_bool operator>=(real_ptr const l, ratio_data const &r)
+  {
+    return l->data >= r.to_real();
+  }
+
+  native_bool operator>=(ratio_data const &l, real_ptr const r)
+  {
+    return l.to_real() >= r->data;
+  }
+
+  native_bool operator>=(ratio_data const &l, native_real const r)
+  {
+    return l.to_real() >= r;
+  }
+
+  native_bool operator>=(native_real const l, ratio_data const &r)
+  {
+    return l >= r.to_real();
+  }
+
+  native_bool operator>=(ratio_data const &l, native_integer const r)
+  {
+    return l.numerator >= r * l.denominator;
+  }
+
+  native_bool operator>=(native_integer const l, ratio_data const &r)
+  {
+    return l * r.denominator >= r.numerator;
+  }
+
+  native_bool operator>(native_bool l, ratio_data const &r)
+  {
+    return (l ? 1ll : 0ll) > r;
+  }
+
+  native_bool operator<(native_bool l, ratio_data const &r)
+  {
+    return (l ? 1ll : 0ll) < r;
+  }
+
+  native_bool operator>(ratio_data const &l, native_bool const r)
+  {
+    return l > (r ? 1ll : 0ll);
+  }
+
+  native_bool operator<(ratio_data const &l, native_bool const r)
+  {
+    return l < (r ? 1ll : 0ll);
   }
 }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/reduced.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/reduced.cpp
@@ -2,27 +2,27 @@
 
 #include <jank/runtime/obj/reduced.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::reduced::static_object(object_ptr const o)
+  reduced::reduced(object_ptr const o)
     : val{ o }
   {
     assert(val);
   }
 
-  native_bool obj::reduced::equal(object const &o) const
+  native_bool reduced::equal(object const &o) const
   {
     return &o == &base;
   }
 
-  native_persistent_string obj::reduced::to_string() const
+  native_persistent_string reduced::to_string() const
   {
     fmt::memory_buffer buff;
     to_string(buff);
     return native_persistent_string{ buff.data(), buff.size() };
   }
 
-  void obj::reduced::to_string(fmt::memory_buffer &buff) const
+  void reduced::to_string(fmt::memory_buffer &buff) const
   {
     fmt::format_to(std::back_inserter(buff),
                    "{}@{}",
@@ -30,17 +30,17 @@ namespace jank::runtime
                    fmt::ptr(&base));
   }
 
-  native_persistent_string obj::reduced::to_code_string() const
+  native_persistent_string reduced::to_code_string() const
   {
     return to_string();
   }
 
-  native_hash obj::reduced::to_hash() const
+  native_hash reduced::to_hash() const
   {
     return static_cast<native_hash>(reinterpret_cast<uintptr_t>(this));
   }
 
-  object_ptr obj::reduced::deref() const
+  object_ptr reduced::deref() const
   {
     return val;
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/reduced.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/reduced.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include <jank/runtime/obj/reduced.hpp>
 
 namespace jank::runtime::obj
@@ -15,12 +17,12 @@ namespace jank::runtime::obj
 
   native_persistent_string reduced::to_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     to_string(buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
-  void reduced::to_string(fmt::memory_buffer &buff) const
+  void reduced::to_string(util::string_builder &buff) const
   {
     fmt::format_to(std::back_inserter(buff), "{}@{}", object_type_str(base.type), fmt::ptr(&base));
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/reduced.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/reduced.cpp
@@ -1,5 +1,3 @@
-#include <magic_enum.hpp>
-
 #include <jank/runtime/obj/reduced.hpp>
 
 namespace jank::runtime::obj
@@ -24,10 +22,7 @@ namespace jank::runtime::obj
 
   void reduced::to_string(fmt::memory_buffer &buff) const
   {
-    fmt::format_to(std::back_inserter(buff),
-                   "{}@{}",
-                   magic_enum::enum_name(base.type),
-                   fmt::ptr(&base));
+    fmt::format_to(std::back_inserter(buff), "{}@{}", object_type_str(base.type), fmt::ptr(&base));
   }
 
   native_persistent_string reduced::to_code_string() const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/repeat.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/repeat.cpp
@@ -3,51 +3,50 @@
 #include <jank/runtime/core/math.hpp>
 #include <jank/runtime/core/make_box.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-
-  obj::repeat::static_object(object_ptr const value)
+  repeat::repeat(object_ptr const value)
     : value{ value }
     , count{ make_box(infinite) }
   {
   }
 
-  obj::repeat::static_object(object_ptr const count, object_ptr const value)
+  repeat::repeat(object_ptr const count, object_ptr const value)
     : value{ value }
     , count{ count }
   {
   }
 
-  object_ptr obj::repeat::create(object_ptr const value)
+  object_ptr repeat::create(object_ptr const value)
   {
-    return make_box<obj::repeat>(value);
+    return make_box<repeat>(value);
   }
 
-  object_ptr obj::repeat::create(object_ptr const count, object_ptr const value)
+  object_ptr repeat::create(object_ptr const count, object_ptr const value)
   {
     if(lte(count, make_box(0)))
     {
-      return obj::persistent_list::empty();
+      return persistent_list::empty();
     }
-    return make_box<obj::repeat>(count, value);
+    return make_box<repeat>(count, value);
   }
 
-  obj::repeat_ptr obj::repeat::seq()
+  repeat_ptr repeat::seq()
   {
     return this;
   }
 
-  obj::repeat_ptr obj::repeat::fresh_seq() const
+  repeat_ptr repeat::fresh_seq() const
   {
-    return make_box<obj::repeat>(count, value);
+    return make_box<repeat>(count, value);
   }
 
-  object_ptr obj::repeat::first() const
+  object_ptr repeat::first() const
   {
     return value;
   }
 
-  obj::repeat_ptr obj::repeat::next() const
+  repeat_ptr repeat::next() const
   {
     if(runtime::equal(count, make_box(infinite)))
     {
@@ -57,10 +56,10 @@ namespace jank::runtime
     {
       return nullptr;
     }
-    return make_box<obj::repeat>(make_box(add(count, make_box(-1))), value);
+    return make_box<repeat>(make_box(add(count, make_box(-1))), value);
   }
 
-  obj::repeat_ptr obj::repeat::next_in_place()
+  repeat_ptr repeat::next_in_place()
   {
     if(runtime::equal(count, make_box(infinite)))
     {
@@ -74,12 +73,12 @@ namespace jank::runtime
     return this;
   }
 
-  obj::cons_ptr obj::repeat::conj(object_ptr const head) const
+  cons_ptr repeat::conj(object_ptr const head) const
   {
-    return make_box<obj::cons>(head, this);
+    return make_box<cons>(head, this);
   }
 
-  native_bool obj::repeat::equal(object const &o) const
+  native_bool repeat::equal(object const &o) const
   {
     return visit_seqable(
       [this](auto const typed_o) {
@@ -99,27 +98,27 @@ namespace jank::runtime
       &o);
   }
 
-  void obj::repeat::to_string(fmt::memory_buffer &buff)
+  void repeat::to_string(fmt::memory_buffer &buff)
   {
     runtime::to_string(seq(), buff);
   }
 
-  native_persistent_string obj::repeat::to_string()
+  native_persistent_string repeat::to_string()
   {
     return runtime::to_string(seq());
   }
 
-  native_persistent_string obj::repeat::to_code_string()
+  native_persistent_string repeat::to_code_string()
   {
     return runtime::to_code_string(seq());
   }
 
-  native_hash obj::repeat::to_hash() const
+  native_hash repeat::to_hash() const
   {
     return hash::ordered(&base);
   }
 
-  obj::repeat_ptr obj::repeat::with_meta(object_ptr const m) const
+  repeat_ptr repeat::with_meta(object_ptr const m) const
   {
     auto const meta(behavior::detail::validate_meta(m));
     auto ret(fresh_seq());

--- a/compiler+runtime/src/cpp/jank/runtime/obj/repeat.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/repeat.cpp
@@ -99,7 +99,7 @@ namespace jank::runtime::obj
       &o);
   }
 
-  void repeat::to_string(fmt::memory_buffer &buff)
+  void repeat::to_string(util::string_builder &buff)
   {
     runtime::to_string(seq(), buff);
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/repeat.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/repeat.cpp
@@ -2,6 +2,7 @@
 #include <jank/runtime/visit.hpp>
 #include <jank/runtime/core/math.hpp>
 #include <jank/runtime/core/make_box.hpp>
+#include <jank/runtime/core/seq.hpp>
 
 namespace jank::runtime::obj
 {

--- a/compiler+runtime/src/cpp/jank/runtime/obj/symbol.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/symbol.cpp
@@ -1,5 +1,6 @@
 #include <fmt/compile.h>
 
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/symbol.hpp>
 #include <jank/runtime/core/to_string.hpp>
 #include <jank/runtime/visit.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/obj/symbol.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/symbol.cpp
@@ -4,10 +4,10 @@
 #include <jank/runtime/core/to_string.hpp>
 #include <jank/runtime/visit.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
   template <typename S>
-  static void separate(obj::symbol &sym, S &&s)
+  static void separate(symbol &sym, S &&s)
   {
     auto const found(s.find('/'));
     if(found != native_persistent_string::npos && s.size() > 1)
@@ -21,65 +21,65 @@ namespace jank::runtime
     }
   }
 
-  obj::symbol::static_object(native_persistent_string const &d)
+  symbol::symbol(native_persistent_string const &d)
   {
     separate(*this, d);
   }
 
-  obj::symbol::static_object(native_persistent_string &&d)
+  symbol::symbol(native_persistent_string &&d)
   {
     separate(*this, std::move(d));
   }
 
-  obj::symbol::static_object(native_persistent_string const &ns, native_persistent_string const &n)
+  symbol::symbol(native_persistent_string const &ns, native_persistent_string const &n)
     : ns{ ns }
     , name{ n }
   {
   }
 
-  obj::symbol::static_object(native_persistent_string &&ns, native_persistent_string &&n)
+  symbol::symbol(native_persistent_string &&ns, native_persistent_string &&n)
     : ns{ std::move(ns) }
     , name{ std::move(n) }
   {
   }
 
-  obj::symbol::static_object(native_persistent_string const &ns,
-                             native_persistent_string const &n,
-                             object_ptr const meta)
+  symbol::symbol(native_persistent_string const &ns,
+                 native_persistent_string const &n,
+                 object_ptr const meta)
     : ns{ ns }
     , name{ n }
     , meta{ meta }
   {
   }
 
-  obj::symbol::static_object(object_ptr const ns, object_ptr const n)
+  symbol::symbol(object_ptr const ns, object_ptr const n)
     : ns{ runtime::to_string(ns) }
     , name{ runtime::to_string(n) }
   {
   }
 
-  native_bool obj::symbol::equal(object const &o) const
+  native_bool symbol::equal(object const &o) const
   {
     if(o.type != object_type::symbol)
     {
       return false;
     }
 
-    auto const s(expect_object<obj::symbol>(&o));
+    auto const s(expect_object<symbol>(&o));
     return ns == s->ns && name == s->name;
   }
 
-  native_bool obj::symbol::equal(obj::symbol const &s) const
+  native_bool symbol::equal(symbol const &s) const
   {
     return ns == s.ns && name == s.name;
   }
 
-  native_integer obj::symbol::compare(object const &o) const
+  native_integer symbol::compare(object const &o) const
   {
-    return visit_type<obj::symbol>([this](auto const typed_o) { return compare(*typed_o); }, &o);
+    return visit_type<symbol>([this](auto const typed_o) { return compare(*typed_o); }, &o);
   }
 
-  native_integer obj::symbol::compare(obj::symbol const &s) const
+  native_integer symbol::compare(symbol const &s) const
   {
     if(equal(s))
     {
@@ -119,24 +119,24 @@ namespace jank::runtime
     }
   }
 
-  void obj::symbol::to_string(fmt::memory_buffer &buff) const
+  void symbol::to_string(fmt::memory_buffer &buff) const
   {
     to_string_impl(ns, name, buff);
   }
 
-  native_persistent_string obj::symbol::to_string() const
+  native_persistent_string symbol::to_string() const
   {
     fmt::memory_buffer buff;
     to_string_impl(ns, name, buff);
     return native_persistent_string{ buff.data(), buff.size() };
   }
 
-  native_persistent_string obj::symbol::to_code_string() const
+  native_persistent_string symbol::to_code_string() const
   {
     return to_string();
   }
 
-  native_hash obj::symbol::to_hash() const
+  native_hash symbol::to_hash() const
   {
     if(hash)
     {
@@ -146,41 +146,41 @@ namespace jank::runtime
     return hash = hash::combine(hash::string(name), hash::string(ns));
   }
 
-  obj::symbol_ptr obj::symbol::with_meta(object_ptr const m) const
+  symbol_ptr symbol::with_meta(object_ptr const m) const
   {
     auto const meta(behavior::detail::validate_meta(m));
-    auto ret(make_box<obj::symbol>(ns, name));
+    auto ret(make_box<symbol>(ns, name));
     ret->meta = meta;
     return ret;
   }
 
-  native_persistent_string const &obj::symbol::get_name() const
+  native_persistent_string const &symbol::get_name() const
   {
     return name;
   }
 
-  native_persistent_string const &obj::symbol::get_namespace() const
+  native_persistent_string const &symbol::get_namespace() const
   {
     return ns;
   }
 
-  bool obj::symbol::operator==(obj::symbol const &rhs) const
+  bool symbol::operator==(symbol const &rhs) const
   {
     return ns == rhs.ns && name == rhs.name;
   }
 
-  bool obj::symbol::operator<(obj::symbol const &rhs) const
+  bool symbol::operator<(symbol const &rhs) const
   {
     return to_hash() < rhs.to_hash();
   }
 
-  void obj::symbol::set_ns(native_persistent_string const &s)
+  void symbol::set_ns(native_persistent_string const &s)
   {
     ns = s;
     hash = 0;
   }
 
-  void obj::symbol::set_name(native_persistent_string const &s)
+  void symbol::set_name(native_persistent_string const &s)
   {
     name = s;
     hash = 0;

--- a/compiler+runtime/src/cpp/jank/runtime/obj/symbol.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/symbol.cpp
@@ -1,6 +1,3 @@
-#include <fmt/compile.h>
-
-#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/symbol.hpp>
 #include <jank/runtime/core/to_string.hpp>
 #include <jank/runtime/visit.hpp>
@@ -108,28 +105,28 @@ namespace jank::runtime::obj
 
   static void to_string_impl(native_persistent_string const &ns,
                              native_persistent_string const &name,
-                             fmt::memory_buffer &buff)
+                             util::string_builder &buff)
   {
     if(!ns.empty())
     {
-      format_to(std::back_inserter(buff), FMT_COMPILE("{}/{}"), ns, name);
+      buff(ns)('/')(name);
     }
     else
     {
-      format_to(std::back_inserter(buff), FMT_COMPILE("{}"), name);
+      buff(name);
     }
   }
 
-  void symbol::to_string(fmt::memory_buffer &buff) const
+  void symbol::to_string(util::string_builder &buff) const
   {
     to_string_impl(ns, name, buff);
   }
 
   native_persistent_string symbol::to_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     to_string_impl(ns, name, buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
   native_persistent_string symbol::to_code_string() const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/transient_hash_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/transient_hash_map.cpp
@@ -1,3 +1,4 @@
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/transient_hash_map.hpp>
 #include <jank/runtime/obj/persistent_hash_map.hpp>
 #include <jank/runtime/obj/persistent_vector.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/obj/transient_hash_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/transient_hash_map.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/transient_hash_map.hpp>
 #include <jank/runtime/obj/persistent_hash_map.hpp>
@@ -35,7 +37,7 @@ namespace jank::runtime::obj
     return &base == &o;
   }
 
-  void transient_hash_map::to_string(fmt::memory_buffer &buff) const
+  void transient_hash_map::to_string(util::string_builder &buff) const
   {
     auto inserter(std::back_inserter(buff));
     fmt::format_to(inserter, "{}@{}", object_type_str(base.type), fmt::ptr(&base));
@@ -43,9 +45,9 @@ namespace jank::runtime::obj
 
   native_persistent_string transient_hash_map::to_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     to_string(buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
   native_persistent_string transient_hash_map::to_code_string() const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/transient_hash_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/transient_hash_map.cpp
@@ -8,60 +8,65 @@
 #include <jank/runtime/core/to_string.hpp>
 #include <jank/runtime/core/seq.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::transient_hash_map::static_object(runtime::detail::native_persistent_hash_map &&d)
+  transient_hash_map::transient_hash_map(runtime::detail::native_persistent_hash_map &&d)
     : data{ std::move(d).transient() }
   {
   }
 
-  obj::transient_hash_map::static_object(runtime::detail::native_persistent_hash_map const &d)
+  transient_hash_map::transient_hash_map(runtime::detail::native_persistent_hash_map const &d)
     : data{ d.transient() }
   {
   }
 
-  obj::transient_hash_map::static_object(runtime::detail::native_transient_hash_map &&d)
+  transient_hash_map::transient_hash_map(runtime::detail::native_transient_hash_map &&d)
     : data{ std::move(d) }
   {
   }
 
-  native_bool obj::transient_hash_map::equal(object const &o) const
+  transient_hash_map_ptr transient_hash_map::empty()
+  {
+    return make_box<transient_hash_map>();
+  }
+
+  native_bool transient_hash_map::equal(object const &o) const
   {
     /* Transient equality, in Clojure, is based solely on identity. */
     return &base == &o;
   }
 
-  void obj::transient_hash_map::to_string(fmt::memory_buffer &buff) const
+  void transient_hash_map::to_string(fmt::memory_buffer &buff) const
   {
     auto inserter(std::back_inserter(buff));
     fmt::format_to(inserter, "{}@{}", magic_enum::enum_name(base.type), fmt::ptr(&base));
   }
 
-  native_persistent_string obj::transient_hash_map::to_string() const
+  native_persistent_string transient_hash_map::to_string() const
   {
     fmt::memory_buffer buff;
     to_string(buff);
     return native_persistent_string{ buff.data(), buff.size() };
   }
 
-  native_persistent_string obj::transient_hash_map::to_code_string() const
+  native_persistent_string transient_hash_map::to_code_string() const
   {
     return to_string();
   }
 
-  native_hash obj::transient_hash_map::to_hash() const
+  native_hash transient_hash_map::to_hash() const
   {
     /* Hash is also based only on identity. Clojure uses default hashCode, which does the same. */
     return static_cast<native_hash>(reinterpret_cast<uintptr_t>(this));
   }
 
-  size_t obj::transient_hash_map::count() const
+  size_t transient_hash_map::count() const
   {
     assert_active();
     return data.size();
   }
 
-  object_ptr obj::transient_hash_map::get(object_ptr const key) const
+  object_ptr transient_hash_map::get(object_ptr const key) const
   {
     assert_active();
     auto const res(data.find(key));
@@ -69,10 +74,10 @@ namespace jank::runtime
     {
       return *res;
     }
-    return obj::nil::nil_const();
+    return nil::nil_const();
   }
 
-  object_ptr obj::transient_hash_map::get(object_ptr const key, object_ptr const fallback) const
+  object_ptr transient_hash_map::get(object_ptr const key, object_ptr const fallback) const
   {
     assert_active();
     auto const res(data.find(key));
@@ -83,46 +88,46 @@ namespace jank::runtime
     return fallback;
   }
 
-  object_ptr obj::transient_hash_map::get_entry(object_ptr const key) const
+  object_ptr transient_hash_map::get_entry(object_ptr const key) const
   {
     assert_active();
     auto const res(data.find(key));
     if(res)
     {
-      return make_box<obj::persistent_vector>(std::in_place, key, *res);
+      return make_box<persistent_vector>(std::in_place, key, *res);
     }
-    return obj::nil::nil_const();
+    return nil::nil_const();
   }
 
-  native_bool obj::transient_hash_map::contains(object_ptr const key) const
+  native_bool transient_hash_map::contains(object_ptr const key) const
   {
     assert_active();
     return data.find(key);
   }
 
-  obj::transient_hash_map_ptr
-  obj::transient_hash_map::assoc_in_place(object_ptr const key, object_ptr const val)
+  transient_hash_map_ptr
+  transient_hash_map::assoc_in_place(object_ptr const key, object_ptr const val)
   {
     assert_active();
     data.set(key, val);
     return this;
   }
 
-  obj::transient_hash_map_ptr obj::transient_hash_map::dissoc_in_place(object_ptr const key)
+  transient_hash_map_ptr transient_hash_map::dissoc_in_place(object_ptr const key)
   {
     assert_active();
     data.erase(key);
     return this;
   }
 
-  obj::transient_hash_map_ptr obj::transient_hash_map::conj_in_place(object_ptr const head)
+  transient_hash_map_ptr transient_hash_map::conj_in_place(object_ptr const head)
   {
     assert_active();
 
     if(head->type == object_type::persistent_array_map
        || head->type == object_type::persistent_hash_map)
     {
-      return expect_object<obj::transient_hash_map>(runtime::merge(this, head));
+      return expect_object<transient_hash_map>(runtime::merge(this, head));
     }
 
     if(head->type != object_type::persistent_vector)
@@ -130,7 +135,7 @@ namespace jank::runtime
       throw std::runtime_error{ fmt::format("invalid map entry: {}", runtime::to_string(head)) };
     }
 
-    auto const vec(expect_object<obj::persistent_vector>(head));
+    auto const vec(expect_object<persistent_vector>(head));
     if(vec->count() != 2)
     {
       throw std::runtime_error{ fmt::format("invalid map entry: {}", runtime::to_string(head)) };
@@ -140,24 +145,24 @@ namespace jank::runtime
     return this;
   }
 
-  native_box<obj::transient_hash_map::persistent_type> obj::transient_hash_map::to_persistent()
+  transient_hash_map::persistent_type_ptr transient_hash_map::to_persistent()
   {
     assert_active();
     active = false;
-    return make_box<obj::persistent_hash_map>(std::move(data).persistent());
+    return make_box<persistent_hash_map>(std::move(data).persistent());
   }
 
-  object_ptr obj::transient_hash_map::call(object_ptr const o) const
+  object_ptr transient_hash_map::call(object_ptr const o) const
   {
     return get(o);
   }
 
-  object_ptr obj::transient_hash_map::call(object_ptr const o, object_ptr const fallback) const
+  object_ptr transient_hash_map::call(object_ptr const o, object_ptr const fallback) const
   {
     return get(o, fallback);
   }
 
-  void obj::transient_hash_map::assert_active() const
+  void transient_hash_map::assert_active() const
   {
     if(!active)
     {

--- a/compiler+runtime/src/cpp/jank/runtime/obj/transient_hash_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/transient_hash_map.cpp
@@ -1,5 +1,3 @@
-#include <magic_enum.hpp>
-
 #include <jank/runtime/obj/transient_hash_map.hpp>
 #include <jank/runtime/obj/persistent_hash_map.hpp>
 #include <jank/runtime/obj/persistent_vector.hpp>
@@ -39,7 +37,7 @@ namespace jank::runtime::obj
   void transient_hash_map::to_string(fmt::memory_buffer &buff) const
   {
     auto inserter(std::back_inserter(buff));
-    fmt::format_to(inserter, "{}@{}", magic_enum::enum_name(base.type), fmt::ptr(&base));
+    fmt::format_to(inserter, "{}@{}", object_type_str(base.type), fmt::ptr(&base));
   }
 
   native_persistent_string transient_hash_map::to_string() const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/transient_hash_set.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/transient_hash_set.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include <jank/runtime/obj/transient_hash_set.hpp>
 #include <jank/runtime/obj/persistent_hash_set.hpp>
 #include <jank/runtime/obj/persistent_vector.hpp>
@@ -33,12 +35,12 @@ namespace jank::runtime::obj
 
   native_persistent_string transient_hash_set::to_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     to_string(buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
-  void transient_hash_set::to_string(fmt::memory_buffer &buff) const
+  void transient_hash_set::to_string(util::string_builder &buff) const
   {
     auto inserter(std::back_inserter(buff));
     fmt::format_to(inserter, "{}@{}", object_type_str(base.type), fmt::ptr(&base));

--- a/compiler+runtime/src/cpp/jank/runtime/obj/transient_hash_set.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/transient_hash_set.cpp
@@ -5,85 +5,90 @@
 #include <jank/runtime/obj/persistent_vector.hpp>
 #include <jank/runtime/obj/nil.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::transient_hash_set::static_object(runtime::detail::native_persistent_hash_set &&d)
+  transient_hash_set::transient_hash_set(runtime::detail::native_persistent_hash_set &&d)
     : data{ std::move(d).transient() }
   {
   }
 
-  obj::transient_hash_set::static_object(runtime::detail::native_persistent_hash_set const &d)
+  transient_hash_set::transient_hash_set(runtime::detail::native_persistent_hash_set const &d)
     : data{ d.transient() }
   {
   }
 
-  obj::transient_hash_set::static_object(runtime::detail::native_transient_hash_set &&d)
+  transient_hash_set::transient_hash_set(runtime::detail::native_transient_hash_set &&d)
     : data{ std::move(d) }
   {
   }
 
-  native_bool obj::transient_hash_set::equal(object const &o) const
+  transient_hash_set_ptr transient_hash_set::empty()
+  {
+    return make_box<transient_hash_set>();
+  }
+
+  native_bool transient_hash_set::equal(object const &o) const
   {
     /* Transient equality, in Clojure, is based solely on identity. */
     return &base == &o;
   }
 
-  native_persistent_string obj::transient_hash_set::to_string() const
+  native_persistent_string transient_hash_set::to_string() const
   {
     fmt::memory_buffer buff;
     to_string(buff);
     return native_persistent_string{ buff.data(), buff.size() };
   }
 
-  void obj::transient_hash_set::to_string(fmt::memory_buffer &buff) const
+  void transient_hash_set::to_string(fmt::memory_buffer &buff) const
   {
     auto inserter(std::back_inserter(buff));
     fmt::format_to(inserter, "{}@{}", magic_enum::enum_name(base.type), fmt::ptr(&base));
   }
 
-  native_persistent_string obj::transient_hash_set::to_code_string() const
+  native_persistent_string transient_hash_set::to_code_string() const
   {
     return to_string();
   }
 
-  native_hash obj::transient_hash_set::to_hash() const
+  native_hash transient_hash_set::to_hash() const
   {
     /* Hash is also based only on identity. Clojure uses default hashCode, which does the same. */
     return static_cast<native_hash>(reinterpret_cast<uintptr_t>(this));
   }
 
-  size_t obj::transient_hash_set::count() const
+  size_t transient_hash_set::count() const
   {
     assert_active();
     return data.size();
   }
 
-  obj::transient_hash_set_ptr obj::transient_hash_set::conj_in_place(object_ptr const elem)
+  transient_hash_set_ptr transient_hash_set::conj_in_place(object_ptr const elem)
   {
     assert_active();
     data.insert(elem);
     return this;
   }
 
-  native_box<obj::transient_hash_set::persistent_type> obj::transient_hash_set::to_persistent()
+  transient_hash_set::persistent_type_ptr transient_hash_set::to_persistent()
   {
     assert_active();
     active = false;
-    return make_box<obj::persistent_hash_set>(data.persistent());
+    return make_box<persistent_hash_set>(data.persistent());
   }
 
-  object_ptr obj::transient_hash_set::call(object_ptr const elem) const
+  object_ptr transient_hash_set::call(object_ptr const elem) const
   {
     assert_active();
     auto const found(data.find(elem));
     if(!found)
     {
-      return obj::nil::nil_const();
+      return nil::nil_const();
     }
     return *found;
   }
 
-  object_ptr obj::transient_hash_set::call(object_ptr const elem, object_ptr const fallback) const
+  object_ptr transient_hash_set::call(object_ptr const elem, object_ptr const fallback) const
   {
     assert_active();
     auto const found(data.find(elem));
@@ -94,42 +99,42 @@ namespace jank::runtime
     return *found;
   }
 
-  object_ptr obj::transient_hash_set::get(object_ptr const elem) const
+  object_ptr transient_hash_set::get(object_ptr const elem) const
   {
     return call(elem);
   }
 
-  object_ptr obj::transient_hash_set::get(object_ptr const elem, object_ptr const fallback) const
+  object_ptr transient_hash_set::get(object_ptr const elem, object_ptr const fallback) const
   {
     return call(elem, fallback);
   }
 
-  object_ptr obj::transient_hash_set::get_entry(object_ptr const elem) const
+  object_ptr transient_hash_set::get_entry(object_ptr const elem) const
   {
     auto const found = call(elem);
-    auto const nil(obj::nil::nil_const());
+    auto const nil(nil::nil_const());
     if(found == nil)
     {
       return nil;
     }
 
-    return make_box<obj::persistent_vector>(std::in_place, found, found);
+    return make_box<persistent_vector>(std::in_place, found, found);
   }
 
-  native_bool obj::transient_hash_set::contains(object_ptr const elem) const
+  native_bool transient_hash_set::contains(object_ptr const elem) const
   {
     assert_active();
     return data.find(elem);
   }
 
-  obj::transient_hash_set_ptr obj::transient_hash_set::disjoin_in_place(object_ptr const elem)
+  transient_hash_set_ptr transient_hash_set::disjoin_in_place(object_ptr const elem)
   {
     assert_active();
     data.erase(elem);
     return this;
   }
 
-  void obj::transient_hash_set::assert_active() const
+  void transient_hash_set::assert_active() const
   {
     if(!active)
     {

--- a/compiler+runtime/src/cpp/jank/runtime/obj/transient_hash_set.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/transient_hash_set.cpp
@@ -1,5 +1,3 @@
-#include <magic_enum.hpp>
-
 #include <jank/runtime/obj/transient_hash_set.hpp>
 #include <jank/runtime/obj/persistent_hash_set.hpp>
 #include <jank/runtime/obj/persistent_vector.hpp>
@@ -43,7 +41,7 @@ namespace jank::runtime::obj
   void transient_hash_set::to_string(fmt::memory_buffer &buff) const
   {
     auto inserter(std::back_inserter(buff));
-    fmt::format_to(inserter, "{}@{}", magic_enum::enum_name(base.type), fmt::ptr(&base));
+    fmt::format_to(inserter, "{}@{}", object_type_str(base.type), fmt::ptr(&base));
   }
 
   native_persistent_string transient_hash_set::to_code_string() const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/transient_sorted_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/transient_sorted_map.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/transient_sorted_map.hpp>
 #include <jank/runtime/obj/persistent_sorted_map.hpp>
@@ -35,7 +37,7 @@ namespace jank::runtime::obj
     return &base == &o;
   }
 
-  void transient_sorted_map::to_string(fmt::memory_buffer &buff) const
+  void transient_sorted_map::to_string(util::string_builder &buff) const
   {
     auto inserter(std::back_inserter(buff));
     fmt::format_to(inserter, "{}@{}", object_type_str(base.type), fmt::ptr(&base));
@@ -43,9 +45,9 @@ namespace jank::runtime::obj
 
   native_persistent_string transient_sorted_map::to_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     to_string(buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
   native_persistent_string transient_sorted_map::to_code_string() const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/transient_sorted_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/transient_sorted_map.cpp
@@ -8,60 +8,65 @@
 #include <jank/runtime/core/to_string.hpp>
 #include <jank/runtime/rtti.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::transient_sorted_map::static_object(runtime::detail::native_persistent_sorted_map &&d)
+  transient_sorted_map::transient_sorted_map(runtime::detail::native_persistent_sorted_map &&d)
     : data{ std::move(d).transient() }
   {
   }
 
-  obj::transient_sorted_map::static_object(runtime::detail::native_persistent_sorted_map const &d)
+  transient_sorted_map::transient_sorted_map(runtime::detail::native_persistent_sorted_map const &d)
     : data{ d.transient() }
   {
   }
 
-  obj::transient_sorted_map::static_object(runtime::detail::native_transient_sorted_map &&d)
+  transient_sorted_map::transient_sorted_map(runtime::detail::native_transient_sorted_map &&d)
     : data{ std::move(d) }
   {
   }
 
-  native_bool obj::transient_sorted_map::equal(object const &o) const
+  transient_sorted_map_ptr transient_sorted_map::empty()
+  {
+    return make_box<transient_sorted_map>();
+  }
+
+  native_bool transient_sorted_map::equal(object const &o) const
   {
     /* Transient equality, in Clojure, is based solely on identity. */
     return &base == &o;
   }
 
-  void obj::transient_sorted_map::to_string(fmt::memory_buffer &buff) const
+  void transient_sorted_map::to_string(fmt::memory_buffer &buff) const
   {
     auto inserter(std::back_inserter(buff));
     fmt::format_to(inserter, "{}@{}", magic_enum::enum_name(base.type), fmt::ptr(&base));
   }
 
-  native_persistent_string obj::transient_sorted_map::to_string() const
+  native_persistent_string transient_sorted_map::to_string() const
   {
     fmt::memory_buffer buff;
     to_string(buff);
     return native_persistent_string{ buff.data(), buff.size() };
   }
 
-  native_persistent_string obj::transient_sorted_map::to_code_string() const
+  native_persistent_string transient_sorted_map::to_code_string() const
   {
     return to_string();
   }
 
-  native_hash obj::transient_sorted_map::to_hash() const
+  native_hash transient_sorted_map::to_hash() const
   {
     /* Hash is also based only on identity. Clojure uses default hashCode, which does the same. */
     return static_cast<native_hash>(reinterpret_cast<uintptr_t>(this));
   }
 
-  size_t obj::transient_sorted_map::count() const
+  size_t transient_sorted_map::count() const
   {
     assert_active();
     return data.size();
   }
 
-  object_ptr obj::transient_sorted_map::get(object_ptr const key) const
+  object_ptr transient_sorted_map::get(object_ptr const key) const
   {
     assert_active();
     auto const res(data.find(key));
@@ -69,10 +74,10 @@ namespace jank::runtime
     {
       return res->second;
     }
-    return obj::nil::nil_const();
+    return nil::nil_const();
   }
 
-  object_ptr obj::transient_sorted_map::get(object_ptr const key, object_ptr const fallback) const
+  object_ptr transient_sorted_map::get(object_ptr const key, object_ptr const fallback) const
   {
     assert_active();
     auto const res(data.find(key));
@@ -83,46 +88,46 @@ namespace jank::runtime
     return fallback;
   }
 
-  object_ptr obj::transient_sorted_map::get_entry(object_ptr const key) const
+  object_ptr transient_sorted_map::get_entry(object_ptr const key) const
   {
     assert_active();
     auto const res(data.find(key));
     if(res != data.end())
     {
-      return make_box<obj::persistent_vector>(std::in_place, key, res->second);
+      return make_box<persistent_vector>(std::in_place, key, res->second);
     }
-    return obj::nil::nil_const();
+    return nil::nil_const();
   }
 
-  native_bool obj::transient_sorted_map::contains(object_ptr const key) const
+  native_bool transient_sorted_map::contains(object_ptr const key) const
   {
     assert_active();
     return data.find(key) != data.end();
   }
 
-  obj::transient_sorted_map_ptr
-  obj::transient_sorted_map::assoc_in_place(object_ptr const key, object_ptr const val)
+  transient_sorted_map_ptr
+  transient_sorted_map::assoc_in_place(object_ptr const key, object_ptr const val)
   {
     assert_active();
     data.insert_or_assign(key, val);
     return this;
   }
 
-  obj::transient_sorted_map_ptr obj::transient_sorted_map::dissoc_in_place(object_ptr const key)
+  transient_sorted_map_ptr transient_sorted_map::dissoc_in_place(object_ptr const key)
   {
     assert_active();
     data.erase_key(key);
     return this;
   }
 
-  obj::transient_sorted_map_ptr obj::transient_sorted_map::conj_in_place(object_ptr const head)
+  transient_sorted_map_ptr transient_sorted_map::conj_in_place(object_ptr const head)
   {
     assert_active();
 
     if(head->type == object_type::persistent_array_map
        || head->type == object_type::persistent_sorted_map)
     {
-      return expect_object<obj::transient_sorted_map>(runtime::merge(this, head));
+      return expect_object<transient_sorted_map>(runtime::merge(this, head));
     }
 
     if(head->type != object_type::persistent_vector)
@@ -130,7 +135,7 @@ namespace jank::runtime
       throw std::runtime_error{ fmt::format("invalid map entry: {}", runtime::to_string(head)) };
     }
 
-    auto const vec(expect_object<obj::persistent_vector>(head));
+    auto const vec(expect_object<persistent_vector>(head));
     if(vec->count() != 2)
     {
       throw std::runtime_error{ fmt::format("invalid map entry: {}", runtime::to_string(head)) };
@@ -140,24 +145,24 @@ namespace jank::runtime
     return this;
   }
 
-  native_box<obj::transient_sorted_map::persistent_type> obj::transient_sorted_map::to_persistent()
+  transient_sorted_map::persistent_type_ptr transient_sorted_map::to_persistent()
   {
     assert_active();
     active = false;
-    return make_box<obj::persistent_sorted_map>(std::move(data).persistent());
+    return make_box<persistent_sorted_map>(std::move(data).persistent());
   }
 
-  object_ptr obj::transient_sorted_map::call(object_ptr const o) const
+  object_ptr transient_sorted_map::call(object_ptr const o) const
   {
     return get(o);
   }
 
-  object_ptr obj::transient_sorted_map::call(object_ptr const o, object_ptr const fallback) const
+  object_ptr transient_sorted_map::call(object_ptr const o, object_ptr const fallback) const
   {
     return get(o, fallback);
   }
 
-  void obj::transient_sorted_map::assert_active() const
+  void transient_sorted_map::assert_active() const
   {
     if(!active)
     {

--- a/compiler+runtime/src/cpp/jank/runtime/obj/transient_sorted_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/transient_sorted_map.cpp
@@ -1,5 +1,3 @@
-#include <magic_enum.hpp>
-
 #include <jank/runtime/obj/transient_sorted_map.hpp>
 #include <jank/runtime/obj/persistent_sorted_map.hpp>
 #include <jank/runtime/obj/persistent_vector.hpp>
@@ -39,7 +37,7 @@ namespace jank::runtime::obj
   void transient_sorted_map::to_string(fmt::memory_buffer &buff) const
   {
     auto inserter(std::back_inserter(buff));
-    fmt::format_to(inserter, "{}@{}", magic_enum::enum_name(base.type), fmt::ptr(&base));
+    fmt::format_to(inserter, "{}@{}", object_type_str(base.type), fmt::ptr(&base));
   }
 
   native_persistent_string transient_sorted_map::to_string() const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/transient_sorted_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/transient_sorted_map.cpp
@@ -1,3 +1,4 @@
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/transient_sorted_map.hpp>
 #include <jank/runtime/obj/persistent_sorted_map.hpp>
 #include <jank/runtime/obj/persistent_vector.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/obj/transient_sorted_set.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/transient_sorted_set.cpp
@@ -1,5 +1,3 @@
-#include <magic_enum.hpp>
-
 #include <jank/runtime/obj/transient_sorted_set.hpp>
 #include <jank/runtime/obj/persistent_sorted_set.hpp>
 #include <jank/runtime/obj/persistent_vector.hpp>
@@ -43,7 +41,7 @@ namespace jank::runtime::obj
   void transient_sorted_set::to_string(fmt::memory_buffer &buff) const
   {
     auto inserter(std::back_inserter(buff));
-    fmt::format_to(inserter, "{}@{}", magic_enum::enum_name(base.type), fmt::ptr(&base));
+    fmt::format_to(inserter, "{}@{}", object_type_str(base.type), fmt::ptr(&base));
   }
 
   native_persistent_string transient_sorted_set::to_code_string() const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/transient_sorted_set.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/transient_sorted_set.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include <jank/runtime/obj/transient_sorted_set.hpp>
 #include <jank/runtime/obj/persistent_sorted_set.hpp>
 #include <jank/runtime/obj/persistent_vector.hpp>
@@ -33,12 +35,12 @@ namespace jank::runtime::obj
 
   native_persistent_string transient_sorted_set::to_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     to_string(buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
-  void transient_sorted_set::to_string(fmt::memory_buffer &buff) const
+  void transient_sorted_set::to_string(util::string_builder &buff) const
   {
     auto inserter(std::back_inserter(buff));
     fmt::format_to(inserter, "{}@{}", object_type_str(base.type), fmt::ptr(&base));

--- a/compiler+runtime/src/cpp/jank/runtime/obj/transient_sorted_set.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/transient_sorted_set.cpp
@@ -5,74 +5,79 @@
 #include <jank/runtime/obj/persistent_vector.hpp>
 #include <jank/runtime/obj/nil.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::transient_sorted_set::static_object(runtime::detail::native_persistent_sorted_set &&d)
+  transient_sorted_set::transient_sorted_set(runtime::detail::native_persistent_sorted_set &&d)
     : data{ std::move(d).transient() }
   {
   }
 
-  obj::transient_sorted_set::static_object(runtime::detail::native_persistent_sorted_set const &d)
+  transient_sorted_set::transient_sorted_set(runtime::detail::native_persistent_sorted_set const &d)
     : data{ d.transient() }
   {
   }
 
-  obj::transient_sorted_set::static_object(runtime::detail::native_transient_sorted_set &&d)
+  transient_sorted_set::transient_sorted_set(runtime::detail::native_transient_sorted_set &&d)
     : data{ std::move(d) }
   {
   }
 
-  native_bool obj::transient_sorted_set::equal(object const &o) const
+  transient_sorted_set_ptr transient_sorted_set::empty()
+  {
+    return make_box<transient_sorted_set>();
+  }
+
+  native_bool transient_sorted_set::equal(object const &o) const
   {
     /* Transient equality, in Clojure, is based solely on identity. */
     return &base == &o;
   }
 
-  native_persistent_string obj::transient_sorted_set::to_string() const
+  native_persistent_string transient_sorted_set::to_string() const
   {
     fmt::memory_buffer buff;
     to_string(buff);
     return native_persistent_string{ buff.data(), buff.size() };
   }
 
-  void obj::transient_sorted_set::to_string(fmt::memory_buffer &buff) const
+  void transient_sorted_set::to_string(fmt::memory_buffer &buff) const
   {
     auto inserter(std::back_inserter(buff));
     fmt::format_to(inserter, "{}@{}", magic_enum::enum_name(base.type), fmt::ptr(&base));
   }
 
-  native_persistent_string obj::transient_sorted_set::to_code_string() const
+  native_persistent_string transient_sorted_set::to_code_string() const
   {
     return to_string();
   }
 
-  native_hash obj::transient_sorted_set::to_hash() const
+  native_hash transient_sorted_set::to_hash() const
   {
     /* Hash is also based only on identity. Clojure uses default hashCode, which does the same. */
     return static_cast<native_hash>(reinterpret_cast<uintptr_t>(this));
   }
 
-  size_t obj::transient_sorted_set::count() const
+  size_t transient_sorted_set::count() const
   {
     assert_active();
     return data.size();
   }
 
-  obj::transient_sorted_set_ptr obj::transient_sorted_set::conj_in_place(object_ptr const elem)
+  transient_sorted_set_ptr transient_sorted_set::conj_in_place(object_ptr const elem)
   {
     assert_active();
     data.insert_v(elem);
     return this;
   }
 
-  native_box<obj::transient_sorted_set::persistent_type> obj::transient_sorted_set::to_persistent()
+  transient_sorted_set::persistent_type_ptr transient_sorted_set::to_persistent()
   {
     assert_active();
     active = false;
-    return make_box<obj::persistent_sorted_set>(data.persistent());
+    return make_box<persistent_sorted_set>(data.persistent());
   }
 
-  object_ptr obj::transient_sorted_set::call(object_ptr const elem)
+  object_ptr transient_sorted_set::call(object_ptr const elem)
   {
     assert_active();
     auto const found(data.find(elem));
@@ -80,10 +85,10 @@ namespace jank::runtime
     {
       return found.get();
     }
-    return obj::nil::nil_const();
+    return nil::nil_const();
   }
 
-  object_ptr obj::transient_sorted_set::call(object_ptr const elem, object_ptr const fallback)
+  object_ptr transient_sorted_set::call(object_ptr const elem, object_ptr const fallback)
   {
     assert_active();
     auto const found(data.find(elem));
@@ -94,42 +99,42 @@ namespace jank::runtime
     return fallback;
   }
 
-  object_ptr obj::transient_sorted_set::get(object_ptr const elem)
+  object_ptr transient_sorted_set::get(object_ptr const elem)
   {
     return call(elem);
   }
 
-  object_ptr obj::transient_sorted_set::get(object_ptr const elem, object_ptr const fallback)
+  object_ptr transient_sorted_set::get(object_ptr const elem, object_ptr const fallback)
   {
     return call(elem, fallback);
   }
 
-  object_ptr obj::transient_sorted_set::get_entry(object_ptr const elem)
+  object_ptr transient_sorted_set::get_entry(object_ptr const elem)
   {
     auto const found = call(elem);
-    auto const nil(obj::nil::nil_const());
+    auto const nil(nil::nil_const());
     if(found == nil)
     {
       return nil;
     }
 
-    return make_box<obj::persistent_vector>(std::in_place, found, found);
+    return make_box<persistent_vector>(std::in_place, found, found);
   }
 
-  native_bool obj::transient_sorted_set::contains(object_ptr const elem) const
+  native_bool transient_sorted_set::contains(object_ptr const elem) const
   {
     assert_active();
     return data.find(elem) != data.end();
   }
 
-  obj::transient_sorted_set_ptr obj::transient_sorted_set::disjoin_in_place(object_ptr const elem)
+  transient_sorted_set_ptr transient_sorted_set::disjoin_in_place(object_ptr const elem)
   {
     assert_active();
     data.erase_key(elem);
     return this;
   }
 
-  void obj::transient_sorted_set::assert_active() const
+  void transient_sorted_set::assert_active() const
   {
     if(!active)
     {

--- a/compiler+runtime/src/cpp/jank/runtime/obj/transient_vector.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/transient_vector.cpp
@@ -1,3 +1,4 @@
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/transient_vector.hpp>
 #include <jank/runtime/obj/persistent_vector.hpp>
 #include <jank/runtime/obj/nil.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/obj/transient_vector.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/transient_vector.cpp
@@ -1,5 +1,3 @@
-#include <magic_enum.hpp>
-
 #include <jank/runtime/obj/transient_vector.hpp>
 #include <jank/runtime/obj/persistent_vector.hpp>
 #include <jank/runtime/obj/nil.hpp>
@@ -45,7 +43,7 @@ namespace jank::runtime::obj
   void transient_vector::to_string(fmt::memory_buffer &buff) const
   {
     auto inserter(std::back_inserter(buff));
-    fmt::format_to(inserter, "{}@{}", magic_enum::enum_name(base.type), fmt::ptr(&base));
+    fmt::format_to(inserter, "{}@{}", object_type_str(base.type), fmt::ptr(&base));
   }
 
   native_persistent_string transient_vector::to_code_string() const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/transient_vector.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/transient_vector.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/obj/transient_vector.hpp>
 #include <jank/runtime/obj/persistent_vector.hpp>
@@ -36,12 +38,12 @@ namespace jank::runtime::obj
 
   native_persistent_string transient_vector::to_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     to_string(buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
-  void transient_vector::to_string(fmt::memory_buffer &buff) const
+  void transient_vector::to_string(util::string_builder &buff) const
   {
     auto inserter(std::back_inserter(buff));
     fmt::format_to(inserter, "{}@{}", object_type_str(base.type), fmt::ptr(&base));

--- a/compiler+runtime/src/cpp/jank/runtime/obj/volatile.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/volatile.cpp
@@ -2,27 +2,27 @@
 
 #include <jank/runtime/obj/volatile.hpp>
 
-namespace jank::runtime
+namespace jank::runtime::obj
 {
-  obj::volatile_::static_object(object_ptr const o)
+  volatile_::volatile_(object_ptr const o)
     : val{ o }
   {
     assert(val);
   }
 
-  native_bool obj::volatile_::equal(object const &o) const
+  native_bool volatile_::equal(object const &o) const
   {
     return &o == &base;
   }
 
-  native_persistent_string obj::volatile_::to_string() const
+  native_persistent_string volatile_::to_string() const
   {
     fmt::memory_buffer buff;
     to_string(buff);
     return native_persistent_string{ buff.data(), buff.size() };
   }
 
-  void obj::volatile_::to_string(fmt::memory_buffer &buff) const
+  void volatile_::to_string(fmt::memory_buffer &buff) const
   {
     fmt::format_to(std::back_inserter(buff),
                    "{}@{}",
@@ -30,22 +30,22 @@ namespace jank::runtime
                    fmt::ptr(&base));
   }
 
-  native_persistent_string obj::volatile_::to_code_string() const
+  native_persistent_string volatile_::to_code_string() const
   {
     return to_string();
   }
 
-  native_hash obj::volatile_::to_hash() const
+  native_hash volatile_::to_hash() const
   {
     return static_cast<native_hash>(reinterpret_cast<uintptr_t>(this));
   }
 
-  object_ptr obj::volatile_::deref() const
+  object_ptr volatile_::deref() const
   {
     return val;
   }
 
-  object_ptr obj::volatile_::reset(object_ptr const o)
+  object_ptr volatile_::reset(object_ptr const o)
   {
     val = o;
     assert(val);

--- a/compiler+runtime/src/cpp/jank/runtime/obj/volatile.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/volatile.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include <jank/runtime/obj/volatile.hpp>
 
 namespace jank::runtime::obj
@@ -15,12 +17,12 @@ namespace jank::runtime::obj
 
   native_persistent_string volatile_::to_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     to_string(buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
-  void volatile_::to_string(fmt::memory_buffer &buff) const
+  void volatile_::to_string(util::string_builder &buff) const
   {
     fmt::format_to(std::back_inserter(buff), "{}@{}", object_type_str(base.type), fmt::ptr(&base));
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/volatile.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/volatile.cpp
@@ -1,5 +1,3 @@
-#include <magic_enum.hpp>
-
 #include <jank/runtime/obj/volatile.hpp>
 
 namespace jank::runtime::obj
@@ -24,10 +22,7 @@ namespace jank::runtime::obj
 
   void volatile_::to_string(fmt::memory_buffer &buff) const
   {
-    fmt::format_to(std::back_inserter(buff),
-                   "{}@{}",
-                   magic_enum::enum_name(base.type),
-                   fmt::ptr(&base));
+    fmt::format_to(std::back_inserter(buff), "{}@{}", object_type_str(base.type), fmt::ptr(&base));
   }
 
   native_persistent_string volatile_::to_code_string() const

--- a/compiler+runtime/src/cpp/jank/runtime/perf.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/perf.cpp
@@ -1,5 +1,7 @@
 #include <nanobench.h>
 
+#include <fmt/format.h>
+
 #include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/perf.hpp>
 #include <jank/runtime/visit.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/perf.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/perf.cpp
@@ -1,5 +1,6 @@
 #include <nanobench.h>
 
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/perf.hpp>
 #include <jank/runtime/visit.hpp>
 #include <jank/runtime/context.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/var.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/var.cpp
@@ -9,6 +9,7 @@
 #include <jank/runtime/core/to_string.hpp>
 #include <jank/runtime/obj/persistent_hash_map.hpp>
 #include <jank/profile/time.hpp>
+#include <jank/native_persistent_string/fmt.hpp>
 
 namespace jank::runtime
 {

--- a/compiler+runtime/src/cpp/jank/runtime/var.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/var.cpp
@@ -10,25 +10,25 @@
 
 namespace jank::runtime
 {
-  var::static_object(ns_ptr const &n, obj::symbol_ptr const &name)
+  var::var(ns_ptr const &n, obj::symbol_ptr const &name)
     : n{ n }
     , name{ name }
     , root{ make_box<var_unbound_root>(this) }
   {
   }
 
-  var::static_object(ns_ptr const &n, obj::symbol_ptr const &name, object_ptr const root)
+  var::var(ns_ptr const &n, obj::symbol_ptr const &name, object_ptr const root)
     : n{ n }
     , name{ name }
     , root{ root }
   {
   }
 
-  var::static_object(ns_ptr const &n,
-                     obj::symbol_ptr const &name,
-                     object_ptr const root,
-                     native_bool const dynamic,
-                     native_bool const thread_bound)
+  var::var(ns_ptr const &n,
+           obj::symbol_ptr const &name,
+           object_ptr const root,
+           native_bool const dynamic,
+           native_bool const thread_bound)
     : n{ n }
     , name{ name }
     , root{ root }
@@ -182,7 +182,7 @@ namespace jank::runtime
     return make_box<var>(n, name, get_root(), dynamic.load(), thread_bound.load());
   }
 
-  var_thread_binding::static_object(object_ptr const value, std::thread::id const id)
+  var_thread_binding::var_thread_binding(object_ptr const value, std::thread::id const id)
     : value{ value }
     , thread_id{ id }
   {
@@ -213,7 +213,7 @@ namespace jank::runtime
     return hash::visit(value);
   }
 
-  var_unbound_root::static_object(var_ptr const var)
+  var_unbound_root::var_unbound_root(var_ptr const var)
     : var{ var }
   {
   }

--- a/compiler+runtime/src/cpp/jank/runtime/var.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/var.cpp
@@ -55,21 +55,22 @@ namespace jank::runtime
     return n == v.n && name == v.name;
   }
 
-  static void to_string_impl(ns_ptr const n, obj::symbol_ptr const &name, fmt::memory_buffer &buff)
+  static void
+  to_string_impl(ns_ptr const n, obj::symbol_ptr const &name, util::string_builder &buff)
   {
-    format_to(std::back_inserter(buff), FMT_COMPILE("#'{}/{}"), n->name->name, name->name);
+    buff("#'")(n->name->name)('/')(name->name);
   }
 
-  void var::to_string(fmt::memory_buffer &buff) const
+  void var::to_string(util::string_builder &buff) const
   {
     to_string_impl(n, name, buff);
   }
   native_persistent_string var::to_string() const
   /* TODO: Maybe cache this. */
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     to_string_impl(n, name, buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
   native_persistent_string var::to_code_string() const
@@ -206,7 +207,7 @@ namespace jank::runtime
     return var_thread_binding::to_string();
   }
 
-  void var_thread_binding::to_string(fmt::memory_buffer &buff) const
+  void var_thread_binding::to_string(util::string_builder &buff) const
   {
     runtime::to_string(value, buff);
   }
@@ -228,12 +229,12 @@ namespace jank::runtime
 
   native_persistent_string var_unbound_root::to_string() const
   {
-    fmt::memory_buffer buff;
+    util::string_builder buff;
     to_string(buff);
-    return native_persistent_string{ buff.data(), buff.size() };
+    return buff.release();
   }
 
-  void var_unbound_root::to_string(fmt::memory_buffer &buff) const
+  void var_unbound_root::to_string(util::string_builder &buff) const
   {
     fmt::format_to(std::back_inserter(buff),
                    "unbound@{} for var {}",

--- a/compiler+runtime/src/cpp/jank/runtime/var.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/var.cpp
@@ -6,6 +6,8 @@
 #include <jank/runtime/behavior/callable.hpp>
 #include <jank/runtime/rtti.hpp>
 #include <jank/runtime/context.hpp>
+#include <jank/runtime/core/to_string.hpp>
+#include <jank/runtime/obj/persistent_hash_map.hpp>
 #include <jank/profile/time.hpp>
 
 namespace jank::runtime

--- a/compiler+runtime/src/cpp/jank/util/clang_format.cpp
+++ b/compiler+runtime/src/cpp/jank/util/clang_format.cpp
@@ -1,8 +1,12 @@
+#include <fstream>
+
+#include <fmt/format.h>
+
+#include <clang/Format/Format.h>
+
 #include <jank/util/clang_format.hpp>
 #include <jank/util/process_location.hpp>
 #include <jank/util/dir.hpp>
-
-#include <clang/Format/Format.h>
 
 namespace jank::util
 {

--- a/compiler+runtime/src/cpp/jank/util/cli.cpp
+++ b/compiler+runtime/src/cpp/jank/util/cli.cpp
@@ -1,5 +1,7 @@
 #include <CLI/CLI.hpp>
 
+#include <fmt/format.h>
+
 #include <jank/util/cli.hpp>
 #include <jank/runtime/module/loader.hpp>
 

--- a/compiler+runtime/src/cpp/jank/util/dir.cpp
+++ b/compiler+runtime/src/cpp/jank/util/dir.cpp
@@ -1,6 +1,9 @@
 #include <clang/Basic/Version.h>
 #include <llvm/TargetParser/Host.h>
 
+#include <fmt/format.h>
+
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/util/dir.hpp>
 #include <jank/util/sha256.hpp>
 

--- a/compiler+runtime/src/cpp/jank/util/escape.cpp
+++ b/compiler+runtime/src/cpp/jank/util/escape.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include <jank/util/escape.hpp>
 
 namespace jank::util

--- a/compiler+runtime/src/cpp/jank/util/string_builder.cpp
+++ b/compiler+runtime/src/cpp/jank/util/string_builder.cpp
@@ -1,0 +1,303 @@
+#include <bit>
+#include <codecvt>
+#include <locale>
+
+#include <jank/util/string_builder.hpp>
+
+namespace jank::util
+{
+  static void realloc(string_builder &sb, size_t const required)
+  {
+    auto const new_capacity{ std::bit_ceil(required) };
+    auto const new_data{ new(PointerFreeGC) string_builder::value_type[new_capacity] };
+    string_builder::traits_type::copy(new_data, sb.buffer, sb.pos);
+    delete sb.buffer;
+    sb.buffer = new_data;
+    sb.capacity = new_capacity;
+  }
+
+  static void maybe_realloc(string_builder &sb, size_t const additional_size)
+  {
+    auto const required_size{ sb.pos + additional_size + 1 };
+    if(sb.capacity < required_size)
+    {
+      realloc(sb, required_size);
+    }
+  }
+
+  static void write(string_builder &sb, char const * const str, size_t const size)
+  {
+    string_builder::traits_type::copy(sb.buffer + sb.pos, str, size);
+    sb.pos += size;
+  }
+
+  string_builder::string_builder()
+  {
+    realloc(*this, capacity);
+  }
+
+  string_builder::string_builder(size_t const capacity)
+    : capacity{ capacity }
+  {
+    realloc(*this, capacity);
+  }
+
+  string_builder::~string_builder()
+  {
+    delete buffer;
+  }
+
+  string_builder &string_builder::operator()(native_bool const d) &
+  {
+    if(d)
+    {
+      auto const required{ 4 };
+      maybe_realloc(*this, required);
+      write(*this, "true", required);
+    }
+    else
+    {
+      auto const required{ 5 };
+      maybe_realloc(*this, required);
+      write(*this, "false", required);
+    }
+
+    return *this;
+  }
+
+  string_builder &string_builder::operator()(native_integer const d) &
+  {
+    /* NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg) */
+    auto const required{ snprintf(nullptr, 0, "%lld", d) };
+    maybe_realloc(*this, required);
+
+    /* NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg) */
+    snprintf(buffer + pos, capacity - pos, "%lld", d);
+    pos += required;
+
+    return *this;
+  }
+
+  string_builder &string_builder::operator()(native_real const d) &
+  {
+    /* NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg) */
+    auto const required{ snprintf(nullptr, 0, "%f", d) };
+    maybe_realloc(*this, required);
+
+    /* NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg) */
+    snprintf(buffer + pos, capacity - pos, "%f", d);
+    pos += required;
+
+    return *this;
+  }
+
+  string_builder &string_builder::operator()(native_hash const d) &
+  {
+    /* NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg) */
+    auto const required{ snprintf(nullptr, 0, "%d", d) };
+    maybe_realloc(*this, required);
+
+    /* NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg) */
+    snprintf(buffer + pos, capacity - pos, "%d", d);
+    pos += required;
+
+    return *this;
+  }
+
+  string_builder &string_builder::operator()(void const * const d) &
+  {
+    /* NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg) */
+    auto const required{ snprintf(nullptr, 0, "%p", d) };
+    maybe_realloc(*this, required);
+
+    /* NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg) */
+    snprintf(buffer + pos, capacity - pos, "%p", d);
+    pos += required;
+
+    return *this;
+  }
+
+  string_builder &string_builder::operator()(int const d) &
+  {
+    /* NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg) */
+    auto const required{ snprintf(nullptr, 0, "%d", d) };
+    maybe_realloc(*this, required);
+
+    /* NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg) */
+    snprintf(buffer + pos, capacity - pos, "%d", d);
+    pos += required;
+
+    return *this;
+  }
+
+  string_builder &string_builder::operator()(size_t const d) &
+  {
+    /* NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg) */
+    auto const required{ snprintf(nullptr, 0, "%zu", d) };
+    maybe_realloc(*this, required);
+
+    /* NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg) */
+    snprintf(buffer + pos, capacity - pos, "%zu", d);
+    pos += required;
+
+    return *this;
+  }
+
+  string_builder &string_builder::operator()(char const d) &
+  {
+    maybe_realloc(*this, 1);
+
+    buffer[pos] = d;
+    ++pos;
+
+    return *this;
+  }
+
+  string_builder &string_builder::operator()(char32_t const d) &
+  {
+    std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> converter;
+    return (*this)(converter.to_bytes(d));
+  }
+
+  string_builder &string_builder::operator()(char const * const d) &
+  {
+    auto const required{ strlen(d) };
+    maybe_realloc(*this, required);
+
+    write(*this, d, required);
+
+    return *this;
+  }
+
+  string_builder &string_builder::operator()(native_transient_string const &d) &
+  {
+    auto const required{ d.size() };
+    maybe_realloc(*this, required);
+
+    write(*this, d.data(), required);
+
+    return *this;
+  }
+
+  string_builder &string_builder::operator()(native_persistent_string const &d) &
+  {
+    auto const required{ d.size() };
+    maybe_realloc(*this, required);
+
+    write(*this, d.data(), required);
+
+    return *this;
+  }
+
+  void string_builder::push_back(native_bool const d) &
+  {
+    (*this)(d);
+  }
+
+  void string_builder::push_back(native_integer const d) &
+  {
+    (*this)(d);
+  }
+
+  void string_builder::push_back(native_real const d) &
+  {
+    (*this)(d);
+  }
+
+  void string_builder::push_back(native_hash const d) &
+  {
+    (*this)(d);
+  }
+
+  void string_builder::push_back(void const * const d) &
+  {
+    (*this)(d);
+  }
+
+  void string_builder::push_back(int const d) &
+  {
+    (*this)(d);
+  }
+
+  void string_builder::push_back(size_t const d) &
+  {
+    (*this)(d);
+  }
+
+  void string_builder::push_back(char const d) &
+  {
+    (*this)(d);
+  }
+
+  void string_builder::push_back(char32_t const d) &
+  {
+    (*this)(d);
+  }
+
+  void string_builder::push_back(char const * const d) &
+  {
+    (*this)(d);
+  }
+
+  void string_builder::push_back(native_transient_string const &d) &
+  {
+    (*this)(d);
+  }
+
+  void string_builder::push_back(native_persistent_string const &d) &
+  {
+    (*this)(d);
+  }
+
+  void string_builder::reserve(size_t const new_capacity)
+  {
+    if(capacity < new_capacity)
+    {
+      realloc(*this, new_capacity);
+    }
+  }
+
+  string_builder::value_type *string_builder::data() const
+  {
+    return buffer;
+  }
+
+  size_t string_builder::size() const
+  {
+    return pos;
+  }
+
+  native_persistent_string string_builder::release()
+  {
+    assert(pos < capacity);
+
+    native_persistent_string ret;
+    if(pos <= native_persistent_string::max_small_size)
+    {
+      ret.init_small(buffer, pos);
+    }
+    else
+    {
+      ret.init_large_shared(buffer, pos);
+    }
+
+    pos = capacity = 0;
+    buffer = nullptr;
+
+    return ret;
+  }
+
+  native_transient_string string_builder::str() const
+  {
+    assert(pos < capacity);
+    buffer[pos] = 0;
+    return { buffer, pos };
+  }
+
+  native_persistent_string_view string_builder::view() const &
+  {
+    assert(pos < capacity);
+    buffer[pos] = 0;
+    return { buffer, pos };
+  }
+}

--- a/compiler+runtime/src/cpp/main.cpp
+++ b/compiler+runtime/src/cpp/main.cpp
@@ -99,6 +99,7 @@ namespace jank
     using namespace jank;
     using namespace jank::runtime;
 
+    //__rt_ctx->load_module("/clojure.core", module::origin::latest).expect_ok();
     __rt_ctx->compile_module(opts.target_ns).expect_ok();
   }
 

--- a/compiler+runtime/src/cpp/main.cpp
+++ b/compiler+runtime/src/cpp/main.cpp
@@ -11,6 +11,7 @@
 
 #include <folly/FBString.h>
 
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/util/mapped_file.hpp>
 #include <jank/read/lex.hpp>
 #include <jank/read/parse.hpp>

--- a/compiler+runtime/src/cpp/main.cpp
+++ b/compiler+runtime/src/cpp/main.cpp
@@ -16,6 +16,7 @@
 #include <jank/read/parse.hpp>
 #include <jank/runtime/context.hpp>
 #include <jank/runtime/behavior/callable.hpp>
+#include <jank/runtime/core/to_string.hpp>
 #include <jank/analyze/processor.hpp>
 #include <jank/evaluate.hpp>
 #include <jank/jit/processor.hpp>

--- a/compiler+runtime/src/jank/clojure/core.jank
+++ b/compiler+runtime/src/jank/clojure/core.jank
@@ -1918,13 +1918,25 @@
    f must be free of side-effects"
   clojure.core-native/iterate)
 
-; TODO: integer_range
-(def range
+(defn range
   "Returns a lazy seq of nums from start (inclusive) to end
    (exclusive), by step, where start defaults to 0, step to 1, and end to
    infinity. When step is equal to 0, returns an infinite sequence of
    start. When start is equal to end, returns empty list."
-  clojure.core-native/range)
+  ([]
+   (iterate inc 0))
+  ([end]
+   (if (integer? end)
+     (clojure.core-native/integer-range end)
+     (clojure.core-native/range end)))
+  ([start end]
+   (if (and (integer? start) (integer? end))
+     (clojure.core-native/integer-range start end)
+     (clojure.core-native/range start end)))
+  ([start end step]
+   (if (and (integer? start) (integer? end) (integer? step))
+     (clojure.core-native/integer-range start end step)
+     (clojure.core-native/range start end step))))
 
 (def nth
   "Returns the value at the index. get returns nil if index out of

--- a/compiler+runtime/test/cpp/jank/jit/processor.cpp
+++ b/compiler+runtime/test/cpp/jank/jit/processor.cpp
@@ -15,6 +15,7 @@
 #include <jank/runtime/obj/persistent_string.hpp>
 #include <jank/runtime/obj/keyword.hpp>
 #include <jank/runtime/context.hpp>
+#include <jank/runtime/core/to_string.hpp>
 #include <jank/analyze/processor.hpp>
 #include <jank/jit/processor.hpp>
 

--- a/compiler+runtime/test/cpp/jank/jit/processor.cpp
+++ b/compiler+runtime/test/cpp/jank/jit/processor.cpp
@@ -6,6 +6,7 @@
 
 #include <fmt/color.h>
 
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/util/mapped_file.hpp>
 #include <jank/util/scope_exit.hpp>
 #include <jank/read/lex.hpp>

--- a/compiler+runtime/test/cpp/jank/read/parse.cpp
+++ b/compiler+runtime/test/cpp/jank/read/parse.cpp
@@ -5,6 +5,8 @@
 #include <jank/runtime/rtti.hpp>
 #include <jank/runtime/core.hpp>
 #include <jank/runtime/context.hpp>
+#include <jank/runtime/obj/persistent_hash_set.hpp>
+#include <jank/runtime/obj/keyword.hpp>
 #include <jank/util/escape.hpp>
 
 /* This must go last; doctest and glog both define CHECK and family. */

--- a/compiler+runtime/test/cpp/jank/read/parse.cpp
+++ b/compiler+runtime/test/cpp/jank/read/parse.cpp
@@ -1,5 +1,7 @@
 #include <unistd.h>
 
+#include <fmt/format.h>
+
 #include <jank/read/lex.hpp>
 #include <jank/read/parse.hpp>
 #include <jank/runtime/rtti.hpp>

--- a/compiler+runtime/test/cpp/jank/util/string_builder.cpp
+++ b/compiler+runtime/test/cpp/jank/util/string_builder.cpp
@@ -11,7 +11,7 @@ namespace jank::util
   {
     TEST_CASE("empty")
     {
-      string_builder sb;
+      string_builder const sb;
       CHECK_EQ("", sb.view());
     }
 
@@ -26,14 +26,14 @@ namespace jank::util
         }
         CHECK_EQ(initial_capacity / 2, sb.pos);
         CHECK_EQ(initial_capacity, sb.capacity);
-        native_transient_string input(initial_capacity / 2, ' ');
+        native_transient_string const input(initial_capacity / 2, ' ');
         CHECK_EQ(input, sb.view());
       }
 
       SUBCASE("no resize: full")
       {
         string_builder sb;
-        native_transient_string input(initial_capacity - 1, 'a');
+        native_transient_string const input(initial_capacity - 1, 'a');
         sb(input);
         CHECK_EQ(input.size(), sb.pos);
         CHECK_EQ(initial_capacity, sb.capacity);
@@ -43,7 +43,7 @@ namespace jank::util
       SUBCASE("resize: full + 1")
       {
         string_builder sb;
-        native_transient_string input(initial_capacity, 'a');
+        native_transient_string const input(initial_capacity, 'a');
         sb(input);
         CHECK_EQ(input.size(), sb.pos);
         CHECK_EQ(initial_capacity * 2, sb.capacity);
@@ -53,7 +53,7 @@ namespace jank::util
       SUBCASE("resize: full + a bunch")
       {
         string_builder sb;
-        native_transient_string input((initial_capacity * 3) + 5, '.');
+        native_transient_string const input((initial_capacity * 3) + 5, '.');
         sb(input);
         CHECK_EQ(input.size(), sb.pos);
         CHECK_EQ(initial_capacity * 4, sb.capacity);

--- a/compiler+runtime/test/cpp/jank/util/string_builder.cpp
+++ b/compiler+runtime/test/cpp/jank/util/string_builder.cpp
@@ -1,0 +1,101 @@
+#include <jank/util/string_builder.hpp>
+
+/* This must go last; doctest and glog both define CHECK and family. */
+#include <doctest/doctest.h>
+
+namespace jank::util
+{
+  static constexpr size_t initial_capacity{ string_builder::initial_capacity };
+
+  TEST_SUITE("string_builder")
+  {
+    TEST_CASE("empty")
+    {
+      string_builder sb;
+      CHECK_EQ("", sb.view());
+    }
+
+    TEST_CASE("resize")
+    {
+      SUBCASE("no resize: more space")
+      {
+        string_builder sb;
+        for(size_t i{}; i < initial_capacity / 2; ++i)
+        {
+          sb(' ');
+        }
+        CHECK_EQ(initial_capacity / 2, sb.pos);
+        CHECK_EQ(initial_capacity, sb.capacity);
+        native_transient_string input(initial_capacity / 2, ' ');
+        CHECK_EQ(input, sb.view());
+      }
+
+      SUBCASE("no resize: full")
+      {
+        string_builder sb;
+        native_transient_string input(initial_capacity - 1, 'a');
+        sb(input);
+        CHECK_EQ(input.size(), sb.pos);
+        CHECK_EQ(initial_capacity, sb.capacity);
+        CHECK_EQ(input, sb.view());
+      }
+
+      SUBCASE("resize: full + 1")
+      {
+        string_builder sb;
+        native_transient_string input(initial_capacity, 'a');
+        sb(input);
+        CHECK_EQ(input.size(), sb.pos);
+        CHECK_EQ(initial_capacity * 2, sb.capacity);
+        CHECK_EQ(input, sb.view());
+      }
+
+      SUBCASE("resize: full + a bunch")
+      {
+        string_builder sb;
+        native_transient_string input((initial_capacity * 3) + 5, '.');
+        sb(input);
+        CHECK_EQ(input.size(), sb.pos);
+        CHECK_EQ(initial_capacity * 4, sb.capacity);
+        CHECK_EQ(input, sb.view());
+      }
+    }
+
+    TEST_CASE("pointer")
+    {
+      string_builder sb;
+      auto const p{ reinterpret_cast<void const *>(0xcafebabe) };
+      sb(p);
+      CHECK_EQ(10, sb.pos);
+      CHECK_EQ(initial_capacity, sb.capacity);
+      CHECK_EQ("0xcafebabe", sb.view());
+    }
+
+    TEST_CASE("int")
+    {
+      string_builder sb;
+      sb(-50000);
+      CHECK_EQ(6, sb.pos);
+      CHECK_EQ(initial_capacity, sb.capacity);
+      CHECK_EQ("-50000", sb.view());
+    }
+
+    TEST_CASE("float / double")
+    {
+      string_builder sb;
+      sb(3.14);
+      CHECK_EQ(8, sb.pos);
+      CHECK_EQ(initial_capacity, sb.capacity);
+      CHECK_EQ("3.140000", sb.view());
+    }
+
+    TEST_CASE("char32_t")
+    {
+      string_builder sb;
+      sb(static_cast<char32_t>(0x1F601));
+      CHECK_EQ(4, sb.pos);
+      CHECK_EQ(initial_capacity, sb.capacity);
+      CHECK_EQ("😁", sb.view());
+    }
+  }
+}

--- a/compiler+runtime/test/cpp/main.cpp
+++ b/compiler+runtime/test/cpp/main.cpp
@@ -12,6 +12,7 @@
 #include <llvm/Support/TargetSelect.h>
 
 #include <jank/runtime/context.hpp>
+#include <jank/runtime/core/to_string.hpp>
 #include <clojure/core_native.hpp>
 
 /* NOLINTNEXTLINE(bugprone-exception-escape): println can throw. */

--- a/compiler+runtime/test/cpp/main.cpp
+++ b/compiler+runtime/test/cpp/main.cpp
@@ -11,6 +11,7 @@
 #include <llvm/Support/ManagedStatic.h>
 #include <llvm/Support/TargetSelect.h>
 
+#include <jank/native_persistent_string/fmt.hpp>
 #include <jank/runtime/context.hpp>
 #include <jank/runtime/core/to_string.hpp>
 #include <clojure/core_native.hpp>


### PR DESCRIPTION
This drops (serial) compile times from ~980s to ~740 seconds. This is important not just for our dev experience, but because we'll ultimately be including more of these header during runtime and startup. We need them to be as light as possible. I used [clang build analyzer](https://github.com/aras-p/ClangBuildAnalyzer) for figuring out the most important things to tackle. There's a lot more which can be done (we can definitely get under 500s), but for now this PR includes:

* Replace `static_object` with distinct object types
* Remove `magic_enum` in favor of `constexpr` fns
* Move various CRTP templates into cpp files with explicit instantiations
* Remove fmt from headers and provide a custom string builder instead
  * fmt is still used within cpp files (for now)
* Clean up lots of includes based on all of the changes above