### PR TITLE
Don't escape `?` or `\?` in strings

### DIFF
--- a/compiler+runtime/CMakeLists.txt
+++ b/compiler+runtime/CMakeLists.txt
@@ -434,6 +434,7 @@ if(jank_tests)
     test/cpp/jank/read/parse.cpp
     test/cpp/jank/analyze/box.cpp
     test/cpp/jank/runtime/detail/native_persistent_list.cpp
+    test/cpp/jank/runtime/obj/persistent_string.cpp
     test/cpp/jank/runtime/obj/ratio.cpp
     test/cpp/jank/jit/processor.cpp
   )

--- a/compiler+runtime/src/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/src/cpp/jank/read/lex.cpp
@@ -940,7 +940,7 @@ namespace jank::read
             {
               return err(std::move(e.unwrap()));
             }
-            auto const token_start(pos);
+            auto token_start(pos);
             native_bool escaped{}, contains_escape{};
             while(true)
             {
@@ -960,8 +960,10 @@ namespace jank::read
               {
                 switch(oc.expect_ok().character)
                 {
-                  case '"':
                   case '?':
+                    contains_escape = false;
+                    ++token_start;
+                  case '"':
                   case '\'':
                   case '\\':
                   case 'a':

--- a/compiler+runtime/src/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/src/cpp/jank/read/lex.cpp
@@ -940,7 +940,7 @@ namespace jank::read
             {
               return err(std::move(e.unwrap()));
             }
-            auto token_start(pos);
+            auto const token_start(pos);
             native_bool escaped{}, contains_escape{};
             while(true)
             {
@@ -960,10 +960,8 @@ namespace jank::read
               {
                 switch(oc.expect_ok().character)
                 {
-                  case '?':
-                    contains_escape = false;
-                    ++token_start;
                   case '"':
+                  case '?':
                   case '\'':
                   case '\\':
                   case 'a':

--- a/compiler+runtime/src/cpp/jank/util/escape.cpp
+++ b/compiler+runtime/src/cpp/jank/util/escape.cpp
@@ -5,18 +5,7 @@
 
 namespace jank::util
 {
-  /* Converts escape sequences (2 characters) to their mapped (single) character:
-   *  \n => '\n'
-   *  \t => '\t'
-   *  \r => '\r'
-   *  \\ => '\\'
-   *  \" => '"'
-   *  \a => '\a'
-   *  \v => '\v'
-   *  \? => '?'
-   *  \f => '\f'
-   *  \b => '\b'
-   * */
+  /* Converts escape sequences starting with backslash to their mapped character. e.g., \" => " */
   result<native_persistent_string, unescape_error> unescape(native_persistent_string const &input)
   {
     util::string_builder sb{ input.size() };
@@ -79,17 +68,7 @@ namespace jank::util
     return ok(sb.release());
   }
 
-  /* Converts the following (single) characters to their escape sequences (2 characters):
-   *  '\n' => \n
-   *  '\t' => \t
-   *  '\r' => \r
-   *  '\\' => \\
-   *  '"'  => \"
-   *  '\a' => \a
-   *  '\v' => \v
-   *  '\f' => \f
-   *  '\b' => \b
-   * */
+  /* Converts special characters to their escape sequences. e.g., " => \" */
   native_persistent_string escape(native_persistent_string const &input)
   {
     /* We can expect on relocation, since escaping anything will result in a larger string.

--- a/compiler+runtime/src/cpp/jank/util/escape.cpp
+++ b/compiler+runtime/src/cpp/jank/util/escape.cpp
@@ -48,6 +48,9 @@ namespace jank::util
           case 'v':
             sb('\v');
             break;
+          case '?':
+            sb('?');
+            break;
           case 'f':
             sb('\f');
             break;

--- a/compiler+runtime/src/cpp/jank/util/escape.cpp
+++ b/compiler+runtime/src/cpp/jank/util/escape.cpp
@@ -69,7 +69,7 @@ namespace jank::util
 
   native_persistent_string escape(native_persistent_string const &input)
   {
-    /* We can expect on relocation, since escaping anything bar \? will result in a larger string.
+    /* We can expect on relocation, since escaping results in an equal or larger length string.
      * I'm not going to guess at the stats, to predict a better allocation, until this shows
      * up in the profiler, though. */
     util::string_builder sb{ input.size() };

--- a/compiler+runtime/src/cpp/jank/util/escape.cpp
+++ b/compiler+runtime/src/cpp/jank/util/escape.cpp
@@ -49,7 +49,7 @@ namespace jank::util
             sb('\v');
             break;
           case '?':
-            sb('?');
+            sb('\?');
             break;
           case 'f':
             sb('\f');
@@ -105,9 +105,6 @@ namespace jank::util
         case '\v':
           sb('\\');
           sb('v');
-          break;
-        case '\?':
-          sb('?');
           break;
         case '\f':
           sb('\\');

--- a/compiler+runtime/src/cpp/jank/util/escape.cpp
+++ b/compiler+runtime/src/cpp/jank/util/escape.cpp
@@ -5,6 +5,18 @@
 
 namespace jank::util
 {
+  /* Converts escape sequences (2 characters) to their mapped (single) character:
+   *  \n => '\n'
+   *  \t => '\t'
+   *  \r => '\r'
+   *  \\ => '\\'
+   *  \" => '"'
+   *  \a => '\a'
+   *  \v => '\v'
+   *  \? => '?'
+   *  \f => '\f'
+   *  \b => '\b'
+   * */
   result<native_persistent_string, unescape_error> unescape(native_persistent_string const &input)
   {
     util::string_builder sb{ input.size() };
@@ -67,9 +79,20 @@ namespace jank::util
     return ok(sb.release());
   }
 
+  /* Converts the following (single) characters to their escape sequences (2 characters):
+   *  '\n' => \n
+   *  '\t' => \t
+   *  '\r' => \r
+   *  '\\' => \\
+   *  '"'  => \"
+   *  '\a' => \a
+   *  '\v' => \v
+   *  '\f' => \f
+   *  '\b' => \b
+   * */
   native_persistent_string escape(native_persistent_string const &input)
   {
-    /* We can expect on relocation, since escaping results in an equal or larger length string.
+    /* We can expect on relocation, since escaping anything will result in a larger string.
      * I'm not going to guess at the stats, to predict a better allocation, until this shows
      * up in the profiler, though. */
     util::string_builder sb{ input.size() };

--- a/compiler+runtime/src/cpp/jank/util/escape.cpp
+++ b/compiler+runtime/src/cpp/jank/util/escape.cpp
@@ -69,7 +69,7 @@ namespace jank::util
 
   native_persistent_string escape(native_persistent_string const &input)
   {
-    /* We can expect on relocation, since escaping anything will result in a larger string.
+    /* We can expect on relocation, since escaping anything bar \? will result in a larger string.
      * I'm not going to guess at the stats, to predict a better allocation, until this shows
      * up in the profiler, though. */
     util::string_builder sb{ input.size() };

--- a/compiler+runtime/src/cpp/jank/util/escape.cpp
+++ b/compiler+runtime/src/cpp/jank/util/escape.cpp
@@ -48,9 +48,6 @@ namespace jank::util
           case 'v':
             sb('\v');
             break;
-          case '?':
-            sb('\?');
-            break;
           case 'f':
             sb('\f');
             break;
@@ -107,7 +104,6 @@ namespace jank::util
           sb('v');
           break;
         case '\?':
-          sb('\\');
           sb('?');
           break;
         case '\f':

--- a/compiler+runtime/src/cpp/jank/util/escape.cpp
+++ b/compiler+runtime/src/cpp/jank/util/escape.cpp
@@ -49,7 +49,7 @@ namespace jank::util
             sb('\v');
             break;
           case '?':
-            sb('\?');
+            sb('?');
             break;
           case 'f':
             sb('\f');

--- a/compiler+runtime/test/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/test/cpp/jank/read/lex.cpp
@@ -1444,6 +1444,15 @@ namespace jank::read::lex
                 { 0, 3, token_kind::string, "a"sv }
         }));
       }
+      SUBCASE("Question mark")
+      {
+        processor p{ "\"?\"" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 3, token_kind::string, "?"sv }
+        }));
+      }
 
       SUBCASE("Multi-char")
       {

--- a/compiler+runtime/test/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/test/cpp/jank/read/lex.cpp
@@ -1444,15 +1444,6 @@ namespace jank::read::lex
                 { 0, 3, token_kind::string, "a"sv }
         }));
       }
-      SUBCASE("Question mark")
-      {
-        processor p{ "\"?\"" };
-        native_vector<result<token, error>> const tokens(p.begin(), p.end());
-        CHECK(tokens
-              == make_tokens({
-                { 0, 3, token_kind::string, "?"sv }
-        }));
-      }
 
       SUBCASE("Multi-char")
       {

--- a/compiler+runtime/test/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/test/cpp/jank/read/lex.cpp
@@ -1507,7 +1507,7 @@ namespace jank::read::lex
         native_vector<result<token, error>> const tokens2(q.begin(), q.end());
         CHECK(tokens2
               == make_tokens({
-                { 0, 26, token_kind::escaped_string, "\\\?\?\\' \\\\ a\\a b\\b f\\f v\\v"sv }
+                { 0, 26, token_kind::escaped_string, "\\??\\' \\\\ a\\a b\\b f\\f v\\v"sv }
         }));
       }
 

--- a/compiler+runtime/test/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/test/cpp/jank/read/lex.cpp
@@ -1498,7 +1498,7 @@ namespace jank::read::lex
         native_vector<result<token, error>> const tokens2(q.begin(), q.end());
         CHECK(tokens2
               == make_tokens({
-                { 1, 25, token_kind::escaped_string, "??\\' \\\\ a\\a b\\b f\\f v\\v"sv }
+                { 0, 26, token_kind::escaped_string, "\\\?\?\\' \\\\ a\\a b\\b f\\f v\\v"sv }
         }));
       }
 

