### PR TITLE
fix: (str nil) => ""

### DIFF
--- a/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
@@ -930,14 +930,14 @@ namespace jank::runtime
 
   native_persistent_string str(object_ptr const o, object_ptr const args)
   {
+    util::string_builder buff;
+    buff.reserve(16);
+    if(!is_nil(o))
+    {
+      runtime::to_string(o, buff);
+    }
     return visit_seqable(
-      [=](auto const typed_args) -> native_persistent_string {
-        util::string_builder buff;
-        buff.reserve(16);
-        if(!is_nil(o))
-        {
-          runtime::to_string(o, buff);
-        }
+      [&](auto const typed_args) -> native_persistent_string {
         for(auto it(typed_args->fresh_seq()); it != nullptr; it = it->next_in_place())
         {
           auto const fst(it->first());

--- a/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
@@ -937,7 +937,7 @@ namespace jank::runtime
       runtime::to_string(o, buff);
     }
     return visit_seqable(
-      [&](auto const typed_args) -> native_persistent_string {
+      [](auto const typed_args, auto &buff) -> native_persistent_string {
         for(auto it(typed_args->fresh_seq()); it != nullptr; it = it->next_in_place())
         {
           auto const fst(it->first());
@@ -949,7 +949,8 @@ namespace jank::runtime
         }
         return buff.release();
       },
-      args);
+      args,
+      buff);
   }
 
   obj::persistent_list_ptr list(object_ptr const s)

--- a/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
@@ -937,7 +937,7 @@ namespace jank::runtime
       runtime::to_string(o, buff);
     }
     return visit_seqable(
-      [](auto const typed_args, auto &buff) -> native_persistent_string {
+      [](auto const typed_args, util::string_builder &buff) -> native_persistent_string {
         for(auto it(typed_args->fresh_seq()); it != nullptr; it = it->next_in_place())
         {
           auto const fst(it->first());

--- a/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
@@ -934,14 +934,19 @@ namespace jank::runtime
       [=](auto const typed_args) -> native_persistent_string {
         util::string_builder buff;
         buff.reserve(16);
-        runtime::to_string(o, buff);
+        if(!is_nil(o))
+        {
+          runtime::to_string(o, buff);
+        }
         if(0 < sequence_length(typed_args))
         {
           auto const fresh(typed_args->fresh_seq());
-          runtime::to_string(fresh->first(), buff);
-          for(auto it(fresh->next_in_place()); it != nullptr; it = it->next_in_place())
+          for(auto it(fresh); it != nullptr; it = it->next_in_place())
           {
-            runtime::to_string(it->first(), buff);
+            if(!is_nil(it->first()))
+            {
+              runtime::to_string(it->first(), buff);
+            }
           }
         }
         return buff.release();

--- a/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
@@ -938,18 +938,16 @@ namespace jank::runtime
         {
           runtime::to_string(o, buff);
         }
-        if(0 < sequence_length(typed_args))
-        {
           for(auto it(typed_args->fresh_seq()); it != nullptr; it = it->next_in_place())
           {
             auto const fst(it->first());
-            if(!is_nil(fst))
+            if(is_nil(fst))
             {
-              runtime::to_string(fst, buff);
+	      continue;
             }
+	    runtime::to_string(fst, buff);
           }
-        }
-        return buff.release();
+          return buff.release();
       },
       args);
   }

--- a/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
@@ -938,16 +938,16 @@ namespace jank::runtime
         {
           runtime::to_string(o, buff);
         }
-          for(auto it(typed_args->fresh_seq()); it != nullptr; it = it->next_in_place())
+        for(auto it(typed_args->fresh_seq()); it != nullptr; it = it->next_in_place())
+        {
+          auto const fst(it->first());
+          if(is_nil(fst))
           {
-            auto const fst(it->first());
-            if(is_nil(fst))
-            {
-	      continue;
-            }
-	    runtime::to_string(fst, buff);
+            continue;
           }
-          return buff.release();
+          runtime::to_string(fst, buff);
+        }
+        return buff.release();
       },
       args);
   }

--- a/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
@@ -940,12 +940,12 @@ namespace jank::runtime
         }
         if(0 < sequence_length(typed_args))
         {
-          auto const fresh(typed_args->fresh_seq());
-          for(auto it(fresh); it != nullptr; it = it->next_in_place())
+          for(auto it(typed_args->fresh_seq()); it != nullptr; it = it->next_in_place())
           {
-            if(!is_nil(it->first()))
+            auto const fst(it->first());
+            if(!is_nil(fst))
             {
-              runtime::to_string(it->first(), buff);
+              runtime::to_string(fst, buff);
             }
           }
         }

