### PR TITLE
fix: nth should not respond to unordered collections

### DIFF
--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_string.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_string.hpp
@@ -45,8 +45,8 @@ namespace jank::runtime::obj
     native_bool contains(object_ptr key) const;
 
     /* behavior::indexable */
-    object_ptr nth(object_ptr const key) const;
-    object_ptr nth(object_ptr const key, object_ptr const fallback) const;
+    object_ptr nth(object_ptr const index) const;
+    object_ptr nth(object_ptr const index, object_ptr const fallback) const;
 
     string_result<persistent_string_ptr> substring(native_integer start) const;
     string_result<persistent_string_ptr> substring(native_integer start, native_integer end) const;

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_string.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_string.hpp
@@ -44,6 +44,9 @@ namespace jank::runtime::obj
     object_ptr get_entry(object_ptr key) const;
     native_bool contains(object_ptr key) const;
 
+    object_ptr nth(object_ptr const key) const;
+    object_ptr nth(object_ptr const key, object_ptr const fallback) const;
+
     string_result<persistent_string_ptr> substring(native_integer start) const;
     string_result<persistent_string_ptr> substring(native_integer start, native_integer end) const;
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_string.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_string.hpp
@@ -44,6 +44,7 @@ namespace jank::runtime::obj
     object_ptr get_entry(object_ptr key) const;
     native_bool contains(object_ptr key) const;
 
+    /* behavior::indexable */
     object_ptr nth(object_ptr const key) const;
     object_ptr nth(object_ptr const key, object_ptr const fallback) const;
 

--- a/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
@@ -790,6 +790,10 @@ namespace jank::runtime
         }
         else if constexpr(behavior::seqable<T>)
         {
+          if constexpr(!behavior::sequential<T> && !std::is_same_v<T, obj::persistent_string>)
+          {
+            throw std::runtime_error{ fmt::format("not ordered: {}", object_type_str(o->type)) };
+          }
           native_integer i{};
           for(auto it(typed_o->fresh_seq()); it != nullptr; it = next_in_place(it), ++i)
           {
@@ -830,6 +834,10 @@ namespace jank::runtime
         }
         else if constexpr(behavior::seqable<T>)
         {
+          if constexpr(!behavior::sequential<T> && !std::is_same_v<T, obj::persistent_string>)
+          {
+            throw std::runtime_error{ fmt::format("not ordered: {}", object_type_str(o->type)) };
+          }
           native_integer i{};
           for(auto it(typed_o->fresh_seq()); it != nullptr; it = next_in_place(it), ++i)
           {

--- a/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
@@ -788,12 +788,8 @@ namespace jank::runtime
         {
           return typed_o->nth(idx);
         }
-        else if constexpr(behavior::seqable<T>)
+        else if constexpr(behavior::seqable<T> && behavior::sequential<T>)
         {
-          if constexpr(!behavior::sequential<T> && !std::is_same_v<T, obj::persistent_string>)
-          {
-            throw std::runtime_error{ fmt::format("not ordered: {}", object_type_str(o->type)) };
-          }
           native_integer i{};
           for(auto it(typed_o->fresh_seq()); it != nullptr; it = next_in_place(it), ++i)
           {
@@ -832,12 +828,8 @@ namespace jank::runtime
         {
           return typed_o->nth(idx, fallback);
         }
-        else if constexpr(behavior::seqable<T>)
+        else if constexpr(behavior::seqable<T> && behavior::sequential<T>)
         {
-          if constexpr(!behavior::sequential<T> && !std::is_same_v<T, obj::persistent_string>)
-          {
-            throw std::runtime_error{ fmt::format("not ordered: {}", object_type_str(o->type)) };
-          }
           native_integer i{};
           for(auto it(typed_o->fresh_seq()); it != nullptr; it = next_in_place(it), ++i)
           {

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string.cpp
@@ -101,7 +101,22 @@ namespace jank::runtime::obj
 
   object_ptr persistent_string::nth(object_ptr const index) const
   {
-    return get(index);
+    if(index->type == object_type::integer)
+    {
+      auto const i(expect_object<integer>(index)->data);
+      if(i < 0 || data.size() <= static_cast<size_t>(i))
+      {
+        throw std::runtime_error{
+          fmt::format("out of bounds index {}; string has a size of {}", i, data.size())
+        };
+      }
+      return make_box<character>(data[i]);
+    }
+    else
+    {
+      throw std::runtime_error{ fmt::format("nth on a string must be an integer; found {}",
+                                            runtime::to_string(index)) };
+    }
   }
 
   object_ptr persistent_string::nth(object_ptr const index, object_ptr const fallback) const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string.cpp
@@ -99,6 +99,16 @@ namespace jank::runtime::obj
     throw std::runtime_error{ fmt::format("get_entry not supported on string") };
   }
 
+  object_ptr persistent_string::nth(object_ptr const index) const
+  {
+    return get(index);
+  }
+
+  object_ptr persistent_string::nth(object_ptr const index, object_ptr const fallback) const
+  {
+    return get(index, fallback);
+  }
+
   string_result<persistent_string_ptr> persistent_string::substring(native_integer start) const
   {
     return substring(start, static_cast<native_integer>(data.size()));


### PR DESCRIPTION
Closes https://github.com/jank-lang/jank/issues/211

```
clojure.core=> (nth {1 2} 0)
Exception: not ordered: persistent_array_map

clojure.core=> (nth #{1 2} 0)
Exception: not ordered: persistent_hash_set

clojure.core=> (nth [1] 0)
1

clojure.core=> (nth [] 0 123)
123

clojure.core=> (nth '(1 2) 0)
1

clojure.core=> (nth "abc" 1)
\b
```