### PR TITLE
Fix trailing comma/semi/paren on symbols and keywords

### DIFF
--- a/compiler+runtime/src/cpp/jank/analyze/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/analyze/processor.cpp
@@ -287,7 +287,7 @@ namespace jank::analyze
       {
         if(is_variadic)
         {
-          return err(error{ "invalid function; parameters contain mutliple &" });
+          return err(error{ "invalid function; parameters contain multiple &" });
         }
         else if(it + 1 == params->data.end())
         {

--- a/compiler+runtime/src/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/src/cpp/jank/read/lex.cpp
@@ -893,8 +893,7 @@ namespace jank::read
             if(oc.is_err() || std::iswspace(static_cast<wint_t>(c)) || is_special_char(c))
             {
               ++pos;
-              return err(
-                error{ token_start, "invalid keyword: must be non-empty" });
+              return err(error{ token_start, "invalid keyword: must be non-empty" });
             }
 
             /* Support auto-resolved qualified keywords. */

--- a/compiler+runtime/src/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/src/cpp/jank/read/lex.cpp
@@ -309,7 +309,7 @@ namespace jank::read
     static native_bool is_special_char(char32_t const c)
     {
       return c == '(' || c == ')' || c == '{' || c == '}' || c == '[' || c == ']' || c == '"'
-        || c == '^' || c == '\\' || c == '`' || c == '~';
+        || c == '^' || c == '\\' || c == '`' || c == '~' || c == ',' || c == ';';
     }
 
     static native_bool is_symbol_char(char32_t const c)
@@ -890,11 +890,11 @@ namespace jank::read
 
             auto const oc(peek());
             auto const c(oc.expect_ok().character);
-            if(oc.is_err() || std::iswspace(static_cast<wint_t>(c)))
+            if(oc.is_err() || std::iswspace(static_cast<wint_t>(c)) || is_special_char(c))
             {
               ++pos;
               return err(
-                error{ token_start, "invalid keyword: expected non-whitespace character after :" });
+                error{ token_start, "invalid keyword: must be non-empty" });
             }
 
             /* Support auto-resolved qualified keywords. */

--- a/compiler+runtime/test/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/test/cpp/jank/read/lex.cpp
@@ -409,7 +409,7 @@ namespace jank::read::lex
         native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({
-                { 0, 4, token_kind::boolean,  true },
+                { 0, 4, token_kind::boolean, true },
                 { 4, 1, token_kind::comment, ""sv }
         }));
       }
@@ -1824,7 +1824,7 @@ namespace jank::read::lex
           CHECK(tokens
                 == make_results({
                   error{ 0, 0, "invalid keyword: must be non-empty" },
-                  token{ 1, 1, token_kind::close_paren }
+                  token{ 1, 1,              token_kind::close_paren }
           }));
         }
         SUBCASE("Comma is whitespace")
@@ -1843,7 +1843,7 @@ namespace jank::read::lex
           CHECK(tokens
                 == make_tokens({
                   { 0, 4, token_kind::keyword, "abc"sv },
-                  { 4, 1, token_kind::comment, ""sv }
+                  { 4, 1, token_kind::comment,    ""sv }
           }));
         }
       }

--- a/compiler+runtime/test/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/test/cpp/jank/read/lex.cpp
@@ -338,6 +338,25 @@ namespace jank::read::lex
                 { 0, 4, token_kind::symbol, "onil"sv }
         }));
       }
+      SUBCASE("Comma is whitespace")
+      {
+        processor p{ "nil," };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 3, token_kind::nil }
+        }));
+      }
+      SUBCASE("Semicolon is whitespace")
+      {
+        processor p{ "nil;" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 3, token_kind::nil },
+                { 3, 1, token_kind::comment, ""sv }
+        }));
+      }
     }
 
     TEST_CASE("Boolean")
