### PR TITLE
Fix `with-bindings` for persistent_array_map

### DIFF
--- a/compiler+runtime/src/jank/clojure/core.jank
+++ b/compiler+runtime/src/jank/clojure/core.jank
@@ -4405,7 +4405,7 @@
   Pops the installed bindings after f returned. Returns whatever f returns."
   [binding-map f & args]
   (push-thread-bindings (if (= "persistent_array_map" (type binding-map))
-                          (into {} binding-map)
+                          (into (hash-map) binding-map)
                           binding-map))
   (try
     (apply f args)

--- a/compiler+runtime/src/jank/clojure/core.jank
+++ b/compiler+runtime/src/jank/clojure/core.jank
@@ -4404,7 +4404,9 @@
   values as thread-local bindings. Then calls f with the supplied arguments.
   Pops the installed bindings after f returned. Returns whatever f returns."
   [binding-map f & args]
-  (push-thread-bindings binding-map)
+  (push-thread-bindings (if (= "persistent_array_map" (type binding-map))
+                          (into {} binding-map)
+                          binding-map))
   (try
     (apply f args)
     (catch e (throw e))


### PR DESCRIPTION
I considered implementing the binding mechanics in terms of `persistent_array_map` but wasn't sure it was worth it.