### PR TITLE
(nthnext c 0) returns (seq c)

### DIFF
--- a/compiler+runtime/src/jank/clojure/core.jank
+++ b/compiler+runtime/src/jank/clojure/core.jank
@@ -2001,7 +2001,7 @@
   [coll n]
   (if (and (seq coll) (pos? n))
     (recur (next coll) (dec n))
-    coll))
+    (seq coll)))
 
 (defn nthrest
   "Returns the nth rest of coll, coll when n is 0."


### PR DESCRIPTION
Closes https://github.com/jank-lang/jank/issues/216

```
clojure.core=> (nthnext "abc" 0)
(\a \b \c)
```