--- a/compiler+runtime/test/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/test/cpp/jank/read/lex.cpp
@@ -1455,7 +1455,7 @@ namespace jank::read::lex
       }
       SUBCASE("Escaped Question mark")
       {
-        processor p{ "\"\\?\"" };
+        processor p{ R"("\?")" };
         native_vector<result<token, error>> const tokens(p.begin(), p.end());
         CHECK(tokens
               == make_tokens({

--- a/compiler+runtime/test/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/test/cpp/jank/read/lex.cpp
@@ -1444,6 +1444,24 @@ namespace jank::read::lex
                 { 0, 3, token_kind::string, "a"sv }
         }));
       }
+      SUBCASE("Question mark")
+      {
+        processor p{ "\"?\"" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 3, token_kind::string, "?"sv }
+        }));
+      }
+      SUBCASE("Escaped Question mark")
+      {
+        processor p{ "\"\\?\"" };
+        native_vector<result<token, error>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 4, token_kind::escaped_string, "\\?"sv }
+        }));
+      }
 
       SUBCASE("Multi-char")
       {

--- a/compiler+runtime/test/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/test/cpp/jank/read/lex.cpp
@@ -1498,7 +1498,7 @@ namespace jank::read::lex
         native_vector<result<token, error>> const tokens2(q.begin(), q.end());
         CHECK(tokens2
               == make_tokens({
-                { 0, 26, token_kind::escaped_string, "\\??\\' \\\\ a\\a b\\b f\\f v\\v"sv }
+                { 1, 25, token_kind::escaped_string, "??\\' \\\\ a\\a b\\b f\\f v\\v"sv }
         }));
       }
 

