### PR TITLE
POC: reduceable

### DIFF
--- a/compiler+runtime/include/cpp/jank/runtime/behavior/reduceable.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/behavior/reduceable.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <jank/runtime/native_box.hpp>
+
+namespace jank::runtime::behavior
+{
+  template <typename T>
+  concept reduceable = requires(T * const t) {
+    { t->reduce(std::function<object *(object *, object *)>{}, object_ptr{}) } -> std::convertible_to<object_ptr>;
+  };
+
+  template <typename T>
+  concept reduceable_kv = requires(T * const t) {
+    { t->reduce_kv(std::function<object *(object *, object *, object *)>{}, object_ptr{}) } -> std::convertible_to<object_ptr>;
+  };
+}

--- a/compiler+runtime/include/cpp/jank/runtime/behavior/reduceable.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/behavior/reduceable.hpp
@@ -6,10 +6,7 @@ namespace jank::runtime::behavior
 {
   template <typename T>
   concept reduceable = requires(T * const t) {
-    {
-      t->reduce(std::declval<std::function<object_ptr(object_ptr, object_ptr)> const &>(),
-                object_ptr{})
-    } -> std::convertible_to<object_ptr>;
+    { t->reduce(object_ptr{}, object_ptr{}) } -> std::convertible_to<object_ptr>;
   };
 
   /*

--- a/compiler+runtime/include/cpp/jank/runtime/behavior/reduceable.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/behavior/reduceable.hpp
@@ -7,14 +7,14 @@ namespace jank::runtime::behavior
   template <typename T>
   concept reduceable = requires(T * const t) {
     {
-      t->reduce(std::function<object *(object *, object *)>{}, object_ptr{})
+      t->reduce(std::function<object_ptr(object_ptr, object_ptr)>{}, object_ptr{})
     } -> std::convertible_to<object_ptr>;
   };
 
   template <typename T>
   concept reduceable_kv = requires(T * const t) {
     {
-      t->reduce_kv(std::function<object *(object *, object *, object *)>{}, object_ptr{})
+      t->reduce_kv(std::function<object_ptr(object_ptr, object_ptr, object_ptr)>{}, object_ptr{})
     } -> std::convertible_to<object_ptr>;
   };
 }

--- a/compiler+runtime/include/cpp/jank/runtime/behavior/reduceable.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/behavior/reduceable.hpp
@@ -7,7 +7,8 @@ namespace jank::runtime::behavior
   template <typename T>
   concept reduceable = requires(T * const t) {
     {
-      t->reduce(std::declval<std::function<object_ptr(object_ptr, object_ptr)> const &>(), object_ptr{})
+      t->reduce(std::declval<std::function<object_ptr(object_ptr, object_ptr)> const &>(),
+                object_ptr{})
     } -> std::convertible_to<object_ptr>;
   };
 

--- a/compiler+runtime/include/cpp/jank/runtime/behavior/reduceable.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/behavior/reduceable.hpp
@@ -7,14 +7,16 @@ namespace jank::runtime::behavior
   template <typename T>
   concept reduceable = requires(T * const t) {
     {
-      t->reduce(std::function<object_ptr(object_ptr, object_ptr)>{}, object_ptr{})
+      t->reduce(std::declval<std::function<object_ptr(object_ptr, object_ptr)> const &>(), object_ptr{})
     } -> std::convertible_to<object_ptr>;
   };
 
+  /*
   template <typename T>
   concept reduceable_kv = requires(T * const t) {
     {
       t->reduce_kv(std::function<object_ptr(object_ptr, object_ptr, object_ptr)>{}, object_ptr{})
     } -> std::convertible_to<object_ptr>;
   };
+  */
 }

--- a/compiler+runtime/include/cpp/jank/runtime/behavior/reduceable.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/behavior/reduceable.hpp
@@ -6,11 +6,15 @@ namespace jank::runtime::behavior
 {
   template <typename T>
   concept reduceable = requires(T * const t) {
-    { t->reduce(std::function<object *(object *, object *)>{}, object_ptr{}) } -> std::convertible_to<object_ptr>;
+    {
+      t->reduce(std::function<object *(object *, object *)>{}, object_ptr{})
+    } -> std::convertible_to<object_ptr>;
   };
 
   template <typename T>
   concept reduceable_kv = requires(T * const t) {
-    { t->reduce_kv(std::function<object *(object *, object *, object *)>{}, object_ptr{}) } -> std::convertible_to<object_ptr>;
+    {
+      t->reduce_kv(std::function<object *(object *, object *, object *)>{}, object_ptr{})
+    } -> std::convertible_to<object_ptr>;
   };
 }

