### PR TITLE
fix: character syntax under fn

### DIFF
--- a/compiler+runtime/src/cpp/jank/codegen/llvm_processor.cpp
+++ b/compiler+runtime/src/cpp/jank/codegen/llvm_processor.cpp
@@ -1401,7 +1401,7 @@ namespace jank::codegen
       auto const create_fn(
         ctx->module->getOrInsertFunction("jank_character_create", create_fn_type));
 
-      llvm::SmallVector<llvm::Value *, 1> const args{ gen_c_string(c->to_string()) };
+      llvm::SmallVector<llvm::Value *, 1> const args{ gen_c_string(c->to_code_string()) };
       auto const call(ctx->builder->CreateCall(create_fn, args));
       ctx->builder->CreateStore(call, global);
 


### PR DESCRIPTION
Closes https://github.com/jank-lang/jank/issues/226

```
clojure.core=> #(do \a)
clojure.core/clojure_core-fn-4370 (jit_function@0x7ee91c80c6c8)

clojure.core=> (#(do \a))
\a

clojure.core=> (#(do \b))
\b
```