--- a/compiler+runtime/test/cpp/jank/read/parse.cpp
+++ b/compiler+runtime/test/cpp/jank/read/parse.cpp
@@ -353,6 +353,19 @@ namespace jank::read::parse
           offset += len + 1;
         }
       }
+
+      SUBCASE("Escaped ? becomes ?")
+      {
+        lex::processor lp{ R"("\?")" };
+        processor p{ lp.begin(), lp.end() };
+        auto const &s{ "?" };
+        auto const r(p.next());
+        CHECK(equal(r.expect_ok().unwrap().ptr, make_box(s)));
+        auto const escaped(util::escape(s));
+        CHECK(r.expect_ok().unwrap().start
+              == lex::token{ 1, 3, lex::token_kind::string, "?" });
+        CHECK(r.expect_ok().unwrap().end == r.expect_ok().unwrap().start);
+      }
     }
 
     TEST_CASE("Symbol")

--- a/compiler+runtime/test/cpp/jank/read/parse.cpp
+++ b/compiler+runtime/test/cpp/jank/read/parse.cpp
@@ -358,9 +358,8 @@ namespace jank::read::parse
       {
         lex::processor lp{ R"("\?")" };
         processor p{ lp.begin(), lp.end() };
-        auto const &s{ "?" };
         auto const r(p.next());
-        CHECK(equal(r.expect_ok().unwrap().ptr, make_box(s)));
+        CHECK(equal(r.expect_ok().unwrap().ptr, make_box("?")));
         CHECK(r.expect_ok().unwrap().start
               == lex::token{ 0, 4, lex::token_kind::escaped_string, "\\?" });
         CHECK(r.expect_ok().unwrap().end == r.expect_ok().unwrap().start);

--- a/compiler+runtime/test/cpp/jank/read/parse.cpp
+++ b/compiler+runtime/test/cpp/jank/read/parse.cpp
@@ -361,9 +361,8 @@ namespace jank::read::parse
         auto const &s{ "?" };
         auto const r(p.next());
         CHECK(equal(r.expect_ok().unwrap().ptr, make_box(s)));
-        auto const escaped(util::escape(s));
         CHECK(r.expect_ok().unwrap().start
-              == lex::token{ 1, 3, lex::token_kind::string, "?" });
+              == lex::token{ 0, 4, lex::token_kind::escaped_string, "\\?" });
         CHECK(r.expect_ok().unwrap().end == r.expect_ok().unwrap().start);
       }
     }

