### PR TITLE
Add support for shebangs

### DIFF
--- a/compiler+runtime/src/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/src/cpp/jank/read/lex.cpp
@@ -1072,7 +1072,7 @@ namespace jank::read
                   }
                   else
                   {
-                    const size_t length = pos - token_start - 2;
+                    size_t const length = pos - token_start - 2;
                     native_persistent_string_view const comment{ file.data() + token_start + 2,
                                                                  length };
                     return ok(token{ token_start, length, token_kind::comment, comment });

--- a/compiler+runtime/src/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/src/cpp/jank/read/lex.cpp
@@ -1047,6 +1047,37 @@ namespace jank::read
                                      token_kind::reader_macro_conditional });
                   }
                 }
+              case '!':
+                {
+                  while(true)
+                  {
+                    auto const oc(peek());
+                    if(oc.is_err())
+                    {
+                      break;
+                    }
+                    auto const c(oc.expect_ok().character);
+                    if(c == '\n')
+                    {
+                      break;
+                    }
+
+                    ++pos;
+                  }
+
+                  ++pos;
+                  if(pos == token_start + 2)
+                  {
+                    return ok(token{ token_start, 1, token_kind::comment, ""sv });
+                  }
+                  else
+                  {
+                    size_t length = pos - token_start - 2;
+                    native_persistent_string_view const comment{ file.data() + token_start + 2,
+                                                                 length };
+                    return ok(token{ token_start, length, token_kind::comment, comment });
+                  }
+                }
               default:
                 break;
             }

--- a/compiler+runtime/src/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/src/cpp/jank/read/lex.cpp
@@ -1072,7 +1072,7 @@ namespace jank::read
                   }
                   else
                   {
-                    size_t const length = pos - token_start - 2;
+                    auto const length{ pos - token_start - 2 };
                     native_persistent_string_view const comment{ file.data() + token_start + 2,
                                                                  length };
                     return ok(token{ token_start, length, token_kind::comment, comment });

--- a/compiler+runtime/src/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/src/cpp/jank/read/lex.cpp
@@ -1072,7 +1072,7 @@ namespace jank::read
                   }
                   else
                   {
-                    size_t length = pos - token_start - 2;
+                    const size_t length = pos - token_start - 2;
                     native_persistent_string_view const comment{ file.data() + token_start + 2,
                                                                  length };
                     return ok(token{ token_start, length, token_kind::comment, comment });

--- a/compiler+runtime/test/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/test/cpp/jank/read/lex.cpp
@@ -1679,7 +1679,7 @@ namespace jank::read::lex
           }));
         }
 
-	SUBCASE("Multiple lines starting with #!")
+        SUBCASE("Multiple lines starting with #!")
         {
           processor p{ "#!foo\n#!bar" };
           native_vector<result<token, error>> const tokens(p.begin(), p.end());
@@ -1690,7 +1690,7 @@ namespace jank::read::lex
           }));
         }
 
-	SUBCASE("Double #")
+        SUBCASE("Double #")
         {
           processor p{ "##!foo" };
           native_vector<result<token, error>> const tokens(p.begin(), p.end());
@@ -1701,7 +1701,7 @@ namespace jank::read::lex
           }));
         }
 
-	SUBCASE("Double !")
+        SUBCASE("Double !")
         {
           processor p{ "#!!foo" };
           native_vector<result<token, error>> const tokens(p.begin(), p.end());
@@ -1747,8 +1747,8 @@ namespace jank::read::lex
           native_vector<result<token, error>> const tokens(p.begin(), p.end());
           CHECK(tokens
                 == make_tokens({
-		    { 0, 1, token_kind::open_paren},
-		    { 1, 1, token_kind::comment, ")"sv },
+                  { 0, 1, token_kind::open_paren },
+                  { 1, 1, token_kind::comment, ")"sv },
           }));
         }
       }


### PR DESCRIPTION
Closes https://github.com/jank-lang/jank/issues/232

```
clojure.core=> #! hello
nil
clojure.core=> (+ 1 1) #! addition
2
```

From the issue:
> We just need to add a ! case following # which then reuses the comment code (pull it into a fn named build_comment).

The code I ended up writing for shebang, while heavily inspired by the existing comment code, ended up being different in a few places throughout the code, such that it didn't seem appropriate to me to try to reuse a common function. Let me know if I'm missing something and should change my approach.