--- a/compiler+runtime/src/jank/clojure/core.jank
+++ b/compiler+runtime/src/jank/clojure/core.jank
@@ -252,7 +252,9 @@
     ([]
      "")
     ([o]
-     (clojure.core-native/to-string o))
+     (if (nil? o)
+       ""
+       (clojure.core-native/to-string o)))
     ([o & args]
      (clojure.core-native/str o args))))
 


### PR DESCRIPTION
Closes #241 

Here are a some notes on the approach I took and why it differed from what was expected for this ticket.

**The original behavior:**

```
clojure.core=> 
nil
clojure.core=> (str nil)
"nil"
clojure.core=> (str nil "hello" nil)
"nilhellonil"
clojure.core=> (println nil)
nil
nil
clojure.core=> (println "hello" nil nil)
hello nil nil
nil
clojure.core=> (prn "hello" nil nil)
"hello" nil nil
nil
clojure.core=> nil
nil
```

**First-attempt changes:**

```
// nil.cpp
...
  native_persistent_string const &nil::to_string() const
  {
    // static native_persistent_string const s{ "nil" };
    static native_persistent_string const s{ "" };
    return s;
  }

  native_persistent_string const &nil::to_code_string() const
  {
    // return to_string();
    static native_persistent_string const s{ "nil" };
    return s;
  }

  void nil::to_string(util::string_builder &buff) const
  {
    //fmt::format_to(std::back_inserter(buff), "nil");
    fmt::format_to(std::back_inserter(buff), "");
  }
...
```

**Behavior after first attempt**
```
clojure.core=> 
nil    ;; should be empty line
clojure.core=> (str nil)
""     ;; good
clojure.core=> (str nil "hello" nil)
"hello" ;; good
clojure.core=> (println "hello" nil nil)
hello  ;; should be: hello nil nil
nil
clojure.core=> (prn "hello" nil nil)
"hello" nil nil  ;; good
nil
clojure.core=> nil
nil    ;; good
```

After some time spent trying and failing to correct the above, I eventually went to the Clojure source:

Clojure `str`:
https://github.com/clojure/clojure/blob/clojure-1.11.1/src/clj/clojure/core.clj#L546

```
(defn str
  ...
  (^String [] "")
  (^String [^Object x]
   (if (nil? x) "" (. x (toString))))  ;; <<==== NOTE
  (^String [x & ys]
     ((fn [^StringBuilder sb more]
          (if more
            (recur (. sb  (append (str (first more)))) (next more))
            (str sb)))
      (new StringBuilder (str x)) ys)))
```

Taking inspiration from Clojure, I decided to implement this `nil` behavior in jank's `str` functions. In the results below, all but the first case show correct behavior. The failing case is not a regression.


**New behavior**
```
clojure.core=> 
nil  ;; should be empty line
clojure.core=> (str nil)
""
clojure.core=> (str nil "hello" nil)
"hello"
clojure.core=> (println nil)
nil
nil
clojure.core=> (println "hello" nil nil)
hello nil nil
nil
clojure.core=> (prn "hello" nil nil)
"hello" nil nil
nil
clojure.core=> nil
nil
```

Also, this had no effect on: 
keyword differs from CLJ/S for non-strings
https://github.com/jank-lang/jank/issues/246
