### PR TITLE
feature: Unbox var interning in the IR

### DIFF
--- a/compiler+runtime/include/cpp/jank/c_api.h
+++ b/compiler+runtime/include/cpp/jank/c_api.h
@@ -28,6 +28,7 @@ extern "C"
   void jank_ns_set_symbol_counter(char const * const ns, uint64_t const count);
 
   jank_object_ptr jank_var_intern(jank_object_ptr ns, jank_object_ptr name);
+  jank_object_ptr jank_var_intern_c(char const * const ns, char const * const name);
   jank_object_ptr jank_var_bind_root(jank_object_ptr var, jank_object_ptr val);
   jank_object_ptr jank_var_set_dynamic(jank_object_ptr var, jank_object_ptr dynamic);
 

--- a/compiler+runtime/src/cpp/jank/c_api.cpp
+++ b/compiler+runtime/src/cpp/jank/c_api.cpp
@@ -95,6 +95,14 @@ extern "C"
     return erase(__rt_ctx->intern_var(ns_obj->data, name_obj->data).expect_ok());
   }
 
+  jank_object_ptr jank_var_intern_c(char const * const ns, char const * const name)
+  {
+    auto const ns_string{ native_persistent_string(ns) };
+    __rt_ctx->intern_ns(ns_string);
+    auto const name_string{ native_persistent_string(name) };
+    return erase(__rt_ctx->intern_var(ns_string, name_string).expect_ok());
+  }
+
   jank_object_ptr jank_var_bind_root(jank_object_ptr const var, jank_object_ptr const val)
   {
     auto const var_obj(try_object<runtime::var>(reinterpret_cast<object *>(var)));

--- a/compiler+runtime/src/cpp/jank/c_api.cpp
+++ b/compiler+runtime/src/cpp/jank/c_api.cpp
@@ -97,10 +97,8 @@ extern "C"
 
   jank_object_ptr jank_var_intern_c(char const * const ns, char const * const name)
   {
-    auto const ns_string{ native_persistent_string(ns) };
-    __rt_ctx->intern_ns(ns_string);
-    auto const name_string{ native_persistent_string(name) };
-    return erase(__rt_ctx->intern_var(ns_string, name_string).expect_ok());
+    __rt_ctx->intern_ns(ns);
+    return erase(__rt_ctx->intern_var(ns, name).expect_ok());
   }
 
   jank_object_ptr jank_var_bind_root(jank_object_ptr const var, jank_object_ptr const val)

--- a/compiler+runtime/src/cpp/jank/codegen/llvm_processor.cpp
+++ b/compiler+runtime/src/cpp/jank/codegen/llvm_processor.cpp
@@ -1012,10 +1012,10 @@ namespace jank::codegen
         llvm::FunctionType::get(ctx->builder->getPtrTy(),
                                 { ctx->builder->getPtrTy(), ctx->builder->getPtrTy() },
                                 false));
-      auto const fn(ctx->module->getOrInsertFunction("jank_var_intern", fn_type));
+      auto const fn(ctx->module->getOrInsertFunction("jank_var_intern_c", fn_type));
 
-      llvm::SmallVector<llvm::Value *, 2> const args{ gen_global(make_box(qualified_name->ns)),
-                                                      gen_global(make_box(qualified_name->name)) };
+      llvm::SmallVector<llvm::Value *, 2> const args{ gen_c_string(qualified_name->ns),
+                                                      gen_c_string(qualified_name->name) };
       auto const call(ctx->builder->CreateCall(fn, args));
       ctx->builder->CreateStore(call, global);
 


### PR DESCRIPTION
This PR creates a new c_api function `jank_var_intern_c` used for interning vars just with c strings.

```shell
[monty@nixos:~/repos/jank/compiler+runtime]$ ./build/jank compile clojure.core | wc -l
162070
```