### PR TITLE
String associatively_readable implementation

### DIFF
--- a/compiler+runtime/CMakeLists.txt
+++ b/compiler+runtime/CMakeLists.txt
@@ -436,6 +436,7 @@ if(jank_tests)
     test/cpp/jank/runtime/detail/native_persistent_list.cpp
     test/cpp/jank/runtime/obj/ratio.cpp
     test/cpp/jank/runtime/obj/persistent_string.cpp
+    test/cpp/jank/runtime/obj/persistent_vector.cpp
     test/cpp/jank/jit/processor.cpp
   )
   add_executable(jank::test_exe ALIAS jank_test_exe)

--- a/compiler+runtime/CMakeLists.txt
+++ b/compiler+runtime/CMakeLists.txt
@@ -435,6 +435,7 @@ if(jank_tests)
     test/cpp/jank/analyze/box.cpp
     test/cpp/jank/runtime/detail/native_persistent_list.cpp
     test/cpp/jank/runtime/obj/ratio.cpp
+    test/cpp/jank/runtime/obj/persistent_string.cpp
     test/cpp/jank/jit/processor.cpp
   )
   add_executable(jank::test_exe ALIAS jank_test_exe)

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_string.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_string.hpp
@@ -38,6 +38,12 @@ namespace jank::runtime::obj
     /* behavior::comparable extended */
     native_integer compare(persistent_string const &) const;
 
+    /* behavior::associatively_readable */
+    object_ptr get(object_ptr const key) const;
+    object_ptr get(object_ptr const key, object_ptr const fallback) const;
+    object_ptr get_entry(object_ptr key) const;
+    native_bool contains(object_ptr key) const;
+
     string_result<persistent_string_ptr> substring(native_integer start) const;
     string_result<persistent_string_ptr> substring(native_integer start, native_integer end) const;
 

--- a/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
@@ -1082,7 +1082,7 @@ namespace jank::runtime
 
   object_ptr chunk_buffer(object_ptr const capacity)
   {
-    return make_box<obj::chunk_buffer>(static_cast<size_t>(to_int(capacity)));
+    return make_box<obj::chunk_buffer>(capacity);
   }
 
   object_ptr chunk_append(object_ptr const buff, object_ptr const val)