--- a/compiler+runtime/include/cpp/jank/runtime/core/seq.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core/seq.hpp
@@ -128,7 +128,9 @@ namespace jank::runtime
   size_t sequence_length(object_ptr const s, size_t const max);
 
   object_ptr reduce(object_ptr f, object_ptr init, object_ptr s);
-  object_ptr reduce(std::function<object *(object *, object *)> f, object_ptr init, object_ptr s);
+  object_ptr reduce(std::function<object_ptr(object_ptr, object_ptr)> f, object_ptr init, object_ptr s);
+  object_ptr reduce_kv(object_ptr f, object_ptr init, object_ptr s);
+  object_ptr reduce_kv(std::function<object_ptr(object_ptr, object_ptr, object_ptr)> f, object_ptr init, object_ptr s);
   object_ptr reduced(object_ptr o);
   native_bool is_reduced(object_ptr o);
 

--- a/compiler+runtime/include/cpp/jank/runtime/core/seq.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core/seq.hpp
@@ -128,7 +128,7 @@ namespace jank::runtime
   size_t sequence_length(object_ptr const s, size_t const max);
 
   object_ptr reduce(object_ptr f, object_ptr init, object_ptr s);
-  object_ptr reduce(std::function<object_ptr(object_ptr, object_ptr)> f, object_ptr init, object_ptr s);
+  object_ptr reduce(std::function<object_ptr(object_ptr, object_ptr)> const &f, object_ptr init, object_ptr s);
   /*
   object_ptr reduce_kv(object_ptr f, object_ptr init, object_ptr s);
   object_ptr reduce_kv(std::function<object_ptr(object_ptr, object_ptr, object_ptr)> f, object_ptr init, object_ptr s);

--- a/compiler+runtime/include/cpp/jank/runtime/core/seq.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core/seq.hpp
@@ -128,6 +128,7 @@ namespace jank::runtime
   size_t sequence_length(object_ptr const s, size_t const max);
 
   object_ptr reduce(object_ptr f, object_ptr init, object_ptr s);
+  object_ptr reduce(std::function<object *(object *, object *)> f, object_ptr init, object_ptr s);
   object_ptr reduced(object_ptr o);
   native_bool is_reduced(object_ptr o);
 

--- a/compiler+runtime/include/cpp/jank/runtime/core/seq.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core/seq.hpp
@@ -129,8 +129,10 @@ namespace jank::runtime
 
   object_ptr reduce(object_ptr f, object_ptr init, object_ptr s);
   object_ptr reduce(std::function<object_ptr(object_ptr, object_ptr)> f, object_ptr init, object_ptr s);
+  /*
   object_ptr reduce_kv(object_ptr f, object_ptr init, object_ptr s);
   object_ptr reduce_kv(std::function<object_ptr(object_ptr, object_ptr, object_ptr)> f, object_ptr init, object_ptr s);
+  */
   object_ptr reduced(object_ptr o);
   native_bool is_reduced(object_ptr o);
 

--- a/compiler+runtime/include/cpp/jank/runtime/core/seq.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core/seq.hpp
@@ -128,7 +128,8 @@ namespace jank::runtime
   size_t sequence_length(object_ptr const s, size_t const max);
 
   object_ptr reduce(object_ptr f, object_ptr init, object_ptr s);
