### PR TITLE
Implement clojure.core/sort

### DIFF
--- a/compiler+runtime/include/cpp/jank/runtime/core/seq.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core/seq.hpp
@@ -144,4 +144,6 @@ namespace jank::runtime
 
   object_ptr repeat(object_ptr val);
   object_ptr repeat(object_ptr n, object_ptr val);
+
+  object_ptr sort(object_ptr coll);
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/native_vector_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/native_vector_sequence.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <jank/runtime/object.hpp>
+#include <jank/option.hpp>
 
 namespace jank::runtime::obj
 {
@@ -18,6 +19,7 @@ namespace jank::runtime::obj
     native_vector_sequence(native_vector_sequence const &) = default;
     native_vector_sequence(native_vector<object_ptr> const &data, size_t index);
     native_vector_sequence(native_vector<object_ptr> &&data);
+    native_vector_sequence(option<object_ptr> const &meta, native_vector<object_ptr> &&data);
     native_vector_sequence(native_vector<object_ptr> &&data, size_t index);
 
     /* behavior::object_like */
@@ -29,7 +31,7 @@ namespace jank::runtime::obj
 
     /* behavior::seqable */
     native_vector_sequence_ptr seq();
-    native_vector_sequence_ptr fresh_seq();
+    native_vector_sequence_ptr fresh_seq() const;
 
     /* behavior::countable */
     size_t count() const;
@@ -41,6 +43,10 @@ namespace jank::runtime::obj
 
     /* behavior::sequenceable_in_place */
     native_vector_sequence_ptr next_in_place();
+
+    /* behavior::metadatable */
+    native_vector_sequence_ptr with_meta(object_ptr const m) const;
+    option<object_ptr> meta;
 
     object base{ obj_type };
     native_vector<object_ptr> data{};

--- a/compiler+runtime/src/cpp/clojure/core_native.cpp
+++ b/compiler+runtime/src/cpp/clojure/core_native.cpp
@@ -504,6 +504,7 @@ jank_object_ptr jank_load_clojure_core_native()
   intern_fn("tagged-literal", &tagged_literal);
   intern_fn("tagged-literal?", &is_tagged_literal);
   intern_fn("sorted?", &is_sorted);
+  intern_fn("sort", &sort);
 
   /* TODO: jank.math? */
   intern_fn("sqrt", static_cast<native_real (*)(object_ptr)>(&runtime::sqrt));

--- a/compiler+runtime/src/cpp/jank/runtime/core/math.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/math.cpp
@@ -1419,7 +1419,7 @@ namespace jank::runtime
   native_real tan(object_ptr const l)
   {
     return visit_number_like(
-      [](auto const typed_l) -> native_real { return std::tanf(typed_l->to_real()); },
+      [](auto const typed_l) -> native_real { return tanf(typed_l->to_real()); },
       l);
   }
 

--- a/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
@@ -1178,4 +1178,29 @@ namespace jank::runtime
   {
     return make_box<obj::repeat>(n, val);
   }
+
+  object_ptr sort(object_ptr const coll)
+  {
+    return visit_seqable(
+      [](auto const typed_coll) -> object_ptr {
+        native_vector<object_ptr> vec;
+        for(auto it(typed_coll->fresh_seq()); it != nullptr; it = it->next_in_place())
+        {
+          vec.push_back(it->first());
+        }
+
+        std::stable_sort(vec.begin(), vec.end(), [](object_ptr const a, object_ptr const b) {
+          return runtime::compare(a, b) < 0;
+        });
+
+        auto sorted_seq = make_box<obj::native_vector_sequence>(std::move(vec));
+	// TODO: fix this; preserve metadata
+        // if(auto meta = typed_coll->meta())
+        // {
+        //   sorted_seq->meta(meta);
+        // }
+        return sorted_seq;
+      },
+      coll);
+  }
 }

--- a/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
@@ -15,6 +15,7 @@
 #include <jank/runtime/behavior/indexable.hpp>
 #include <jank/runtime/behavior/stackable.hpp>
 #include <jank/runtime/behavior/chunkable.hpp>
+#include "jank/runtime/behavior/metadatable.hpp"
 #include <jank/runtime/core.hpp>
 
 namespace jank::runtime
@@ -1193,13 +1194,13 @@ namespace jank::runtime
           return runtime::compare(a, b) < 0;
         });
 
