### PR TITLE
Preserve (hash/array)map meta on assoc, dissoc and conj

### DIFF
--- a/compiler+runtime/include/cpp/jank/runtime/obj/detail/base_persistent_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/detail/base_persistent_map.hpp
@@ -29,6 +29,7 @@ namespace jank::runtime::obj::detail
     using value_type = V;
 
     base_persistent_map() = default;
+    base_persistent_map(option<object_ptr> meta);
 
     /* behavior::object_like */
     native_bool equal(object const &o) const;

--- a/compiler+runtime/include/cpp/jank/runtime/obj/detail/base_persistent_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/detail/base_persistent_map.hpp
@@ -29,7 +29,7 @@ namespace jank::runtime::obj::detail
     using value_type = V;
 
     base_persistent_map() = default;
-    base_persistent_map(option<object_ptr> meta);
+    base_persistent_map(option<object_ptr> const &meta);
 
     /* behavior::object_like */
     native_bool equal(object const &o) const;

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_array_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_array_map.hpp
@@ -29,7 +29,7 @@ namespace jank::runtime::obj
     persistent_array_map(value_type &&d);
     persistent_array_map(value_type const &d);
     persistent_array_map(object_ptr meta, value_type &&d);
-    persistent_array_map(option<object_ptr> meta, value_type &&d);
+    persistent_array_map(option<object_ptr> const &meta, value_type &&d);
 
     template <typename... Args>
     persistent_array_map(runtime::detail::in_place_unique, Args &&...args)

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_array_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_array_map.hpp
@@ -17,6 +17,11 @@ namespace jank::runtime::obj
   {
     static constexpr object_type obj_type{ object_type::persistent_array_map };
     static constexpr size_t max_size{ value_type::max_size };
+    using parent_type
+      = obj::detail::base_persistent_map<persistent_array_map,
+                                         persistent_array_map_sequence,
+                                         runtime::detail::native_persistent_array_map>;
+
 
     persistent_array_map() = default;
     persistent_array_map(persistent_array_map &&) noexcept = default;
@@ -24,6 +29,7 @@ namespace jank::runtime::obj
     persistent_array_map(value_type &&d);
     persistent_array_map(value_type const &d);
     persistent_array_map(object_ptr meta, value_type &&d);
+    persistent_array_map(option<object_ptr> meta, value_type &&d);
 
     template <typename... Args>
     persistent_array_map(runtime::detail::in_place_unique, Args &&...args)

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_map.hpp
@@ -27,7 +27,8 @@ namespace jank::runtime::obj
     persistent_hash_map() = default;
     persistent_hash_map(persistent_hash_map &&) noexcept = default;
     persistent_hash_map(persistent_hash_map const &) = default;
-    persistent_hash_map(runtime::detail::native_persistent_array_map const &m,
+    persistent_hash_map(option<object_ptr> meta,
+                        runtime::detail::native_persistent_array_map const &m,
                         object_ptr key,
                         object_ptr val);
     persistent_hash_map(value_type &&d);

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_map.hpp
@@ -17,6 +17,10 @@ namespace jank::runtime::obj
                                        runtime::detail::native_persistent_hash_map>
   {
     static constexpr object_type obj_type{ object_type::persistent_hash_map };
+    using parent_type
+      = obj::detail::base_persistent_map<persistent_hash_map,
+                                         persistent_hash_map_sequence,
+                                         runtime::detail::native_persistent_hash_map>;
 
     using transient_type = transient_hash_map;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_map.hpp
@@ -10,6 +10,7 @@ namespace jank::runtime::obj
   using persistent_array_map_ptr = native_box<struct persistent_array_map>;
   using transient_hash_map_ptr = native_box<struct transient_hash_map>;
   using persistent_hash_map_ptr = native_box<struct persistent_hash_map>;
+  using meta_option = option<object_ptr>;
 
   struct persistent_hash_map
     : obj::detail::base_persistent_map<persistent_hash_map,
@@ -29,6 +30,7 @@ namespace jank::runtime::obj
     persistent_hash_map(value_type &&d);
     persistent_hash_map(value_type const &d);
     persistent_hash_map(object_ptr meta, value_type &&d);
+    persistent_hash_map(meta_option meta, value_type &&d);
 
     template <typename... Args>
     persistent_hash_map(runtime::detail::in_place_unique, Args &&...args)

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_map.hpp
@@ -27,14 +27,14 @@ namespace jank::runtime::obj
     persistent_hash_map() = default;
     persistent_hash_map(persistent_hash_map &&) noexcept = default;
     persistent_hash_map(persistent_hash_map const &) = default;
-    persistent_hash_map(option<object_ptr> meta,
+    persistent_hash_map(option<object_ptr> const &meta,
                         runtime::detail::native_persistent_array_map const &m,
                         object_ptr key,
                         object_ptr val);
     persistent_hash_map(value_type &&d);
     persistent_hash_map(value_type const &d);
     persistent_hash_map(object_ptr meta, value_type &&d);
-    persistent_hash_map(option<object_ptr> meta, value_type &&d);
+    persistent_hash_map(option<object_ptr> const &meta, value_type &&d);
 
     template <typename... Args>
     persistent_hash_map(runtime::detail::in_place_unique, Args &&...args)

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_map.hpp
@@ -10,7 +10,6 @@ namespace jank::runtime::obj
   using persistent_array_map_ptr = native_box<struct persistent_array_map>;
   using transient_hash_map_ptr = native_box<struct transient_hash_map>;
   using persistent_hash_map_ptr = native_box<struct persistent_hash_map>;
-  using meta_option = option<object_ptr>;
 
   struct persistent_hash_map
     : obj::detail::base_persistent_map<persistent_hash_map,
@@ -30,7 +29,7 @@ namespace jank::runtime::obj
     persistent_hash_map(value_type &&d);
     persistent_hash_map(value_type const &d);
     persistent_hash_map(object_ptr meta, value_type &&d);
-    persistent_hash_map(meta_option meta, value_type &&d);
+    persistent_hash_map(option<object_ptr> meta, value_type &&d);
 
     template <typename... Args>
     persistent_hash_map(runtime::detail::in_place_unique, Args &&...args)

--- a/compiler+runtime/src/cpp/jank/runtime/obj/detail/base_persistent_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/detail/base_persistent_map.cpp
@@ -6,6 +6,12 @@
 namespace jank::runtime::obj::detail
 {
   template <typename PT, typename ST, typename V>
+  base_persistent_map<PT, ST, V>::base_persistent_map(option<object_ptr> const meta)
+    : meta{ meta }
+  {
+  }
+
+  template <typename PT, typename ST, typename V>
   native_bool base_persistent_map<PT, ST, V>::equal(object const &o) const
   {
     if(&o == &base)

--- a/compiler+runtime/src/cpp/jank/runtime/obj/detail/base_persistent_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/detail/base_persistent_map.cpp
@@ -6,7 +6,7 @@
 namespace jank::runtime::obj::detail
 {
   template <typename PT, typename ST, typename V>
-  base_persistent_map<PT, ST, V>::base_persistent_map(option<object_ptr> const meta)
+  base_persistent_map<PT, ST, V>::base_persistent_map(option<object_ptr> const &meta)
     : meta{ meta }
   {
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_array_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_array_map.cpp
@@ -28,6 +28,12 @@ namespace jank::runtime::obj
     this->meta = meta;
   }
 
+  persistent_array_map::persistent_array_map(option<object_ptr> const meta, value_type &&d)
+    : parent_type{ meta }
+    , data{ std::move(d) }
+  {
+  }
+
   object_ptr persistent_array_map::get(object_ptr const key) const
   {
     auto const res(data.find(key));
@@ -74,13 +80,13 @@ namespace jank::runtime::obj
      * TODO: Benchmark if it's faster to have this behavior or to check first. */
     if(data.size() == runtime::detail::native_persistent_array_map::max_size)
     {
-      return make_box<persistent_hash_map>(data, key, val);
+      return make_box<persistent_hash_map>(meta, data, key, val);
     }
     else
     {
       auto copy(data.clone());
       copy.insert_or_assign(key, val);
-      return make_box<persistent_array_map>(std::move(copy));
+      return make_box<persistent_array_map>(meta, std::move(copy));
     }
   }
 
@@ -88,7 +94,7 @@ namespace jank::runtime::obj
   {
     auto copy(data.clone());
     copy.erase(key);
-    return make_box<persistent_array_map>(std::move(copy));
+    return make_box<persistent_array_map>(meta, std::move(copy));
   }
 
   object_ptr persistent_array_map::conj(object_ptr const head) const
@@ -112,13 +118,13 @@ namespace jank::runtime::obj
 
     if(data.size() == runtime::detail::native_persistent_array_map::max_size)
     {
-      return make_box<persistent_hash_map>(data, vec->data[0], vec->data[1]);
+      return make_box<persistent_hash_map>(meta, data, vec->data[0], vec->data[1]);
     }
     else
     {
       auto copy(data.clone());
       copy.insert_or_assign(vec->data[0], vec->data[1]);
-      return make_box<persistent_array_map>(std::move(copy));
+      return make_box<persistent_array_map>(meta, std::move(copy));
     }
   }
 

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_array_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_array_map.cpp
@@ -28,7 +28,7 @@ namespace jank::runtime::obj
     this->meta = meta;
   }
 
-  persistent_array_map::persistent_array_map(option<object_ptr> const meta, value_type &&d)
+  persistent_array_map::persistent_array_map(option<object_ptr> const &meta, value_type &&d)
     : parent_type{ meta }
     , data{ std::move(d) }
   {

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_map.cpp
@@ -10,7 +10,7 @@
 
 namespace jank::runtime::obj
 {
-  persistent_hash_map::persistent_hash_map(option<object_ptr> meta,
+  persistent_hash_map::persistent_hash_map(option<object_ptr> const &meta,
                                            runtime::detail::native_persistent_array_map const &m,
                                            object_ptr const key,
                                            object_ptr const val)
@@ -41,7 +41,7 @@ namespace jank::runtime::obj
     this->meta = meta;
   }
 
-  persistent_hash_map::persistent_hash_map(option<object_ptr> const meta, value_type &&d)
+  persistent_hash_map::persistent_hash_map(option<object_ptr> const &meta, value_type &&d)
     : parent_type{ meta }
     , data{ std::move(d) }
   {

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_map.cpp
@@ -40,9 +40,9 @@ namespace jank::runtime::obj
   }
 
   persistent_hash_map::persistent_hash_map(option<object_ptr> const meta, value_type &&d)
-    : data{ std::move(d) }
+    : parent_type{ meta }
+    , data{ std::move(d) }
   {
-    this->meta = meta;
   }
 
   persistent_hash_map_ptr persistent_hash_map::create_from_seq(object_ptr const seq)

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_map.cpp
@@ -39,6 +39,12 @@ namespace jank::runtime::obj
     this->meta = meta;
   }
 
+  persistent_hash_map::persistent_hash_map(meta_option meta, value_type &&d)
+    : data{ std::move(d) }
+  {
+    this->meta = meta;
+  }
+
   persistent_hash_map_ptr persistent_hash_map::create_from_seq(object_ptr const seq)
   {
     return make_box<persistent_hash_map>(visit_seqable(
@@ -103,13 +109,13 @@ namespace jank::runtime::obj
   persistent_hash_map::assoc(object_ptr const key, object_ptr const val) const
   {
     auto copy(data.set(key, val));
-    return make_box<persistent_hash_map>(std::move(copy));
+    return make_box<persistent_hash_map>(meta, std::move(copy));
   }
 
   persistent_hash_map_ptr persistent_hash_map::dissoc(object_ptr const key) const
   {
     auto copy(data.erase(key));
-    return make_box<persistent_hash_map>(std::move(copy));
+    return make_box<persistent_hash_map>(meta, std::move(copy));
   }
 
   persistent_hash_map_ptr persistent_hash_map::conj(object_ptr const head) const
@@ -132,7 +138,7 @@ namespace jank::runtime::obj
     }
 
     auto copy(data.set(vec->data[0], vec->data[1]));
-    return make_box<persistent_hash_map>(std::move(copy));
+    return make_box<persistent_hash_map>(meta, std::move(copy));
   }
 
   object_ptr persistent_hash_map::call(object_ptr const o) const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_map.cpp
@@ -10,9 +10,11 @@
 
 namespace jank::runtime::obj
 {
-  persistent_hash_map::persistent_hash_map(runtime::detail::native_persistent_array_map const &m,
+  persistent_hash_map::persistent_hash_map(option<object_ptr> meta,
+                                           runtime::detail::native_persistent_array_map const &m,
                                            object_ptr const key,
                                            object_ptr const val)
+    : parent_type{ meta }
   {
     runtime::detail::native_transient_hash_map transient;
     for(auto const &e : m)

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_map.cpp
@@ -39,7 +39,7 @@ namespace jank::runtime::obj
     this->meta = meta;
   }
 
-  persistent_hash_map::persistent_hash_map(meta_option meta, value_type &&d)
+  persistent_hash_map::persistent_hash_map(option<object_ptr> const meta, value_type &&d)
     : data{ std::move(d) }
   {
     this->meta = meta;


### PR DESCRIPTION
I was playing around with solving #173 and this is what I came up with. I still need to do the other collection types and their various operations, but wanted to get some feedback on the approach before I make too many changes.