--- a/compiler+runtime/test/cpp/jank/read/parse.cpp
+++ b/compiler+runtime/test/cpp/jank/read/parse.cpp
@@ -315,11 +315,11 @@ namespace jank::read::parse
     {
       SUBCASE("Unescaped")
       {
-        lex::processor lp{ R"("foo" "bar")" };
+        lex::processor lp{ R"("foo" "bar" "?")" };
         processor p{ lp.begin(), lp.end() };
 
         size_t offset{};
-        for(auto const &s : { "foo", "bar" })
+        for(auto const &s : { "foo", "bar", "?" })
         {
           auto const r(p.next());
           CHECK(equal(r.expect_ok().unwrap().ptr, make_box(s)));
@@ -336,10 +336,10 @@ namespace jank::read::parse
 
       SUBCASE("Escaped")
       {
-        lex::processor lp{ R"("foo\n" "\t\"bar\"" "\r" "\a" "\?" "\f" "\b")" };
+        lex::processor lp{ R"("foo\n" "\t\"bar\"" "\r" "\a" "\f" "\b")" };
         processor p{ lp.begin(), lp.end() };
         size_t offset{};
-        for(auto const &s : { "foo\n", "\t\"bar\"", "\r", "\a", "\?", "\f", "\b" })
+        for(auto const &s : { "foo\n", "\t\"bar\"", "\r", "\a", "\f", "\b" })
         {
           auto const r(p.next());
           CHECK(equal(r.expect_ok().unwrap().ptr, make_box(s)));

--- a/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
@@ -1,0 +1,18 @@
+#include <jank/runtime/obj/persistent_string.hpp>
+#include <jank/runtime/core.hpp>
+
+/* This must go last; doctest and glog both define CHECK and family. */
+#include <doctest/doctest.h>
+
+namespace jank::runtime::obj
+{
+  TEST_SUITE("persistent_string")
+  {
+    TEST_CASE("to_code_string")
+    {
+      static auto const s{ make_box("?") };
+      static auto const expected{ make_box("\"?\"") };
+      CHECK(equal(make_box(s->to_code_string()), expected));
+    }
+  }
+}

--- a/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
@@ -10,8 +10,8 @@ namespace jank::runtime::obj
   {
     TEST_CASE("to_code_string")
     {
-      auto const s{ make_box("?") };
-      auto const expected{ make_box("\"?\"") };
+      static auto const s{ make_box("?") };
+      static auto const expected{ make_box("\"?\"") };
       CHECK(equal(make_box(s->to_code_string()), expected));
     }
   }

--- a/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/persistent_string.cpp
@@ -10,8 +10,8 @@ namespace jank::runtime::obj
   {
     TEST_CASE("to_code_string")
     {
-      static auto const s{ make_box("?") };
-      static auto const expected{ make_box("\"?\"") };
+      auto const s{ make_box("?") };
+      auto const expected{ make_box("\"?\"") };
       CHECK(equal(make_box(s->to_code_string()), expected));
     }
   }


### PR DESCRIPTION
Close #221 

Because Clojure strings don't recognize the escape sequence `\?`, we don't want to print strings that contain it. In C++ strings, `\?` and `?` are the same character, so for Clojure compatibility, this PR has jank print both `?` and `\?` as `?` instead of the current `\?`.

It's handy to be able to write `"\?"` in `.jank` files coming from C++, so the lexer still considers it a valid escape sequence and still unescapes it to `?`. A cosmetic change is included in `unparse` to emphasize that `\?` and `?` are the same character in C++.

```
clojure.core=> "?"
"?"
clojure.core=> "\?"
"?"
clojure.core=> "\\?"
"\\?"
clojure.core=> (count "\\?")
2
clojure.core=> (str \?)
"?"
clojure.core=> (str \\ \?)
"\\?"
clojure.core=> (count "\?")
1
clojure.core=> (count "?")
1
clojure.core=> (= "?" "\?")
true
```