-  object_ptr reduce(std::function<object_ptr(object_ptr, object_ptr)> const &f, object_ptr init, object_ptr s);
+  object_ptr
+  reduce(std::function<object_ptr(object_ptr, object_ptr)> const &f, object_ptr init, object_ptr s);
   /*
   object_ptr reduce_kv(object_ptr f, object_ptr init, object_ptr s);
   object_ptr reduce_kv(std::function<object_ptr(object_ptr, object_ptr, object_ptr)> f, object_ptr init, object_ptr s);

--- a/compiler+runtime/include/cpp/jank/runtime/core/seq.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core/seq.hpp
@@ -128,8 +128,6 @@ namespace jank::runtime
   size_t sequence_length(object_ptr const s, size_t const max);
 
   object_ptr reduce(object_ptr f, object_ptr init, object_ptr s);
-  object_ptr
-  reduce(std::function<object_ptr(object_ptr, object_ptr)> const &f, object_ptr init, object_ptr s);
   /*
   object_ptr reduce_kv(object_ptr f, object_ptr init, object_ptr s);
   object_ptr reduce_kv(std::function<object_ptr(object_ptr, object_ptr, object_ptr)> f, object_ptr init, object_ptr s);

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_map.hpp
@@ -91,6 +91,9 @@ namespace jank::runtime::obj
     object_ptr call(object_ptr) const;
     object_ptr call(object_ptr, object_ptr) const;
 
+    /* behavior::reduceable_kv */
+    object_ptr reduce_kv(std::function<object_ptr(object_ptr, object_ptr, object_ptr)>, object_ptr) const;
+
     /* behavior::transientable */
     obj::transient_hash_map_ptr to_transient() const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_map.hpp
@@ -92,7 +92,7 @@ namespace jank::runtime::obj
     object_ptr call(object_ptr, object_ptr) const;
 
     /* behavior::reduceable_kv */
-    object_ptr reduce_kv(std::function<object_ptr(object_ptr, object_ptr, object_ptr)>, object_ptr) const;
+    //object_ptr reduce_kv(std::function<object_ptr(object_ptr, object_ptr, object_ptr)>, object_ptr) const;
 
     /* behavior::transientable */
     obj::transient_hash_map_ptr to_transient() const;

--- a/compiler+runtime/include/cpp/jank/runtime/obj/repeat.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/repeat.hpp
@@ -34,7 +34,7 @@ namespace jank::runtime::obj
     repeat_ptr fresh_seq() const;
 
     /* behavior::reduceable */
-    object_ptr reduce(std::function<object_ptr(object_ptr, object_ptr)> f, object_ptr init) const;
+    object_ptr reduce(std::function<object_ptr(object_ptr, object_ptr)> const &f, object_ptr init) const;
 
     /* behavior::sequenceable */
     object_ptr first() const;

--- a/compiler+runtime/include/cpp/jank/runtime/obj/repeat.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/repeat.hpp
@@ -34,7 +34,7 @@ namespace jank::runtime::obj
     repeat_ptr fresh_seq() const;
 
     /* behavior::reduceable */
-    object_ptr reduce(std::function<object *(object *, object *)> f, object_ptr init) const;
+    object_ptr reduce(std::function<object_ptr(object_ptr, object_ptr)> f, object_ptr init) const;
 
     /* behavior::sequenceable */
     object_ptr first() const;

--- a/compiler+runtime/include/cpp/jank/runtime/obj/repeat.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/repeat.hpp
@@ -34,8 +34,7 @@ namespace jank::runtime::obj
     repeat_ptr fresh_seq() const;
 
     /* behavior::reduceable */
-    object_ptr
-    reduce(std::function<object_ptr(object_ptr, object_ptr)> const &f, object_ptr init) const;
+    object_ptr reduce(object_ptr f, object_ptr init) const;
 
     /* behavior::sequenceable */
     object_ptr first() const;

--- a/compiler+runtime/include/cpp/jank/runtime/obj/repeat.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/repeat.hpp
@@ -34,7 +34,8 @@ namespace jank::runtime::obj
     repeat_ptr fresh_seq() const;
 
     /* behavior::reduceable */
-    object_ptr reduce(std::function<object_ptr(object_ptr, object_ptr)> const &f, object_ptr init) const;
+    object_ptr
+    reduce(std::function<object_ptr(object_ptr, object_ptr)> const &f, object_ptr init) const;
 
     /* behavior::sequenceable */
     object_ptr first() const;

--- a/compiler+runtime/include/cpp/jank/runtime/obj/repeat.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/repeat.hpp
@@ -33,6 +33,9 @@ namespace jank::runtime::obj
     repeat_ptr seq();
     repeat_ptr fresh_seq() const;
 
+    /* behavior::reduceable */
+    object_ptr reduce(std::function<object *(object *, object *)> f, object_ptr init) const;
+
     /* behavior::sequenceable */
     object_ptr first() const;
     repeat_ptr next() const;