-        auto sorted_seq = make_box<obj::native_vector_sequence>(std::move(vec));
-	// TODO: fix this; preserve metadata
-        // if(auto meta = typed_coll->meta())
-        // {
-        //   sorted_seq->meta(meta);
-        // }
-        return sorted_seq;
+        using T = typename decltype(typed_coll)::value_type;
+
+        if constexpr(behavior::metadatable<T>) {
+          return make_box<obj::native_vector_sequence>(typed_coll->meta, std::move(vec));
+        } else {
+          return make_box<obj::native_vector_sequence>(std::move(vec));
+        }
       },
       coll);
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/native_vector_sequence.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/native_vector_sequence.cpp
@@ -25,6 +25,12 @@ namespace jank::runtime::obj
     assert(!this->data.empty());
   }
 
+  native_vector_sequence::native_vector_sequence(option<object_ptr> const &meta, native_vector<object_ptr> &&data)
+    : meta{ meta }
+    , data{ std::move(data) }
+  {
+  }
+
   /* behavior::objectable */
   native_bool native_vector_sequence::equal(object const &o) const
   {
@@ -61,7 +67,7 @@ namespace jank::runtime::obj
     return data.empty() ? nullptr : this;
   }
 
-  native_vector_sequence_ptr native_vector_sequence::fresh_seq()
+  native_vector_sequence_ptr native_vector_sequence::fresh_seq() const
   {
     return data.empty() ? nullptr : make_box<native_vector_sequence>(data, index);
   }
@@ -108,4 +114,13 @@ namespace jank::runtime::obj
   {
     return make_box<cons>(head, data.empty() ? nullptr : this);
   }
+
+  native_vector_sequence_ptr native_vector_sequence::with_meta(object_ptr const m) const
+  {
+    auto const meta(behavior::detail::validate_meta(m));
+    auto ret(fresh_seq());
+    ret->meta = meta;
+    return ret;
+  }
+
 }

--- a/compiler+runtime/src/jank/clojure/core.jank
+++ b/compiler+runtime/src/jank/clojure/core.jank
@@ -4924,6 +4924,7 @@
     (fn [x y]
       (cond (pred x y) -1 (pred y x) 1 :else 0)))
 
+#_
 (defn sort
   "Returns a sorted sequence of the items in coll. If no comparator is
   supplied, uses compare.  comparator must implement
@@ -4939,6 +4940,14 @@
   ;;      (with-meta (seq a) (meta coll)))
   ;;    ())
    (throw "TODO: port")))
+
+(def sort
+  "Returns a sorted sequence of the items in coll. If no comparator is
+  supplied, uses compare.  comparator must implement
+  java.util.Comparator.  Guaranteed to be stable: equal elements will
+  not be reordered.  If coll is a Java array, it will be modified.  To
+  avoid this, sort a copy of the array."
+  clojure.core-native/sort)
 
 (defn sort-by
   "Returns a sorted sequence of the items in coll, where the sort

--- a/compiler+runtime/src/jank/clojure/core.jank
+++ b/compiler+runtime/src/jank/clojure/core.jank
@@ -4924,23 +4924,6 @@
     (fn [x y]
       (cond (pred x y) -1 (pred y x) 1 :else 0)))
 
-#_
-(defn sort
-  "Returns a sorted sequence of the items in coll. If no comparator is
-  supplied, uses compare.  comparator must implement
-  java.util.Comparator.  Guaranteed to be stable: equal elements will
-  not be reordered.  If coll is a Java array, it will be modified.  To
-  avoid this, sort a copy of the array."
-  ([coll]
-   (sort compare coll))
-  ([#_java.util.Comparator comp coll]
-  ;;  (if (seq coll)
-  ;;    (let [a (to-array coll)]
-  ;;      (. java.util.Arrays (sort a comp))
-  ;;      (with-meta (seq a) (meta coll)))
-  ;;    ())
-   (throw "TODO: port")))
-
 (def sort
   "Returns a sorted sequence of the items in coll. If no comparator is
   supplied, uses compare.  comparator must implement


### PR DESCRIPTION
Issue: https://github.com/jank-lang/jank/issues/178

Examples:
```
clojure.core=> (sort [3 2 1])
(1 2 3)
clojure.core=> (meta (sort ^:a [4 3 2]))
{:a true}
clojure.core=> (sort '(4 3 2))
(2 3 4)
clojure.core=> (sort [[4] [3] [2]])
([2] [3] [4])
clojure.core=> (type (sort []))
"native_vector_sequence"
```