--- a/compiler+runtime/src/cpp/jank/runtime/obj/array_chunk.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/array_chunk.cpp
@@ -81,8 +81,8 @@ namespace jank::runtime::obj
   {
     if(index->type == object_type::integer)
     {
-      auto const i(static_cast<size_t>(expect_object<integer>(index)->data));
-      if(buffer.size() - offset <= i)
+      auto const i(expect_object<integer>(index)->data);
+      if(i < 0 || buffer.size() - offset <= static_cast<size_t>(i))
       {
         throw std::runtime_error{ fmt::format(
           "out of bounds index {}; array_chunk has a size of {} and offset of {}",
@@ -103,14 +103,10 @@ namespace jank::runtime::obj
   {
     if(index->type == object_type::integer)
     {
-      auto const i(static_cast<size_t>(expect_object<integer>(index)->data));
-      if(buffer.size() - offset <= i)
+      auto const i(expect_object<integer>(index)->data);
+      if(i < 0 || buffer.size() - offset <= static_cast<size_t>(i))
       {
-        throw std::runtime_error{ fmt::format(
-          "out of bounds index {}; array_chunk has a size of {} and offset of {}",
-          i,
-          buffer.size(),
-          offset) };
+        return fallback;
       }
       return buffer[offset + i];
     }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string.cpp
@@ -72,25 +72,27 @@ namespace jank::runtime::obj
   {
     if(key->type == object_type::integer)
     {
-      auto const i(static_cast<size_t>(expect_object<integer>(key)->data));
-      if(data.size() <= i)
+      auto const i(expect_object<integer>(key)->data);
+      if(i < 0 || data.size() <= static_cast<size_t>(i))
       {
-        return nil::nil_const();
+        return fallback;
       }
-      return make_box<runtime::obj::character>(data[i]);
+      return make_box<character>(data[i]);
     }
-    return fallback;
+    else
+    {
+      return fallback;
+    }
   }
 
   native_bool persistent_string::contains(object_ptr const key) const
   {
     if(key->type == object_type::integer)
     {
-      auto const i(static_cast<size_t>(expect_object<integer>(key)->data));
-      return 0 <= i && i < data.size();
+      auto const i(expect_object<integer>(key)->data);
+      return 0 <= i && static_cast<size_t>(i) < data.size();
     }
-    throw std::runtime_error{ fmt::format("contains? not supported on string: {}",
-                                          runtime::to_string(key)) };
+    return false;
   }
 
   object_ptr persistent_string::get_entry(object_ptr const) const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string.cpp
@@ -1,6 +1,7 @@
 #include <fmt/format.h>
 
 #include <jank/native_persistent_string/fmt.hpp>
+#include <jank/runtime/behavior/associatively_readable.hpp>
 #include <jank/runtime/obj/persistent_string.hpp>
 #include <jank/runtime/obj/persistent_string_sequence.hpp>
 #include <jank/runtime/rtti.hpp>
@@ -60,6 +61,40 @@ namespace jank::runtime::obj
   native_integer persistent_string::compare(persistent_string const &s) const
   {
     return data.compare(s.data);
+  }
+
+  object_ptr persistent_string::get(object_ptr const key) const
+  {
+    return get(key, nil::nil_const());
+  }
+
+  object_ptr persistent_string::get(object_ptr const key, object_ptr const fallback) const
+  {
+    if(key->type == object_type::integer)
+    {
+      auto const i(static_cast<size_t>(expect_object<integer>(key)->data));
+      if(data.size() <= i)
+      {
+        return nil::nil_const();
+      }
+      return make_box<runtime::obj::character>(data[i]);
+    }
+    return fallback;
+  }
+
+  native_bool persistent_string::contains(object_ptr const key) const
+  {
+    if(key->type == object_type::integer)
+    {
+      auto const i(static_cast<size_t>(expect_object<integer>(key)->data));
+      return data.size() <= i;
+    }
+    throw std::runtime_error{ fmt::format("contains? not supported on string: {}", runtime::to_string(key)) };
+  }
+
+  object_ptr persistent_string::get_entry(object_ptr const) const
+  {
+    throw std::runtime_error{ fmt::format("get_entry not supported on string") };
   }
 
   string_result<persistent_string_ptr> persistent_string::substring(native_integer start) const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string.cpp
@@ -1,7 +1,6 @@
 #include <fmt/format.h>
 
 #include <jank/native_persistent_string/fmt.hpp>
-#include <jank/runtime/behavior/associatively_readable.hpp>
 #include <jank/runtime/obj/persistent_string.hpp>
 #include <jank/runtime/obj/persistent_string_sequence.hpp>
 #include <jank/runtime/rtti.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string.cpp
@@ -87,7 +87,7 @@ namespace jank::runtime::obj
     if(key->type == object_type::integer)
     {
       auto const i(static_cast<size_t>(expect_object<integer>(key)->data));
-      return data.size() <= i;
+      return 0 <= i && i < data.size();
     }
     throw std::runtime_error{ fmt::format("contains? not supported on string: {}", runtime::to_string(key)) };
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string.cpp
@@ -89,7 +89,8 @@ namespace jank::runtime::obj
       auto const i(static_cast<size_t>(expect_object<integer>(key)->data));
       return 0 <= i && i < data.size();
     }
-    throw std::runtime_error{ fmt::format("contains? not supported on string: {}", runtime::to_string(key)) };
+    throw std::runtime_error{ fmt::format("contains? not supported on string: {}",
+                                          runtime::to_string(key)) };
   }
 
   object_ptr persistent_string::get_entry(object_ptr const) const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_vector.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_vector.cpp
@@ -227,19 +227,7 @@ namespace jank::runtime::obj
 
   object_ptr persistent_vector::get(object_ptr const key) const
   {
-    if(key->type == object_type::integer)
-    {
-      auto const i(static_cast<size_t>(expect_object<integer>(key)->data));
-      if(data.size() <= i)
-      {
-        return nil::nil_const();
-      }
-      return data[i];
-    }
-    else
-    {
-      return nil::nil_const();
-    }
+    return get(key, nil::nil_const());
   }
 
   object_ptr persistent_vector::get(object_ptr const key, object_ptr const fallback) const
@@ -314,8 +302,8 @@ namespace jank::runtime::obj
   {
     if(index->type == object_type::integer)
     {
-      auto const i(static_cast<size_t>(expect_object<integer>(index)->data));
-      if(data.size() <= i)
+      auto const i(expect_object<integer>(index)->data);
+      if(i < 0 || data.size() <= static_cast<size_t>(i))
       {
         throw std::runtime_error{
           fmt::format("out of bounds index {}; vector has a size of {}", i, data.size())

--- a/compiler+runtime/test/cpp/jank/native_persistent_string.cpp
+++ b/compiler+runtime/test/cpp/jank/native_persistent_string.cpp
@@ -1,4 +1,3 @@
-/* clang-format off */
 #include <jank/native_persistent_string.hpp>
 
 /* This must go last; doctest and glog both define CHECK and family. */
@@ -6,187 +5,186 @@
 
 namespace jank
 {
-  TEST_SUITE("native_persistent_string")
+  TEST_SUITE("native_persistent_string"){
+    TEST_CASE("Constructor"){ SUBCASE("Default"){ native_persistent_string const s;
+  CHECK(s.empty());
+}
+
+SUBCASE("Copy")
+{
+  SUBCASE("SSO")
   {
-    TEST_CASE("Constructor")
+    native_persistent_string const s{ "foo bar" };
+    /* NOLINTNEXTLINE(performance-unnecessary-copy-initialization) */
+    native_persistent_string const c{ s };
+    CHECK_EQ(c.size(), 7);
+    CHECK_NE(c.data(), s.data());
+  }
+
+  SUBCASE("Long")
+  {
+    native_persistent_string const s{ "foo bar spam meow foo bar spam meow" };
+    /* NOLINTNEXTLINE(performance-unnecessary-copy-initialization) */
+    native_persistent_string const c{ s };
+    CHECK_EQ(c.size(), 35);
+    CHECK_EQ(c.data(), s.data());
+  }
+}
+
+SUBCASE("C string")
+{
+  SUBCASE("SSO")
+  {
+    native_persistent_string const s{ "foo bar" };
+    CHECK_EQ(s.size(), 7);
+  }
+
+  SUBCASE("Long")
+  {
+    native_persistent_string const s{ "foo bar spam foo bar spam foo bar spam" };
+    CHECK_EQ(s.size(), 38);
+  }
+}
+}
+
+TEST_CASE("Find")
+{
+  SUBCASE("Empty corpus, empty pattern")
+  {
+    native_persistent_string const s;
+    CHECK_EQ(s.find(""), 0);
+  }
+
+  SUBCASE("Empty corpus")
+  {
+    native_persistent_string const s;
+    CHECK_EQ(s.find("something"), native_persistent_string::npos);
+  }
+
+  SUBCASE("Empty corpus, high pos")
+  {
+    native_persistent_string const s;
+    CHECK_EQ(s.find("something", 10), native_persistent_string::npos);
+  }
+
+  SUBCASE("Non-empty corpus, empty pattern")
+  {
+    native_persistent_string const s{ "foo bar" };
+    CHECK_EQ(s.find(""), 0);
+  }
+
+  SUBCASE("Non-empty corpus, missing pattern")
+  {
+    native_persistent_string const s{ "I'm not Abel. I'm just Cain." };
+    CHECK_EQ(s.find("p"), native_persistent_string::npos);
+  }
+
+  SUBCASE("Non-empty corpus, missing pattern longer than corpus")
+  {
+    native_persistent_string const s{ "I'm not Abel. I'm just Cain." };
+    CHECK_EQ(s.find("Cupiditate eveniet at alias amet. Placeat facere qui sunt vel voluptas "
+                    "tenetur. Sunt molestias exercitationem repellat aut non qui. Exercitationem "
+                    "iste similique similique ut."),
+             native_persistent_string::npos);
+  }
+}
+
+TEST_CASE("Substring")
+{
+  SUBCASE("Empty corpus, empty substring")
+  {
+    native_persistent_string const s;
+    auto const sub(s.substr());
+    CHECK(sub.empty());
+  }
+
+  SUBCASE("Empty corpus, pos > 0")
+  {
+    native_persistent_string const s;
+    CHECK_THROWS(s.substr(1));
+  }
+
+  SUBCASE("Empty corpus, pos = count, high count")
+  {
+    native_persistent_string const s;
+    auto const sub(s.substr(0, 100));
+    CHECK(sub.empty());
+  }
+
+  SUBCASE("Non-empty corpus, pos = count, high count")
+  {
+    native_persistent_string const s{ "foo bar" };
+    auto const sub(s.substr(7, 100));
+    CHECK(sub.empty());
+  }
+
+  SUBCASE("Non-empty corpus, pos = count, high count")
+  {
+    native_persistent_string const s{ "foo bar" };
+    auto const sub(s.substr(7, 100));
+    CHECK(sub.empty());
+  }
+
+  SUBCASE("SSO")
+  {
+    SUBCASE("Non-empty corpus, prefix")
     {
-      SUBCASE("Default")
-      {
-        native_persistent_string const s;
-        CHECK(s.empty());
-      }
-
-      SUBCASE("Copy")
-      {
-        SUBCASE("SSO")
-        {
-          native_persistent_string const s{ "foo bar" };
-          /* NOLINTNEXTLINE(performance-unnecessary-copy-initialization) */
-          native_persistent_string const c{ s };
-          CHECK_EQ(c.size(), 7);
-          CHECK_NE(c.data(), s.data());
-        }
-
-        SUBCASE("Long")
-        {
-          native_persistent_string const s{ "foo bar spam meow foo bar spam meow" };
-          /* NOLINTNEXTLINE(performance-unnecessary-copy-initialization) */
-          native_persistent_string const c{ s };
-          CHECK_EQ(c.size(), 35);
-          CHECK_EQ(c.data(), s.data());
-        }
-      }
-
-      SUBCASE("C string")
-      {
-        SUBCASE("SSO")
-        {
-          native_persistent_string const s{ "foo bar" };
-          CHECK_EQ(s.size(), 7);
-        }
-
-        SUBCASE("Long")
-        {
-          native_persistent_string const s{ "foo bar spam foo bar spam foo bar spam" };
-          CHECK_EQ(s.size(), 38);
-        }
-      }
+      native_persistent_string const s{ "foo bar" };
+      auto const sub(s.substr(0, 3));
+      CHECK_EQ(sub.size(), 3);
+      CHECK_EQ(sub, "foo");
     }
 
-    TEST_CASE("Find")
+    SUBCASE("Non-empty corpus, suffix")
     {
-      SUBCASE("Empty corpus, empty pattern")
-      {
-        native_persistent_string const s;
-        CHECK_EQ(s.find(""), 0);
-      }
-
-      SUBCASE("Empty corpus")
-      {
-        native_persistent_string const s;
-        CHECK_EQ(s.find("something"), native_persistent_string::npos);
-      }
-
-      SUBCASE("Empty corpus, high pos")
-      {
-        native_persistent_string const s;
-        CHECK_EQ(s.find("something", 10), native_persistent_string::npos);
-      }
-
-      SUBCASE("Non-empty corpus, empty pattern")
-      {
-        native_persistent_string const s{ "foo bar" };
-        CHECK_EQ(s.find(""), 0);
-      }
-
-      SUBCASE("Non-empty corpus, missing pattern")
-      {
-        native_persistent_string const s{ "I'm not Abel. I'm just Cain." };
-        CHECK_EQ(s.find("p"), native_persistent_string::npos);
-      }
-
-      SUBCASE("Non-empty corpus, missing pattern longer than corpus")
-      {
-        native_persistent_string const s{ "I'm not Abel. I'm just Cain." };
-        CHECK_EQ(s.find("Cupiditate eveniet at alias amet. Placeat facere qui sunt vel voluptas tenetur. Sunt molestias exercitationem repellat aut non qui. Exercitationem iste similique similique ut."), native_persistent_string::npos);
-      }
+      native_persistent_string const s{ "foo bar" };
+      auto const sub(s.substr(4, 3));
+      CHECK_EQ(sub.size(), 3);
+      CHECK_EQ(sub, "bar");
+      auto const sub2(s.substr(4));
+      CHECK_EQ(sub2.size(), 3);
+      CHECK_EQ(sub, sub2);
     }
 
-    TEST_CASE("Substring")
+    SUBCASE("Non-empty corpus, middle")
     {
-      SUBCASE("Empty corpus, empty substring")
-      {
-        native_persistent_string const s;
-        auto const sub(s.substr());
-        CHECK(sub.empty());
-      }
-
-      SUBCASE("Empty corpus, pos > 0")
-      {
-        native_persistent_string const s;
-        CHECK_THROWS(s.substr(1));
-      }
-
-      SUBCASE("Empty corpus, pos = count, high count")
-      {
-        native_persistent_string const s;
-        auto const sub(s.substr(0, 100));
-        CHECK(sub.empty());
-      }
-
-      SUBCASE("Non-empty corpus, pos = count, high count")
-      {
-        native_persistent_string const s{ "foo bar" };
-        auto const sub(s.substr(7, 100));
-        CHECK(sub.empty());
-      }
-
-      SUBCASE("Non-empty corpus, pos = count, high count")
-      {
-        native_persistent_string const s{ "foo bar" };
-        auto const sub(s.substr(7, 100));
-        CHECK(sub.empty());
-      }
-
-      SUBCASE("SSO")
-      {
-        SUBCASE("Non-empty corpus, prefix")
-        {
-          native_persistent_string const s{ "foo bar" };
-          auto const sub(s.substr(0, 3));
-          CHECK_EQ(sub.size(), 3);
-          CHECK_EQ(sub, "foo");
-        }
-
-        SUBCASE("Non-empty corpus, suffix")
-        {
-          native_persistent_string const s{ "foo bar" };
-          auto const sub(s.substr(4, 3));
-          CHECK_EQ(sub.size(), 3);
-          CHECK_EQ(sub, "bar");
-          auto const sub2(s.substr(4));
-          CHECK_EQ(sub2.size(), 3);
-          CHECK_EQ(sub, sub2);
-        }
-
-        SUBCASE("Non-empty corpus, middle")
-        {
-          native_persistent_string const s{ "foo bar" };
-          auto const sub(s.substr(2, 3));
-          CHECK_EQ(sub.size(), 3);
-          CHECK_EQ(sub, "o b");
-        }
-      }
-
-      SUBCASE("Long")
-      {
-        SUBCASE("Non-empty corpus, prefix")
-        {
-          native_persistent_string const s{ "foo bar spam meow foo bar spam meow" };
-          auto const sub(s.substr(0, 3));
-          CHECK_EQ(sub.size(), 3);
-          CHECK_EQ(sub, "foo");
-        }
-
-        SUBCASE("Non-empty corpus, suffix")
-        {
-          native_persistent_string const s{ "foo bar spam meow foo bar spam meow" };
-          auto const sub(s.substr(4, 3));
-          CHECK_EQ(sub.size(), 3);
-          CHECK_EQ(sub, "bar");
-          auto const sub2(s.substr(4));
-          CHECK_EQ(sub2, "bar spam meow foo bar spam meow");
-          CHECK_EQ(sub2.substr(0, 3), sub);
-        }
-
-        SUBCASE("Non-empty corpus, middle")
-        {
-          native_persistent_string const s{ "foo bar spam meow foo bar spam meow" };
-          auto const sub(s.substr(2, 3));
-          CHECK_EQ(sub.size(), 3);
-          CHECK_EQ(sub, "o b");
-        }
-      }
+      native_persistent_string const s{ "foo bar" };
+      auto const sub(s.substr(2, 3));
+      CHECK_EQ(sub.size(), 3);
+      CHECK_EQ(sub, "o b");
     }
-  };
+  }
+
+  SUBCASE("Long")
+  {
+    SUBCASE("Non-empty corpus, prefix")
+    {
+      native_persistent_string const s{ "foo bar spam meow foo bar spam meow" };
+      auto const sub(s.substr(0, 3));
+      CHECK_EQ(sub.size(), 3);
+      CHECK_EQ(sub, "foo");
+    }
+
+    SUBCASE("Non-empty corpus, suffix")
+    {
+      native_persistent_string const s{ "foo bar spam meow foo bar spam meow" };
+      auto const sub(s.substr(4, 3));
+      CHECK_EQ(sub.size(), 3);
+      CHECK_EQ(sub, "bar");
+      auto const sub2(s.substr(4));
+      CHECK_EQ(sub2, "bar spam meow foo bar spam meow");
+      CHECK_EQ(sub2.substr(0, 3), sub);
+    }
+
+    SUBCASE("Non-empty corpus, middle")
+    {
+      native_persistent_string const s{ "foo bar spam meow foo bar spam meow" };
+      auto const sub(s.substr(2, 3));
+      CHECK_EQ(sub.size(), 3);
+      CHECK_EQ(sub, "o b");
+    }
+  }
+}
+}
+;
 }

--- a/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
@@ -1,0 +1,40 @@
+/* clang-format off */
+#include <jank/runtime/obj/persistent_string.hpp>
+#include <jank/runtime/obj/character.hpp>
+
+/* This must go last; doctest and glog both define CHECK and family. */
+#include <doctest/doctest.h>
+
+namespace jank
+{
+  TEST_SUITE("persistent_string")
+  {
+    TEST_CASE("Index")
+    {
+      SUBCASE("Present no default")
+      {
+        runtime::obj::persistent_string const s{ "foo bar" };
+        CHECK_EQ(s.get(s, runtime::make_box<runtime::obj::integer>(0)), runtime::make_box<runtime::obj::character>("f"));
+      }
+
+      SUBCASE("Absent no default")
+      {
+        runtime::obj::persistent_string const s{ "foo bar" };
+        CHECK_EQ(s.get(s, runtime::make_box<runtime::obj::integer>(7)), runtime::obj::nil::nil_const());
+      }
+      SUBCASE("Present with default")
+      {
+        runtime::obj::persistent_string const s{ "foo bar" };
+        CHECK_EQ(s.get(s, runtime::make_box<runtime::obj::integer>(0), runtime::make_box<runtime::obj::character>("o")), runtime::make_box<runtime::obj::character>("f"));
+      }
+
+      SUBCASE("Absent with default")
+      {
+        runtime::obj::persistent_string const s{ "foo bar" };
+        CHECK_EQ(s.get(s, runtime::make_box<runtime::obj::integer>(0), runtime::make_box<runtime::obj::character>("o")), runtime::make_box<runtime::obj::character>("f"));
+      }
+      //TODO contains
+      //TODO get_entry
+    }
+  };
+}

--- a/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
@@ -60,7 +60,7 @@ namespace jank::runtime::obj
       }
       catch(std::exception const &e)
       {
-        auto const actual{ fmt::format("{}", e.what()) };
+        std::string const actual{ e.what() };
         auto const expected{ "get_entry not supported on string" };
         CHECK_EQ(actual, expected);
       }

--- a/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
@@ -65,5 +65,5 @@ namespace jank::runtime::obj
         CHECK_EQ(actual, expected);
       }
     }
-  };
+  }
 }

--- a/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
@@ -1,9 +1,4 @@
-#include <fmt/format.h>
-
 #include <jank/runtime/obj/persistent_string.hpp>
-#include <jank/runtime/obj/character.hpp>
-#include <jank/runtime/obj/number.hpp>
-#include <jank/runtime/obj/nil.hpp>
 #include <jank/runtime/core.hpp>
 
 /* This must go last; doctest and glog both define CHECK and family. */

--- a/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
@@ -8,17 +8,17 @@ namespace jank::runtime::obj
 {
   TEST_SUITE("persistent_string")
   {
-    static persistent_string const s{ "foo bar" };
-    static auto const min{ make_box(0) };
-    static auto const min_char{ make_box('f') };
-    static auto const mid{ make_box(3) };
-    static auto const mid_char{ make_box(' ') };
-    static auto const max{ make_box(6) };
-    static auto const max_char{ make_box('r') };
-    static auto const over{ make_box(7) };
-    static auto const under{ make_box(-1) };
-    static auto const nil{ nil::nil_const() };
-    static auto const non_int{ make_box('z') };
+    persistent_string const s{ "foo bar" };
+    auto const min{ make_box(0) };
+    auto const min_char{ make_box('f') };
+    auto const mid{ make_box(3) };
+    auto const mid_char{ make_box(' ') };
+    auto const max{ make_box(6) };
+    auto const max_char{ make_box('r') };
+    auto const over{ make_box(7) };
+    auto const under{ make_box(-1) };
+    auto const nil{ nil::nil_const() };
+    auto const non_int{ make_box('z') };
     TEST_CASE("get")
     {
       CHECK(equal(s.get(min), min_char));

--- a/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
@@ -37,8 +37,34 @@ namespace jank
         runtime::obj::persistent_string const s{ "foo bar" };
         CHECK(runtime::equal(s.get(runtime::make_box<runtime::obj::integer>(0), runtime::make_box<runtime::obj::character>("o")), runtime::make_box<runtime::obj::character>("f")));
       }
-      //TODO contains
-      //TODO get_entry
+
+      SUBCASE("Contains true")
+      {
+        runtime::obj::persistent_string const s{ "foo bar" };
+        CHECK(s.contains(runtime::make_box<runtime::obj::integer>(0)));
+      }
+
+      SUBCASE("Contains false")
+      {
+        runtime::obj::persistent_string const s{ "foo bar" };
+        CHECK(!s.contains(runtime::make_box<runtime::obj::integer>(7)));
+      }
+
+      SUBCASE("get_entry not supported")
+      {
+        runtime::obj::persistent_string const s{ "foo bar" };
+        try
+        {
+          s.get_entry(runtime::make_box<runtime::obj::integer>(0));
+          CHECK(false);
+        }
+        catch(std::exception const &e)
+        {
+          std::string actual = e.what();
+          std::string expected = "get_entry not supported on string";
+          CHECK_EQ(actual, expected);
+        }
+      }
     }
   };
 }