--- a/compiler+runtime/include/cpp/jank/runtime/obj/repeat.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/repeat.hpp
@@ -13,11 +13,11 @@ namespace jank::runtime::obj
     static constexpr object_type obj_type{ object_type::repeat };
     static constexpr native_bool pointer_free{ false };
     static constexpr native_bool is_sequential{ true };
-    static constexpr native_integer infinite{ -1 };
+    static constexpr size_t infinite{ 0 };
 
     repeat() = default;
     repeat(object_ptr value);
-    repeat(object_ptr count, object_ptr value);
+    repeat(size_t count, object_ptr value);
 
     static object_ptr create(object_ptr value);
     static object_ptr create(object_ptr count, object_ptr value);
@@ -51,7 +51,7 @@ namespace jank::runtime::obj
 
     object base{ obj_type };
     object_ptr value{};
-    object_ptr count{};
+    size_t count{};
     option<object_ptr> meta{};
   };
 }

--- a/compiler+runtime/src/cpp/clojure/core_native.cpp
+++ b/compiler+runtime/src/cpp/clojure/core_native.cpp
@@ -386,7 +386,7 @@ jank_object_ptr jank_load_clojure_core_native()
   intern_fn("deref", &deref);
   intern_fn("reduced", &reduced);
   intern_fn("reduced?", &is_reduced);
-  intern_fn("reduce", &reduce);
+  intern_fn("reduce", static_cast<object_ptr (*)(object_ptr, object_ptr, object_ptr)>(&reduce));
   intern_fn("peek", &peek);
   intern_fn("pop", &pop);
   intern_fn("atom", &atom);

--- a/compiler+runtime/src/cpp/clojure/core_native.cpp
+++ b/compiler+runtime/src/cpp/clojure/core_native.cpp
@@ -387,7 +387,7 @@ jank_object_ptr jank_load_clojure_core_native()
   intern_fn("reduced", &reduced);
   intern_fn("reduced?", &is_reduced);
   intern_fn("reduce", static_cast<object_ptr (*)(object_ptr, object_ptr, object_ptr)>(&reduce));
-  intern_fn("reduce-kv", static_cast<object_ptr (*)(object_ptr, object_ptr, object_ptr)>(&reduce_kv));
+  //intern_fn("reduce-kv", static_cast<object_ptr (*)(object_ptr, object_ptr, object_ptr)>(&reduce_kv));
   intern_fn("peek", &peek);
   intern_fn("pop", &pop);
   intern_fn("atom", &atom);

--- a/compiler+runtime/src/cpp/clojure/core_native.cpp
+++ b/compiler+runtime/src/cpp/clojure/core_native.cpp
@@ -387,6 +387,7 @@ jank_object_ptr jank_load_clojure_core_native()
   intern_fn("reduced", &reduced);
   intern_fn("reduced?", &is_reduced);
   intern_fn("reduce", static_cast<object_ptr (*)(object_ptr, object_ptr, object_ptr)>(&reduce));
+  intern_fn("reduce-kv", static_cast<object_ptr (*)(object_ptr, object_ptr, object_ptr)>(&reduce_kv));
   intern_fn("peek", &peek);
   intern_fn("pop", &pop);
   intern_fn("atom", &atom);

--- a/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
@@ -1069,13 +1069,13 @@ namespace jank::runtime
       s);
   }
 