@@ -372,6 +391,26 @@ namespace jank::read::lex
               == make_tokens({
                 { 0, 6, token_kind::symbol, "sotrue"sv },
                 { 7, 6, token_kind::symbol, "ffalse"sv }
+        }));
+      }
+      SUBCASE("Comma is whitespace")
+      {
+        processor p{ "true,false," };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 4, token_kind::boolean,  true },
+                { 5, 5, token_kind::boolean, false }
+        }));
+      }
+      SUBCASE("Semicolon is whitespace")
+      {
+        processor p{ "true;" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 4, token_kind::boolean,  true },
+                { 4, 1, token_kind::comment, ""sv }
         }));
       }
     }
@@ -1277,7 +1316,17 @@ namespace jank::read::lex
         native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_results({
-                error{ 0, "invalid keyword: expected non-whitespace character after :" }
+                error{ 0, "invalid keyword: must be non-empty" }
+        }));
+      }
+
+      SUBCASE("Comma after :")
+      {
+        processor p{ ":," };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                error{ 0, "invalid keyword: must be non-empty" }
         }));
       }
 
@@ -1701,6 +1750,15 @@ namespace jank::read::lex
                   { 0, 9, token_kind::symbol, "🐝/🥀"sv }
           }));
         }
+        SUBCASE("Comma is whitespace")
+        {
+          processor p{ "abc," };
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 3, token_kind::symbol, "abc"sv }
+          }));
+        }
       }
       SUBCASE("Keywords")
       {
@@ -1738,6 +1796,54 @@ namespace jank::read::lex
           CHECK(tokens
                 == make_tokens({
                   { 0, 10, token_kind::keyword, "🐝/🥀"sv }
+          }));
+        }
+        SUBCASE("Single comma is an empty keyword")
+        {
+          processor p{ ":," };
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_results({
+                  error{ 0, 0, "invalid keyword: must be non-empty" }
+          }));
+        }
+        SUBCASE("Single semicolon is an empty keyword")
+        {
+          processor p{ ":;" };
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_results({
+                  error{ 0, 0, "invalid keyword: must be non-empty" },
+                  token{ 1, 1, token_kind::comment, ""sv }
+          }));
+        }
+        SUBCASE("Single paren makes an empty keyword")
+        {
+          processor p{ ":)" };
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_results({
+                  error{ 0, 0, "invalid keyword: must be non-empty" },
+                  token{ 1, 1, token_kind::close_paren }
+          }));
+        }
+        SUBCASE("Comma is whitespace")
+        {
+          processor p{ ":abc," };
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 4, token_kind::keyword, "abc"sv }
+          }));
+        }
+        SUBCASE("Semicolon is whitespace")
+        {
+          processor p{ ":abc;" };
+          native_vector<result<token, error>> const tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 4, token_kind::keyword, "abc"sv },
+                  { 4, 1, token_kind::comment, ""sv }
           }));
         }
       }


### PR DESCRIPTION
Closes #196 
Related https://github.com/jank-lang/jank/issues/204

Ensures that `,` and `;` terminate keywords rather than becoming part of their value. Also ensures unqualified keywords are not allowed to be empty when the character trailing the `:` is a terminator like `)` (half of #204).

I left these cases alone from #196: 

```clojure
;; these are errors in CLJ and CLJS, but seem almost reasonable
;; maybe ok to keep
clojure.core=> :a:
:a:
clojure.core=> 'a:
a:

;; these fail in CLJ, but jank result == CLJS result
;; probably ok to keep
clojure.core=> 'a::a
a::a
clojure.user=> ':a::a
:a::a
```

jank after this pr:
```
clojure.core=> 'a,
a
clojure.core=> 'a;
a
clojure.core=> :error,
:error
clojure.core=> 'nil,
nil
clojure.core=> 'nil;
nil
clojure.core=> 'true,
true
clojure.core=> 'true;
true
clojure.core=> :a:
:a:
clojure.core=> 'a:
a:
clojure.core=> 'a::a
a::a
clojure.core=> ':a::a
:a::a
clojure.core=> '(:)
Read error (2 - 2): invalid keyword: must be non-empty
clojure.core=> :)
Read error (0 - 0): invalid keyword: must be non-empty
```