--- a/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
@@ -14,16 +14,16 @@ namespace jank::runtime::obj
   TEST_SUITE("persistent_string")
   {
     persistent_string const s{ "foo bar" };
-    auto const min{ make_box<integer>(0) };
-    auto const min_char{ make_box<character>("f") };
-    auto const mid{ make_box<integer>(3) };
-    auto const mid_char{ make_box<character>(" ") };
-    auto const max{ make_box<integer>(6) };
-    auto const max_char{ make_box<character>("r") };
-    auto const over{ make_box<integer>(7) };
-    auto const under{ make_box<integer>(-1) };
+    auto const min{ make_box(0) };
+    auto const min_char{ make_box('f') };
+    auto const mid{ make_box(3) };
+    auto const mid_char{ make_box(' ') };
+    auto const max{ make_box(6) };
+    auto const max_char{ make_box('r') };
+    auto const over{ make_box(7) };
+    auto const under{ make_box(-1) };
     auto const nil{ nil::nil_const() };
-    auto const non_int{ make_box<character>("z") };
+    auto const non_int{ make_box('z') };
     TEST_CASE("get")
     {
       CHECK(equal(s.get(min), min_char));

--- a/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
@@ -8,17 +8,17 @@ namespace jank::runtime::obj
 {
   TEST_SUITE("persistent_string")
   {
-    persistent_string const s{ "foo bar" };
-    auto const min{ make_box(0) };
-    auto const min_char{ make_box('f') };
-    auto const mid{ make_box(3) };
-    auto const mid_char{ make_box(' ') };
-    auto const max{ make_box(6) };
-    auto const max_char{ make_box('r') };
-    auto const over{ make_box(7) };
-    auto const under{ make_box(-1) };
-    auto const nil{ nil::nil_const() };
-    auto const non_int{ make_box('z') };
+    static persistent_string const s{ "foo bar" };
+    static auto const min{ make_box(0) };
+    static auto const min_char{ make_box('f') };
+    static auto const mid{ make_box(3) };
+    static auto const mid_char{ make_box(' ') };
+    static auto const max{ make_box(6) };
+    static auto const max_char{ make_box('r') };
+    static auto const over{ make_box(7) };
+    static auto const under{ make_box(-1) };
+    static auto const nil{ nil::nil_const() };
+    static auto const non_int{ make_box('z') };
     TEST_CASE("get")
     {
       CHECK(equal(s.get(min), min_char));

--- a/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
@@ -11,28 +11,28 @@ namespace jank
   {
     TEST_CASE("Index")
     {
-      SUBCASE("Present no default")
-      {
-        runtime::obj::persistent_string const s{ "foo bar" };
-        CHECK_EQ(s.get(s, runtime::make_box<runtime::obj::integer>(0)), runtime::make_box<runtime::obj::character>("f"));
-      }
+      //SUBCASE("Present no default")
+      //{
+      //  runtime::obj::persistent_string const s{ "foo bar" };
+      //  CHECK_EQ(s.get(s, runtime::make_box<runtime::obj::integer>(0)), runtime::make_box<runtime::obj::character>("f"));
+      //}
 
-      SUBCASE("Absent no default")
-      {
-        runtime::obj::persistent_string const s{ "foo bar" };
-        CHECK_EQ(s.get(s, runtime::make_box<runtime::obj::integer>(7)), runtime::obj::nil::nil_const());
-      }
-      SUBCASE("Present with default")
-      {
-        runtime::obj::persistent_string const s{ "foo bar" };
-        CHECK_EQ(s.get(s, runtime::make_box<runtime::obj::integer>(0), runtime::make_box<runtime::obj::character>("o")), runtime::make_box<runtime::obj::character>("f"));
-      }
+      //SUBCASE("Absent no default")
+      //{
+      //  runtime::obj::persistent_string const s{ "foo bar" };
+      //  CHECK_EQ(s.get(s, runtime::make_box<runtime::obj::integer>(7)), runtime::obj::nil::nil_const());
+      //}
+      //SUBCASE("Present with default")
+      //{
+      //  runtime::obj::persistent_string const s{ "foo bar" };
+      //  CHECK_EQ(s.get(s, runtime::make_box<runtime::obj::integer>(0), runtime::make_box<runtime::obj::character>("o")), runtime::make_box<runtime::obj::character>("f"));
+      //}
 
-      SUBCASE("Absent with default")
-      {
-        runtime::obj::persistent_string const s{ "foo bar" };
-        CHECK_EQ(s.get(s, runtime::make_box<runtime::obj::integer>(0), runtime::make_box<runtime::obj::character>("o")), runtime::make_box<runtime::obj::character>("f"));
-      }
+      //SUBCASE("Absent with default")
+      //{
+      //  runtime::obj::persistent_string const s{ "foo bar" };
+      //  CHECK_EQ(s.get(s, runtime::make_box<runtime::obj::integer>(0), runtime::make_box<runtime::obj::character>("o")), runtime::make_box<runtime::obj::character>("f"));
+      //}
       //TODO contains
       //TODO get_entry
     }

--- a/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
@@ -16,6 +16,8 @@ namespace jank::runtime::obj
     persistent_string const s{ "foo bar" };
     auto const min{ make_box<integer>(0) };
     auto const min_char{ make_box<character>("f") };
+    auto const mid{ make_box<integer>(3) };
+    auto const mid_char{ make_box<character>(" ") };
     auto const max{ make_box<integer>(6) };
     auto const max_char{ make_box<character>("r") };
     auto const over{ make_box<integer>(7) };
@@ -25,6 +27,7 @@ namespace jank::runtime::obj
     TEST_CASE("get")
     {
       CHECK(equal(s.get(min), min_char));
+      CHECK(equal(s.get(mid), mid_char));
       CHECK(equal(s.get(max), max_char));
       CHECK(equal(s.get(over), nil));
       CHECK(equal(s.get(under), nil));
@@ -33,6 +36,7 @@ namespace jank::runtime::obj
     TEST_CASE("get with fallback")
     {
       CHECK(equal(s.get(min, non_int), min_char));
+      CHECK(equal(s.get(mid, non_int), mid_char));
       CHECK(equal(s.get(max, non_int), max_char));
       CHECK(equal(s.get(over, non_int), non_int));
       CHECK(equal(s.get(under, non_int), non_int));
@@ -41,6 +45,7 @@ namespace jank::runtime::obj
     TEST_CASE("contains")
     {
       CHECK(s.contains(min));
+      CHECK(s.contains(mid));
       CHECK(s.contains(max));
       CHECK(!s.contains(over));
       CHECK(!s.contains(under));

--- a/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
@@ -13,17 +13,17 @@ namespace jank::runtime::obj
 {
   TEST_SUITE("persistent_string")
   {
-    persistent_string const s{ "foo bar" };
-    auto const min{ make_box(0) };
-    auto const min_char{ make_box('f') };
-    auto const mid{ make_box(3) };
-    auto const mid_char{ make_box(' ') };
-    auto const max{ make_box(6) };
-    auto const max_char{ make_box('r') };
-    auto const over{ make_box(7) };
-    auto const under{ make_box(-1) };
-    auto const nil{ nil::nil_const() };
-    auto const non_int{ make_box('z') };
+    static persistent_string const s{ "foo bar" };
+    static auto const min{ make_box(0) };
+    static auto const min_char{ make_box('f') };
+    static auto const mid{ make_box(3) };
+    static auto const mid_char{ make_box(' ') };
+    static auto const max{ make_box(6) };
+    static auto const max_char{ make_box('r') };
+    static auto const over{ make_box(7) };
+    static auto const under{ make_box(-1) };
+    static auto const nil{ nil::nil_const() };
+    static auto const non_int{ make_box('z') };
     TEST_CASE("get")
     {
       CHECK(equal(s.get(min), min_char));

--- a/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
@@ -60,8 +60,8 @@ namespace jank
         }
         catch(std::exception const &e)
         {
-          std::string actual = e.what();
-          std::string expected = "get_entry not supported on string";
+          std::string const actual = e.what();
+          std::string const expected = "get_entry not supported on string";
           CHECK_EQ(actual, expected);
         }
       }

--- a/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
@@ -1,6 +1,9 @@
 /* clang-format off */
 #include <jank/runtime/obj/persistent_string.hpp>
 #include <jank/runtime/obj/character.hpp>
+#include <jank/runtime/obj/number.hpp>
+#include <jank/runtime/obj/nil.hpp>
+#include <jank/runtime/core.hpp>
 
 /* This must go last; doctest and glog both define CHECK and family. */
 #include <doctest/doctest.h>
@@ -11,28 +14,29 @@ namespace jank
   {
     TEST_CASE("Index")
     {
-      //SUBCASE("Present no default")
-      //{
-      //  runtime::obj::persistent_string const s{ "foo bar" };
-      //  CHECK_EQ(s.get(s, runtime::make_box<runtime::obj::integer>(0)), runtime::make_box<runtime::obj::character>("f"));
-      //}
+      SUBCASE("Present no default")
+      {
+        runtime::obj::persistent_string const s{ "foo bar" };
+        CHECK(runtime::equal(s.get(runtime::make_box<runtime::obj::integer>(0)), (runtime::make_box<runtime::obj::character>("f"))));
+      }
 
-      //SUBCASE("Absent no default")
-      //{
-      //  runtime::obj::persistent_string const s{ "foo bar" };
-      //  CHECK_EQ(s.get(s, runtime::make_box<runtime::obj::integer>(7)), runtime::obj::nil::nil_const());
-      //}
-      //SUBCASE("Present with default")
-      //{
-      //  runtime::obj::persistent_string const s{ "foo bar" };
-      //  CHECK_EQ(s.get(s, runtime::make_box<runtime::obj::integer>(0), runtime::make_box<runtime::obj::character>("o")), runtime::make_box<runtime::obj::character>("f"));
-      //}
+      SUBCASE("Absent no default")
+      {
+        runtime::obj::persistent_string const s{ "foo bar" };
+        CHECK(runtime::equal(s.get(runtime::make_box<runtime::obj::integer>(7)), runtime::obj::nil::nil_const()));
+      }
 
-      //SUBCASE("Absent with default")
-      //{
-      //  runtime::obj::persistent_string const s{ "foo bar" };
-      //  CHECK_EQ(s.get(s, runtime::make_box<runtime::obj::integer>(0), runtime::make_box<runtime::obj::character>("o")), runtime::make_box<runtime::obj::character>("f"));
-      //}
+      SUBCASE("Present with default")
+      {
+        runtime::obj::persistent_string const s{ "foo bar" };
+        CHECK(runtime::equal(s.get(runtime::make_box<runtime::obj::integer>(0), runtime::make_box<runtime::obj::character>("o")), runtime::make_box<runtime::obj::character>("f")));
+      }
+
+      SUBCASE("Absent with default")
+      {
+        runtime::obj::persistent_string const s{ "foo bar" };
+        CHECK(runtime::equal(s.get(runtime::make_box<runtime::obj::integer>(0), runtime::make_box<runtime::obj::character>("o")), runtime::make_box<runtime::obj::character>("f")));
+      }
       //TODO contains
       //TODO get_entry
     }

--- a/compiler+runtime/test/cpp/jank/runtime/obj/persistent_vector.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/persistent_vector.cpp
@@ -1,0 +1,67 @@
+#include <jank/runtime/obj/character.hpp>
+#include <jank/runtime/obj/number.hpp>
+#include <jank/runtime/obj/nil.hpp>
+#include <jank/runtime/core.hpp>
+#include <jank/runtime/context.hpp>
+
+/* This must go last; doctest and glog both define CHECK and family. */
+#include <doctest/doctest.h>
+
+namespace jank::runtime::obj
+{
+  TEST_SUITE("persistent_vector")
+  {
+    persistent_vector_ptr const v(persistent_vector::create(nullptr)
+        ->conj(make_box('f'))
+        ->conj(make_box('o'))
+        ->conj(make_box('o'))
+        ->conj(make_box(' '))
+        ->conj(make_box('b'))
+        ->conj(make_box('a'))
+        ->conj(make_box('r'))
+        );
+    auto const min{ make_box(0) };
+    auto const min_char{ make_box('f') };
+    auto const mid{ make_box(3) };
+    auto const mid_char{ make_box(' ') };
+    auto const max{ make_box(6) };
+    auto const max_char{ make_box('r') };
+    auto const over{ make_box(7) };
+    auto const under{ make_box(-1) };
+    auto const nil{ nil::nil_const() };
+    auto const non_int{ make_box('z') };
+
+    TEST_CASE("get")
+    {
+      CHECK(equal(get(v, min), min_char));
+      CHECK(equal(get(v, mid), mid_char));
+      CHECK(equal(get(v, max), max_char));
+      CHECK(equal(get(v, over), nil));
+      CHECK(equal(get(v, under), nil));
+      CHECK(equal(get(v, non_int), nil));
+    }
+    TEST_CASE("get with fallback")
+    {
+      CHECK(equal(get(v, min, non_int), min_char));
+      CHECK(equal(get(v, mid, non_int), mid_char));
+      CHECK(equal(get(v, max, non_int), max_char));
+      CHECK(equal(get(v, over, non_int), non_int));
+      CHECK(equal(get(v, under, non_int), non_int));
+      CHECK(equal(get(v, non_int, non_int), non_int));
+    }
+    TEST_CASE("contains")
+    {
+      CHECK( contains(v, min));
+      CHECK( contains(v, mid));
+      CHECK( contains(v, max));
+      CHECK(!contains(v, over));
+      CHECK(!contains(v, under));
+      CHECK(!contains(v, non_int));
+    }
+    TEST_CASE("get_entry")
+    {
+      //FIXME
+      //CHECK(equal(find(v, min)), nil);
+    }
+  };
+}

--- a/compiler+runtime/test/cpp/jank/runtime/obj/persistent_vector.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/persistent_vector.cpp
@@ -8,15 +8,14 @@ namespace jank::runtime::obj
 {
   TEST_SUITE("persistent_vector")
   {
-    static auto const v{
-      make_box<persistent_vector>(std::in_place,
-          make_box('f'),
-          make_box('o'),
-          make_box('o'),
-          make_box(' '),
-          make_box('b'),
-          make_box('a'),
-          make_box('r')) };
+    static auto const v{ make_box<persistent_vector>(std::in_place,
+                                                     make_box('f'),
+                                                     make_box('o'),
+                                                     make_box('o'),
+                                                     make_box(' '),
+                                                     make_box('b'),
+                                                     make_box('a'),
+                                                     make_box('r')) };
     static auto const min{ make_box(0) };
     static auto const min_char{ make_box('f') };
     static auto const mid{ make_box(3) };
@@ -57,12 +56,9 @@ namespace jank::runtime::obj
     }
     TEST_CASE("get_entry")
     {
-      CHECK(equal(v->get_entry(min),
-                  make_box<persistent_vector>(std::in_place, min, min_char)));
-      CHECK(equal(v->get_entry(mid),
-                  make_box<persistent_vector>(std::in_place, mid, mid_char)));
-      CHECK(equal(v->get_entry(max),
-                  make_box<persistent_vector>(std::in_place, max, max_char)));
+      CHECK(equal(v->get_entry(min), make_box<persistent_vector>(std::in_place, min, min_char)));
+      CHECK(equal(v->get_entry(mid), make_box<persistent_vector>(std::in_place, mid, mid_char)));
+      CHECK(equal(v->get_entry(max), make_box<persistent_vector>(std::in_place, max, max_char)));
       CHECK(equal(v->get_entry(over), nil));
       CHECK(equal(v->get_entry(under), nil));
       CHECK(equal(v->get_entry(non_int), nil));

--- a/compiler+runtime/test/cpp/jank/runtime/obj/persistent_vector.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/persistent_vector.cpp
@@ -1,7 +1,3 @@
-#include <jank/runtime/obj/character.hpp>
-#include <jank/runtime/obj/number.hpp>
-#include <jank/runtime/obj/nil.hpp>
-#include <jank/runtime/core.hpp>
 #include <jank/runtime/context.hpp>
 
 /* This must go last; doctest and glog both define CHECK and family. */

--- a/compiler+runtime/test/cpp/jank/runtime/obj/persistent_vector.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/persistent_vector.cpp
@@ -1,4 +1,6 @@
-#include <jank/runtime/context.hpp>
+#include <jank/runtime/obj/persistent_vector.hpp>
+#include <jank/runtime/core/make_box.hpp>
+#include <jank/runtime/core/seq.hpp>
 
 /* This must go last; doctest and glog both define CHECK and family. */
 #include <doctest/doctest.h>

--- a/compiler+runtime/test/cpp/jank/runtime/obj/persistent_vector.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/persistent_vector.cpp
@@ -11,24 +11,24 @@ namespace jank::runtime::obj
 {
   TEST_SUITE("persistent_vector")
   {
-    persistent_vector_ptr const v(persistent_vector::create(nullptr)
-                                    ->conj(make_box('f'))
-                                    ->conj(make_box('o'))
-                                    ->conj(make_box('o'))
-                                    ->conj(make_box(' '))
-                                    ->conj(make_box('b'))
-                                    ->conj(make_box('a'))
-                                    ->conj(make_box('r')));
-    auto const min{ make_box(0) };
-    auto const min_char{ make_box('f') };
-    auto const mid{ make_box(3) };
-    auto const mid_char{ make_box(' ') };
-    auto const max{ make_box(6) };
-    auto const max_char{ make_box('r') };
-    auto const over{ make_box(7) };
-    auto const under{ make_box(-1) };
-    auto const nil{ nil::nil_const() };
-    auto const non_int{ make_box('z') };
+    static persistent_vector_ptr const v(persistent_vector::create(nullptr)
+                                           ->conj(make_box('f'))
+                                           ->conj(make_box('o'))
+                                           ->conj(make_box('o'))
+                                           ->conj(make_box(' '))
+                                           ->conj(make_box('b'))
+                                           ->conj(make_box('a'))
+                                           ->conj(make_box('r')));
+    static auto const min{ make_box(0) };
+    static auto const min_char{ make_box('f') };
+    static auto const mid{ make_box(3) };
+    static auto const mid_char{ make_box(' ') };
+    static auto const max{ make_box(6) };
+    static auto const max_char{ make_box('r') };
+    static auto const over{ make_box(7) };
+    static auto const under{ make_box(-1) };
+    static auto const nil{ nil::nil_const() };
+    static auto const non_int{ make_box('z') };
 
     TEST_CASE("get")
     {

--- a/compiler+runtime/test/cpp/jank/runtime/obj/persistent_vector.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/persistent_vector.cpp
@@ -61,11 +61,11 @@ namespace jank::runtime::obj
     TEST_CASE("find")
     {
       CHECK(equal(find(v, min),
-                  persistent_vector::empty()->conj(make_box(min))->conj(make_box(min_char))));
+                  make_box<persistent_vector>(std::in_place, min, min_char)));
       CHECK(equal(find(v, mid),
-                  persistent_vector::empty()->conj(make_box(mid))->conj(make_box(mid_char))));
+                  make_box<persistent_vector>(std::in_place, mid, mid_char)));
       CHECK(equal(find(v, max),
-                  persistent_vector::empty()->conj(make_box(max))->conj(make_box(max_char))));
+                  make_box<persistent_vector>(std::in_place, max, max_char)));
       CHECK(equal(find(v, over), nil));
       CHECK(equal(find(v, under), nil));
       CHECK(equal(find(v, non_int), nil));

--- a/compiler+runtime/test/cpp/jank/runtime/obj/persistent_vector.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/persistent_vector.cpp
@@ -8,24 +8,24 @@ namespace jank::runtime::obj
 {
   TEST_SUITE("persistent_vector")
   {
-    static auto const v{ make_box<persistent_vector>(std::in_place,
-                                                     make_box('f'),
-                                                     make_box('o'),
-                                                     make_box('o'),
-                                                     make_box(' '),
-                                                     make_box('b'),
-                                                     make_box('a'),
-                                                     make_box('r')) };
-    static auto const min{ make_box(0) };
-    static auto const min_char{ make_box('f') };
-    static auto const mid{ make_box(3) };
-    static auto const mid_char{ make_box(' ') };
-    static auto const max{ make_box(6) };
-    static auto const max_char{ make_box('r') };
-    static auto const over{ make_box(7) };
-    static auto const under{ make_box(-1) };
-    static auto const nil{ nil::nil_const() };
-    static auto const non_int{ make_box('z') };
+    auto const v{ make_box<persistent_vector>(std::in_place,
+                                              make_box('f'),
+                                              make_box('o'),
+                                              make_box('o'),
+                                              make_box(' '),
+                                              make_box('b'),
+                                              make_box('a'),
+                                              make_box('r')) };
+    auto const min{ make_box(0) };
+    auto const min_char{ make_box('f') };
+    auto const mid{ make_box(3) };
+    auto const mid_char{ make_box(' ') };
+    auto const max{ make_box(6) };
+    auto const max_char{ make_box('r') };
+    auto const over{ make_box(7) };
+    auto const under{ make_box(-1) };
+    auto const nil{ nil::nil_const() };
+    auto const non_int{ make_box('z') };
 
     TEST_CASE("get")
     {

--- a/compiler+runtime/test/cpp/jank/runtime/obj/persistent_vector.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/persistent_vector.cpp
@@ -11,14 +11,15 @@ namespace jank::runtime::obj
 {
   TEST_SUITE("persistent_vector")
   {
-    static persistent_vector_ptr const v(persistent_vector::empty()
-                                           ->conj(make_box('f'))
-                                           ->conj(make_box('o'))
-                                           ->conj(make_box('o'))
-                                           ->conj(make_box(' '))
-                                           ->conj(make_box('b'))
-                                           ->conj(make_box('a'))
-                                           ->conj(make_box('r')));
+    static auto const v{
+      make_box<persistent_vector>(std::in_place,
+          make_box('f'),
+          make_box('o'),
+          make_box('o'),
+          make_box(' '),
+          make_box('b'),
+          make_box('a'),
+          make_box('r')) };
     static auto const min{ make_box(0) };
     static auto const min_char{ make_box('f') };
     static auto const mid{ make_box(3) };

--- a/compiler+runtime/test/cpp/jank/runtime/obj/persistent_vector.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/persistent_vector.cpp
@@ -12,14 +12,13 @@ namespace jank::runtime::obj
   TEST_SUITE("persistent_vector")
   {
     persistent_vector_ptr const v(persistent_vector::create(nullptr)
-        ->conj(make_box('f'))
-        ->conj(make_box('o'))
-        ->conj(make_box('o'))
-        ->conj(make_box(' '))
-        ->conj(make_box('b'))
-        ->conj(make_box('a'))
-        ->conj(make_box('r'))
-        );
+                                    ->conj(make_box('f'))
+                                    ->conj(make_box('o'))
+                                    ->conj(make_box('o'))
+                                    ->conj(make_box(' '))
+                                    ->conj(make_box('b'))
+                                    ->conj(make_box('a'))
+                                    ->conj(make_box('r')));
     auto const min{ make_box(0) };
     auto const min_char{ make_box('f') };
     auto const mid{ make_box(3) };
@@ -51,9 +50,9 @@ namespace jank::runtime::obj
     }
     TEST_CASE("contains")
     {
-      CHECK( contains(v, min));
-      CHECK( contains(v, mid));
-      CHECK( contains(v, max));
+      CHECK(contains(v, min));
+      CHECK(contains(v, mid));
+      CHECK(contains(v, max));
       CHECK(!contains(v, over));
       CHECK(!contains(v, under));
       CHECK(!contains(v, non_int));
@@ -63,5 +62,5 @@ namespace jank::runtime::obj
       //FIXME
       //CHECK(equal(find(v, min)), nil);
     }
-  };
+  }
 }

--- a/compiler+runtime/test/cpp/jank/runtime/obj/persistent_vector.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/persistent_vector.cpp
@@ -8,24 +8,24 @@ namespace jank::runtime::obj
 {
   TEST_SUITE("persistent_vector")
   {
-    auto const v{ make_box<persistent_vector>(std::in_place,
-                                              make_box('f'),
-                                              make_box('o'),
-                                              make_box('o'),
-                                              make_box(' '),
-                                              make_box('b'),
-                                              make_box('a'),
-                                              make_box('r')) };
-    auto const min{ make_box(0) };
-    auto const min_char{ make_box('f') };
-    auto const mid{ make_box(3) };
-    auto const mid_char{ make_box(' ') };
-    auto const max{ make_box(6) };
-    auto const max_char{ make_box('r') };
-    auto const over{ make_box(7) };
-    auto const under{ make_box(-1) };
-    auto const nil{ nil::nil_const() };
-    auto const non_int{ make_box('z') };
+    static auto const v{ make_box<persistent_vector>(std::in_place,
+                                                     make_box('f'),
+                                                     make_box('o'),
+                                                     make_box('o'),
+                                                     make_box(' '),
+                                                     make_box('b'),
+                                                     make_box('a'),
+                                                     make_box('r')) };
+    static auto const min{ make_box(0) };
+    static auto const min_char{ make_box('f') };
+    static auto const mid{ make_box(3) };
+    static auto const mid_char{ make_box(' ') };
+    static auto const max{ make_box(6) };
+    static auto const max_char{ make_box('r') };
+    static auto const over{ make_box(7) };
+    static auto const under{ make_box(-1) };
+    static auto const nil{ nil::nil_const() };
+    static auto const non_int{ make_box('z') };
 
     TEST_CASE("get")
     {

--- a/compiler+runtime/test/cpp/jank/runtime/obj/persistent_vector.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/persistent_vector.cpp
@@ -59,15 +59,12 @@ namespace jank::runtime::obj
     }
     TEST_CASE("find")
     {
-      CHECK(
-        equal(find(v, min),
-              persistent_vector::create(nullptr)->conj(make_box(min))->conj(make_box(min_char))));
-      CHECK(
-        equal(find(v, mid),
-              persistent_vector::create(nullptr)->conj(make_box(mid))->conj(make_box(mid_char))));
-      CHECK(
-        equal(find(v, max),
-              persistent_vector::create(nullptr)->conj(make_box(max))->conj(make_box(max_char))));
+      CHECK(equal(find(v, min),
+                  persistent_vector::empty()->conj(make_box(min))->conj(make_box(min_char))));
+      CHECK(equal(find(v, mid),
+                  persistent_vector::empty()->conj(make_box(mid))->conj(make_box(mid_char))));
+      CHECK(equal(find(v, max),
+                  persistent_vector::empty()->conj(make_box(max))->conj(make_box(max_char))));
       CHECK(equal(find(v, over), nil));
       CHECK(equal(find(v, under), nil));
       CHECK(equal(find(v, non_int), nil));

--- a/compiler+runtime/test/cpp/jank/runtime/obj/persistent_vector.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/persistent_vector.cpp
@@ -11,7 +11,7 @@ namespace jank::runtime::obj
 {
   TEST_SUITE("persistent_vector")
   {
-    static persistent_vector_ptr const v(persistent_vector::create(nullptr)
+    static persistent_vector_ptr const v(persistent_vector::empty()
                                            ->conj(make_box('f'))
                                            ->conj(make_box('o'))
                                            ->conj(make_box('o'))

--- a/compiler+runtime/test/cpp/jank/runtime/obj/persistent_vector.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/persistent_vector.cpp
@@ -57,10 +57,20 @@ namespace jank::runtime::obj
       CHECK(!contains(v, under));
       CHECK(!contains(v, non_int));
     }
-    TEST_CASE("get_entry")
+    TEST_CASE("find")
     {
-      //FIXME
-      //CHECK(equal(find(v, min)), nil);
+      CHECK(
+        equal(find(v, min),
+              persistent_vector::create(nullptr)->conj(make_box(min))->conj(make_box(min_char))));
+      CHECK(
+        equal(find(v, mid),
+              persistent_vector::create(nullptr)->conj(make_box(mid))->conj(make_box(mid_char))));
+      CHECK(
+        equal(find(v, max),
+              persistent_vector::create(nullptr)->conj(make_box(max))->conj(make_box(max_char))));
+      CHECK(equal(find(v, over), nil));
+      CHECK(equal(find(v, under), nil));
+      CHECK(equal(find(v, non_int), nil));
     }
   }
 }

--- a/compiler+runtime/test/cpp/jank/runtime/obj/persistent_vector.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/persistent_vector.cpp
@@ -1,6 +1,5 @@
 #include <jank/runtime/obj/persistent_vector.hpp>
 #include <jank/runtime/core/make_box.hpp>
-#include <jank/runtime/core/seq.hpp>
 
 /* This must go last; doctest and glog both define CHECK and family. */
 #include <doctest/doctest.h>
@@ -31,42 +30,42 @@ namespace jank::runtime::obj
 
     TEST_CASE("get")
     {
-      CHECK(equal(get(v, min), min_char));
-      CHECK(equal(get(v, mid), mid_char));
-      CHECK(equal(get(v, max), max_char));
-      CHECK(equal(get(v, over), nil));
-      CHECK(equal(get(v, under), nil));
-      CHECK(equal(get(v, non_int), nil));
+      CHECK(equal(v->get(min), min_char));
+      CHECK(equal(v->get(mid), mid_char));
+      CHECK(equal(v->get(max), max_char));
+      CHECK(equal(v->get(over), nil));
+      CHECK(equal(v->get(under), nil));
+      CHECK(equal(v->get(non_int), nil));
     }
     TEST_CASE("get with fallback")
     {
-      CHECK(equal(get(v, min, non_int), min_char));
-      CHECK(equal(get(v, mid, non_int), mid_char));
-      CHECK(equal(get(v, max, non_int), max_char));
-      CHECK(equal(get(v, over, non_int), non_int));
-      CHECK(equal(get(v, under, non_int), non_int));
-      CHECK(equal(get(v, non_int, non_int), non_int));
+      CHECK(equal(v->get(min, non_int), min_char));
+      CHECK(equal(v->get(mid, non_int), mid_char));
+      CHECK(equal(v->get(max, non_int), max_char));
+      CHECK(equal(v->get(over, non_int), non_int));
+      CHECK(equal(v->get(under, non_int), non_int));
+      CHECK(equal(v->get(non_int, non_int), non_int));
     }
     TEST_CASE("contains")
     {
-      CHECK(contains(v, min));
-      CHECK(contains(v, mid));
-      CHECK(contains(v, max));
-      CHECK(!contains(v, over));
-      CHECK(!contains(v, under));
-      CHECK(!contains(v, non_int));
+      CHECK(v->contains(min));
+      CHECK(v->contains(mid));
+      CHECK(v->contains(max));
+      CHECK(!v->contains(over));
+      CHECK(!v->contains(under));
+      CHECK(!v->contains(non_int));
     }
-    TEST_CASE("find")
+    TEST_CASE("get_entry")
     {
-      CHECK(equal(find(v, min),
+      CHECK(equal(v->get_entry(min),
                   make_box<persistent_vector>(std::in_place, min, min_char)));
-      CHECK(equal(find(v, mid),
+      CHECK(equal(v->get_entry(mid),
                   make_box<persistent_vector>(std::in_place, mid, mid_char)));
-      CHECK(equal(find(v, max),
+      CHECK(equal(v->get_entry(max),
                   make_box<persistent_vector>(std::in_place, max, max_char)));
-      CHECK(equal(find(v, over), nil));
-      CHECK(equal(find(v, under), nil));
-      CHECK(equal(find(v, non_int), nil));
+      CHECK(equal(v->get_entry(over), nil));
+      CHECK(equal(v->get_entry(under), nil));
+      CHECK(equal(v->get_entry(non_int), nil));
     }
   }
 }


### PR DESCRIPTION
Closes #225 

Followed Clojure on the implementation of `get_entry`, which throws. CLJS returns nil on `(find "a" 0)`.

```clojure
clojure.core=> (get "a" 0)
\a
clojure.core=> (contains? "a" 0)
true
clojure.core=> (find "a" 0)
Exception: get_entry not supported on string
```