-  object_ptr reduce(std::function<object_ptr(object_ptr, object_ptr)> const f,
+  object_ptr reduce(std::function<object_ptr(object_ptr, object_ptr)> const &f,
                     object_ptr const init,
                     object_ptr const s)
   {
     return visit_object(
-      [](auto const typed_coll, auto const f, auto const init) -> object_ptr {
-        using T = typename decltype(typed_coll)::value_type;
+      [](auto const typed_s, auto const f, auto const init) -> object_ptr {
+        using T = typename decltype(typed_s)::value_type;
 
         if constexpr(std::same_as<T, obj::nil>)
         {
@@ -1083,12 +1083,12 @@ namespace jank::runtime
         }
         else if constexpr(behavior::reduceable<T>)
         {
-          return typed_coll->reduce(f, init);
+          return typed_s->reduce(f, init);
         }
         else if constexpr(behavior::seqable<T>)
         {
           object_ptr res{ init };
-          for(auto it(typed_coll->fresh_seq()); it != nullptr; it = it->next_in_place())
+          for(auto it(typed_s->fresh_seq()); it != nullptr; it = it->next_in_place())
           {
             res = f(res, it->first());
             if(res->type == object_type::reduced)
@@ -1101,7 +1101,7 @@ namespace jank::runtime
         }
         else
         {
-          throw std::runtime_error{ fmt::format("cannot reduce: {}", typed_coll->to_string()) };
+          throw std::runtime_error{ fmt::format("cannot reduce: {}", typed_s->to_string()) };
         }
       },
       s,

--- a/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
@@ -1109,6 +1109,7 @@ namespace jank::runtime
       init);
   }
 
+  /*
   object_ptr reduce_kv(object_ptr const f, object_ptr const init, object_ptr const s)
   {
     return visit_object(
@@ -1192,6 +1193,7 @@ namespace jank::runtime
       f,
       init);
   }
+  */
 
   object_ptr reduced(object_ptr const o)
   {

--- a/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
@@ -1030,50 +1030,6 @@ namespace jank::runtime
   object_ptr reduce(object_ptr const f, object_ptr const init, object_ptr const s)
   {
     return visit_object(
-      [=](auto const typed_source, auto const init, auto const s) -> object_ptr {
-        using T = typename decltype(typed_source)::value_type;
-        if constexpr(std::is_base_of_v<behavior::callable, T>)
-        {
-          auto const arity_flags(typed_source->get_arity_flags());
-          auto const mask(behavior::callable::extract_variadic_arity_mask(arity_flags));
-          switch(mask)
-          {
-            case behavior::callable::mask_variadic_arity(0):
-            case behavior::callable::mask_variadic_arity(1):
-            case behavior::callable::mask_variadic_arity(2):
-              break;
-            default:
-              if constexpr(std::same_as<T, obj::jit_function>)
-              {
-                std::function<object_ptr(object_ptr, object_ptr)> const f(typed_source->arity_2);
-                if(f)
-                {
-                  return reduce(f, init, s);
-                }
-              }
-              else
-              {
-                auto f([&typed_source](object_ptr const a, object_ptr const e) -> object_ptr {
-                  return typed_source->call(a, e);
-                });
-                return reduce(f, init, s);
-              }
-          }
-        }
-        return reduce([&](auto const a, auto const e) { return dynamic_call(typed_source, a, e); },
-                      init,
-                      s);
-      },
-      f,
-      init,
-      s);
-  }
-
-  object_ptr reduce(std::function<object_ptr(object_ptr, object_ptr)> const &f,
-                    object_ptr const init,
-                    object_ptr const s)
-  {
-    return visit_object(
       [](auto const typed_s, auto const f, auto const init) -> object_ptr {
         using T = typename decltype(typed_s)::value_type;
 
@@ -1090,7 +1046,7 @@ namespace jank::runtime
           object_ptr res{ init };
           for(auto it(typed_s->fresh_seq()); it != nullptr; it = it->next_in_place())
           {
-            res = f(res, it->first());
+            res = dynamic_call(f, res, it->first());
             if(res->type == object_type::reduced)
             {
               res = expect_object<obj::reduced>(res)->val;

--- a/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
@@ -1045,7 +1045,7 @@ namespace jank::runtime
             default:
               if constexpr(std::same_as<T, obj::jit_function>)
               {
-                std::function<object_ptr(object *, object *)> f(typed_source->arity_2);
+                std::function<object_ptr(object *, object *)> const f(typed_source->arity_2);
                 if(f)
                 {
                   return reduce(f, init, s);

--- a/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
@@ -10,6 +10,7 @@
 #include <jank/runtime/behavior/conjable.hpp>
 #include <jank/runtime/behavior/countable.hpp>
 #include <jank/runtime/behavior/seqable.hpp>
+#include <jank/runtime/behavior/reduceable.hpp>
 #include <jank/runtime/behavior/set_like.hpp>
 #include <jank/runtime/behavior/sequential.hpp>
 #include <jank/runtime/behavior/collection_like.hpp>
@@ -1028,19 +1029,74 @@ namespace jank::runtime
 
   object_ptr reduce(object_ptr const f, object_ptr const init, object_ptr const s)
   {
-    return visit_seqable(
-      [](auto const typed_coll, object_ptr const f, object_ptr const init) -> object_ptr {
-        object_ptr res{ init };
-        for(auto it(typed_coll->fresh_seq()); it != nullptr; it = it->next_in_place())
-        {
-          res = dynamic_call(f, res, it->first());
-          if(res->type == object_type::reduced)
+    return visit_object(
+      [=](auto const typed_source, auto const init, auto const s) -> object_ptr {
+          using T = typename decltype(typed_source)::value_type;
+          if constexpr(std::is_base_of_v<behavior::callable, T>)
           {
-            res = expect_object<obj::reduced>(res)->val;
-            break;
+            auto const arity_flags(typed_source->get_arity_flags());
+            auto const mask(behavior::callable::extract_variadic_arity_mask(arity_flags));
+            switch(mask)
+            {
+              case behavior::callable::mask_variadic_arity(0):
+              case behavior::callable::mask_variadic_arity(1):
+              case behavior::callable::mask_variadic_arity(2):
+                break;
+              default:
+                if constexpr(std::same_as<T, obj::jit_function>)
+                {
+                  std::function<object_ptr(object *, object *)> f(typed_source->arity_2);
+                  if(f)
+                  {
+                    return reduce(f, init, s);
+                  }
+                }
+                else
+                {
+                  auto f([&typed_source](object_ptr const a, object_ptr const e) -> object_ptr { return typed_source->call(a, e); });
+                  return reduce(f, init, s);
+                }
+            }
           }
+          return reduce([&](auto const a, auto const e){ return dynamic_call(typed_source, a, e); }, init, s);
+          },
+          f,
+          init,
+          s);
+  }
+
+  object_ptr reduce(std::function<object *(object *, object *)> const f, object_ptr const init, object_ptr const s)
+  {
+    return visit_object(
+      [](auto const typed_coll, auto const f, auto const init) -> object_ptr {
+        using T = typename decltype(typed_coll)::value_type;
+
+        if constexpr(std::same_as<T, obj::nil>)
+        {
+          return init;
         }
-        return res;
+        else if constexpr(behavior::reduceable<T>)
+        {
+          return typed_coll->reduce(f, init);
+        }
+        else if constexpr(behavior::seqable<T>)
+        {
+          object_ptr res{ init };
+          for(auto it(typed_coll->fresh_seq()); it != nullptr; it = it->next_in_place())
+          {
+            res = f(res, it->first());
+            if(res->type == object_type::reduced)
+            {
+              res = expect_object<obj::reduced>(res)->val;
+              break;
+            }
+          }
+          return res;
+        }
+        else
+        {
+          throw std::runtime_error{ fmt::format("cannot reduce: {}", typed_coll->to_string()) };
+        }
       },
       s,
       f,

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_map.cpp
@@ -157,4 +157,15 @@ namespace jank::runtime::obj
   {
     return make_box<transient_hash_map>(data);
   }
+
+  object_ptr
+  persistent_hash_map::reduce_kv(std::function<object_ptr(object_ptr, object_ptr, object_ptr)> const f, object_ptr const start) const
+  {
+    auto ret(start);
+    for(auto const &e : data)
+    {
+      ret = f(ret, e.first, e.second);
+    }
+    return ret;
+  }
 }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_map.cpp
@@ -158,6 +158,7 @@ namespace jank::runtime::obj
     return make_box<transient_hash_map>(data);
   }
 
+  /*
   object_ptr
   persistent_hash_map::reduce_kv(std::function<object_ptr(object_ptr, object_ptr, object_ptr)> const f, object_ptr const start) const
   {
@@ -168,4 +169,5 @@ namespace jank::runtime::obj
     }
     return ret;
   }
+  */
 }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/repeat.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/repeat.cpp
@@ -56,6 +56,34 @@ namespace jank::runtime::obj
     return value;
   }
 
+  object_ptr repeat::reduce(std::function<object *(object *, object *)> const f, object_ptr const start) const
+  {
+    object_ptr ret(start);
+    if(runtime::equal(count, make_box(infinite)))
+    {
+      while(true)
+      {
+        ret = f(ret, value);
+        if(ret->type == object_type::reduced)
+        {
+          return expect_object<obj::reduced>(ret)->val;
+        }
+      }
+    }
+    else
+    {
+      auto const bound(to_int(count));
+      for(auto i(0); i<bound; ++i){
+        ret = f(ret, value);
+        if(ret->type == object_type::reduced)
+        {
+          return expect_object<obj::reduced>(ret)->val;
+        }
+      }
+      return ret;
+    }
+  }
+
   repeat_ptr repeat::next() const
   {
     if(runtime::equal(count, make_box(infinite)))

--- a/compiler+runtime/src/cpp/jank/runtime/obj/repeat.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/repeat.cpp
@@ -56,7 +56,8 @@ namespace jank::runtime::obj
     return value;
   }
 
-  object_ptr repeat::reduce(std::function<object *(object *, object *)> const f, object_ptr const start) const
+  object_ptr
+  repeat::reduce(std::function<object *(object *, object *)> const f, object_ptr const start) const
   {
     object_ptr ret(start);
     if(runtime::equal(count, make_box(infinite)))
@@ -73,7 +74,8 @@ namespace jank::runtime::obj
     else
     {
       auto const bound(to_int(count));
-      for(auto i(0); i<bound; ++i){
+      for(auto i(0); i < bound; ++i)
+      {
         ret = f(ret, value);
         if(ret->type == object_type::reduced)
         {

--- a/compiler+runtime/src/cpp/jank/runtime/obj/repeat.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/repeat.cpp
@@ -72,6 +72,8 @@ namespace jank::runtime::obj
             case behavior::callable::mask_variadic_arity(0):
             case behavior::callable::mask_variadic_arity(1):
             case behavior::callable::mask_variadic_arity(2):
+              //TODO create new jit_{function,closure} that can be called
+              //with 2 arity so no extra branch is needed for the common case.
               break;
             default:
               direct = true;

--- a/compiler+runtime/src/cpp/jank/runtime/obj/repeat.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/repeat.cpp
@@ -56,8 +56,8 @@ namespace jank::runtime::obj
     return value;
   }
 
-  object_ptr
-  repeat::reduce(std::function<object_ptr(object_ptr, object_ptr)> const &f, object_ptr const start) const
+  object_ptr repeat::reduce(std::function<object_ptr(object_ptr, object_ptr)> const &f,
+                            object_ptr const start) const
   {
     auto ret(start);
     auto const bound(count);
@@ -96,7 +96,7 @@ namespace jank::runtime::obj
       case 1:
         return nullptr;
     }
-    return make_box<repeat>(c-1, value);
+    return make_box<repeat>(c - 1, value);
   }
 
   repeat_ptr repeat::next_in_place()
@@ -109,7 +109,7 @@ namespace jank::runtime::obj
       case 1:
         return nullptr;
     }
-    count = c-1;
+    count = c - 1;
     return this;
   }
 

--- a/compiler+runtime/src/cpp/jank/runtime/obj/repeat.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/repeat.cpp
@@ -73,8 +73,8 @@ namespace jank::runtime::obj
     }
     else
     {
-      auto const bound(to_int(count));
-      for(auto i(0); i < bound; ++i)
+      auto const bound(static_cast<size_t>(to_int(count)));
+      for(size_t i{}; i < bound; ++i)
       {
         ret = f(ret, value);
         if(ret->type == object_type::reduced)

--- a/compiler+runtime/src/cpp/jank/runtime/obj/repeat.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/repeat.cpp
@@ -57,7 +57,7 @@ namespace jank::runtime::obj
   }
 
   object_ptr
-  repeat::reduce(std::function<object *(object *, object *)> const f, object_ptr const start) const
+  repeat::reduce(std::function<object_ptr(object_ptr, object_ptr)> const f, object_ptr const start) const
   {
     object_ptr ret(start);
     if(runtime::equal(count, make_box(infinite)))

--- a/compiler+runtime/src/cpp/jank/runtime/obj/repeat.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/repeat.cpp
@@ -65,6 +65,8 @@ namespace jank::runtime::obj
     return visit_object(
       [](auto const typed_f, auto ret, auto const value, auto const bound) -> object_ptr {
         using T = typename decltype(typed_f)::value_type;
+        /* If true, we can call typed_f->call(acc, el) directly.
+         * Otherwise, use dynamic_call(typed_f, acc, el). */
         native_bool direct{};
         if constexpr(std::same_as<T, runtime::obj::jit_function>
                      || std::same_as<T, runtime::obj::jit_closure>)

--- a/compiler+runtime/src/cpp/jank/runtime/obj/repeat.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/repeat.cpp
@@ -57,9 +57,9 @@ namespace jank::runtime::obj
   }
 
   object_ptr
-  repeat::reduce(std::function<object_ptr(object_ptr, object_ptr)> const f, object_ptr const start) const
+  repeat::reduce(std::function<object_ptr(object_ptr, object_ptr)> const &f, object_ptr const start) const
   {
-    object_ptr ret(start);
+    auto ret(start);
     auto const bound(count);
     if(bound == infinite)
     {

--- a/compiler+runtime/src/jank/clojure/core.jank
+++ b/compiler+runtime/src/jank/clojure/core.jank
@@ -6748,38 +6748,14 @@ fails, attempts to require sym's namespace and retries."
   ;; (java.util.UUID/randomUUID)
   (throw "TODO: port random-uuid"))
 
-;; (extend-protocol clojure.core.protocols/IKVReduce
-;;  nil
-;;  (kv-reduce
-;;   [_ f init]
-;;   init)
-
-;;  ;;slow path default
-;;  java.lang.Object
-;;  (kv-reduce
-;;   [amap f init]
-;;   (reduce (fn [ret ^java.util.Map$Entry me]
-;;             (f ret
-;;                (.getKey me)
-;;                (.getValue me)))
-;;           init
-;;           amap))
-
-;;  clojure.lang.IKVReduce
-;;  (kv-reduce
-;;   [amap f init]
-;;   (.kvreduce amap f init)))
-
-(defn reduce-kv
-  "Reduces an associative collection. f should be a function of 3
-  arguments. Returns the result of applying f to init, the first key
-  and the first value in coll, then applying f to that result and the
-  2nd key and value, etc. If coll contains no entries, returns init
-  and f is not called. Note that reduce-kv is supported on vectors,
-  where the keys will be the ordinals."  
-  ([f init coll]
-    ;;  (clojure.core.protocols/kv-reduce coll f init)
-   (reduce (fn [s [k v]] (f s k v)) init coll)))
+(def ^{:doc "Reduces an associative collection. f should be a function of 3
+             arguments. Returns the result of applying f to init, the first key
+             and the first value in coll, then applying f to that result and the
+             2nd key and value, etc. If coll contains no entries, returns init
+             and f is not called. Note that reduce-kv is supported on vectors,
+             where the keys will be the ordinals."
+       :arglists '([f init coll])}
+  reduce-kv @clojure.core-native/reduce-kv)
 
 (defn- normalize-slurp-opts
   [opts]

--- a/compiler+runtime/src/jank/clojure/core.jank
+++ b/compiler+runtime/src/jank/clojure/core.jank
@@ -6755,7 +6755,9 @@ fails, attempts to require sym's namespace and retries."
              and f is not called. Note that reduce-kv is supported on vectors,
              where the keys will be the ordinals."
        :arglists '([f init coll])}
-  reduce-kv @clojure.core-native/reduce-kv)
+  reduce-kv
+  ;;@clojure.core-native/reduce-kv
+  (fn [f init coll] (reduce (fn [s [k v]] (f s k v)) init coll)))
 
 (defn- normalize-slurp-opts
   [opts]


### PR DESCRIPTION
Is this something you'd be interested in Jeaye? I know we're not optimizing right now, but I would like to explore alternatives to `sequenceable_in_place`. I wonder if this can compete with `sequenceable_in_place`.

I haven't looked into this warning yet, do you have any advice?

```
/home/runner/work/jank/jank/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp:1072:71: error: the const qualified parameter 'f' is copied for each invocation; consider making it a reference [performance-unnecessary-value-param,-warnings-as-errors]
 1072 |   object_ptr reduce(std::function<object *(object *, object *)> const f,
      |                                                                       ^
      |                                                                      &
```

I also tried making a `reduce` member function that takes a function pointer, and might try to make it a template.

I will look into writing benchmarks. Any pointers welcome.

Implementation taken from Clojure.