### PR TITLE
fix: make `vswap!` callable

### DIFF
--- a/compiler+runtime/include/cpp/jank/runtime/core.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core.hpp
@@ -76,6 +76,7 @@ namespace jank::runtime
 
   object_ptr volatile_(object_ptr o);
   native_bool is_volatile(object_ptr o);
+  object_ptr vswap(object_ptr v, object_ptr fn);
   object_ptr vswap(object_ptr v, object_ptr fn, object_ptr args);
   object_ptr vreset(object_ptr v, object_ptr new_val);
 

--- a/compiler+runtime/src/cpp/clojure/core_native.cpp
+++ b/compiler+runtime/src/cpp/clojure/core_native.cpp
@@ -682,7 +682,6 @@ jank_object_ptr jank_load_clojure_core_native()
     intern_fn_obj("vswap!", fn);
   }
 
-
   {
     auto const fn(
       make_box<obj::jit_function>(behavior::callable::build_arity_flags(0, false, false)));

--- a/compiler+runtime/src/cpp/clojure/core_native.cpp
+++ b/compiler+runtime/src/cpp/clojure/core_native.cpp
@@ -396,7 +396,6 @@ jank_object_ptr jank_load_clojure_core_native()
   intern_fn("volatile!", &volatile_);
   intern_fn("volatile?", &is_volatile);
   intern_fn("vreset!", &vreset);
-  intern_fn("vswap!", &vswap);
   intern_fn("+", static_cast<object_ptr (*)(object_ptr, object_ptr)>(&add));
   intern_fn("-", static_cast<object_ptr (*)(object_ptr, object_ptr)>(&sub));
   intern_fn("/", static_cast<object_ptr (*)(object_ptr, object_ptr)>(&div));
@@ -672,6 +671,17 @@ jank_object_ptr jank_load_clojure_core_native()
     };
     intern_fn_obj("swap-vals!", fn);
   }
+
+  {
+    auto const fn(
+      make_box<obj::jit_function>(behavior::callable::build_arity_flags(2, true, true)));
+    fn->arity_2 = [](object * const vol, object * const fn) -> object * { return vswap(vol, fn); };
+    fn->arity_3 = [](object * const vol, object * const fn, object * const rest) -> object * {
+      return vswap(vol, fn, rest);
+    };
+    intern_fn_obj("vswap!", fn);
+  }
+
 
   {
     auto const fn(

--- a/compiler+runtime/src/cpp/jank/runtime/core.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core.cpp
@@ -556,6 +556,12 @@ namespace jank::runtime
     return o->type == object_type::volatile_;
   }
 
+  object_ptr vswap(object_ptr const v, object_ptr const fn)
+  {
+    auto const v_obj(expect_object<obj::volatile_>(v));
+    return v_obj->reset(dynamic_call(fn, v_obj->deref()));
+  }
+
   object_ptr vswap(object_ptr const v, object_ptr const fn, object_ptr const args)
   {
     auto const v_obj(expect_object<obj::volatile_>(v));

--- a/compiler+runtime/src/cpp/jank/runtime/core.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core.cpp
@@ -558,19 +558,19 @@ namespace jank::runtime
 
   object_ptr vswap(object_ptr const v, object_ptr const fn)
   {
-    auto const v_obj(expect_object<obj::volatile_>(v));
+    auto const v_obj(try_object<obj::volatile_>(v));
     return v_obj->reset(dynamic_call(fn, v_obj->deref()));
   }
 
   object_ptr vswap(object_ptr const v, object_ptr const fn, object_ptr const args)
   {
-    auto const v_obj(expect_object<obj::volatile_>(v));
+    auto const v_obj(try_object<obj::volatile_>(v));
     return v_obj->reset(apply_to(fn, make_box<obj::cons>(v_obj->deref(), args)));
   }
 
   object_ptr vreset(object_ptr const v, object_ptr const new_val)
   {
-    return expect_object<obj::volatile_>(v)->reset(new_val);
+    return try_object<obj::volatile_>(v)->reset(new_val);
   }
 
   void push_thread_bindings(object_ptr const o)


### PR DESCRIPTION
Closes https://github.com/jank-lang/jank/issues/245

```
clojure.core=> (def v (volatile! 1))
#'clojure.core/v

clojure.core=> (vswap! v inc)
2

clojure.core=> (vswap! v + 1)
3

clojure.core=> (vswap! v + 1 2)
6
```
