### PR TITLE
Fix Folly build issues related to memory allocators on MacOS

### DIFF
--- a/compiler+runtime/CMakeLists.txt
+++ b/compiler+runtime/CMakeLists.txt
@@ -27,6 +27,12 @@ project(
     # https://stackoverflow.com/questions/71740678/cmake-error-in-findterminfo-with-clang-15-on-macos
     LANGUAGES C CXX
 )
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS ON) # To enable GNU extensions, equivalent to gnu++20
+set(CMAKE_C_STANDARD 11) # Or C17, C99 - C11 is a safe default
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON) # If you need GNU C extensions
 
 # All options are available here.
 option(jank_local_clang "Whether or not to use a local Clang/LLVM source build" OFF)
@@ -90,8 +96,7 @@ set(
 
 set(
   jank_common_compiler_flags
-  -std=gnu++20
-  -DIMMER_HAS_LIBGC=1 -DIMMER_TAGGED_NODE=0 -DHAVE_CXX14=1
+  -DIMMER_HAS_LIBGC=1 -DIMMER_TAGGED_NODE=0 -DHAVE_CXX14=1 -DFOLLY_HAVE_JEMALLOC=0 -DFOLLY_HAVE_TCMALLOC=0 -DFOLLY_ASSUME_NO_JEMALLOC=1 -DFOLLY_ASSUME_NO_TCMALLOC=1
   #-DLIBASSERT_STATIC_DEFINE=1
   #-stdlib=libc++
 )
@@ -435,6 +440,17 @@ set_target_properties(folly_lib PROPERTIES ENABLE_EXPORTS 1)
 target_link_libraries(
   folly_lib PUBLIC
 )
+
+# ---- Folly Stubs ----
+# Provide stub implementations for jemalloc/tcmalloc symbols
+# that might still be referenced by Folly code even when disabled
+# via preprocessor flags, preventing linker errors.
+add_library(
+  folly_stubs STATIC
+  src/cpp/jank/folly_stubs.c
+)
+set_property(TARGET folly_stubs PROPERTY OUTPUT_NAME folly_stubs)
+
 # ---- libfolly.a ----
 
 # ---- jank executable ----
@@ -458,6 +474,7 @@ target_link_libraries(
   ${jank_link_whole_start} jank_lib ${jank_link_whole_end}
   ${jank_link_whole_start} nanobench_lib ${jank_link_whole_end}
   folly_lib
+  folly_stubs
 )
 
 jank_hook_llvm(jank_exe)
@@ -507,6 +524,7 @@ if(jank_tests)
     ${jank_link_whole_start} jank_lib ${jank_link_whole_end}
     ${jank_link_whole_start} nanobench_lib ${jank_link_whole_end}
     folly_lib
+    folly_stubs
     doctest::doctest
   )
 

--- a/compiler+runtime/bin/format
+++ b/compiler+runtime/bin/format
@@ -3,8 +3,9 @@
 set -euo pipefail
 
 git_root=$(git rev-parse --show-toplevel)
+clang_format=$(which clang-format)
 
 for i in $(git status | grep -E "modified:.*[hc]pp" | sed 's/modified:\s*//'); do
-  "${git_root}"/compiler+runtime/build/llvm-install/usr/local/bin/clang-format -i "${i}"
+  $clang_format -i "${i}"
   echo "formatted" "${i}"
 done

--- a/compiler+runtime/src/cpp/jank/folly_stubs.c
+++ b/compiler+runtime/src/cpp/jank/folly_stubs.c
@@ -1,0 +1,33 @@
+#include <stddef.h>
+#include <stdlib.h>
+
+/* Provide minimal implementations to satisfy the linker.
+ * These should ideally never be called if Folly is configured correctly via
+ * preprocessor flags like FOLLY_HAVE_JEMALLOC=0. If they *are* called,
+ * it indicates a configuration mismatch or unexpected code path in Folly.
+ */
+
+size_t nallocx(size_t size, int flags) {
+    /* This function normally returns a usable size for a requested allocation.
+     * Returning the requested size is a somewhat safe fallback, assuming
+     * the caller can handle it not being a jemalloc-optimized size.
+     */
+    (void)flags;
+    return size;
+}
+
+void* xallocx(void* ptr, size_t size, size_t extra, int flags) {
+    /* This function is tricky. It's related to resizing allocations.
+     * A true stub cannot replicate its behavior. Returning NULL is the
+     * safest option if this function is unexpectedly called, as it signals
+     * failure to resize/allocate without causing memory corruption.
+     * Callers like shrink_to_fit might handle a NULL return gracefully,
+     * or they might proceed assuming success, which could be problematic.
+     */
+    (void)ptr;
+    (void)size;
+    (void)extra;
+    (void)flags;
+    return NULL;
+}
+


### PR DESCRIPTION
This commit addresses several build failures encountered when compiling and linking against the selectively built Folly library, particularly concerning its integration with jemalloc and tcmalloc since these problem still happens on MacOS.

Problem:
- Linker errors due to undefined symbols like `_nallocx`, `_xallocx`, `_mallctl`, etc., referenced by Folly code.
- Compilation errors (conflicting preprocessor defines, missing headers) when attempting to disable allocator usage via flags.
- Compilation error when adding C stub file due to C++ standard flag being applied.

Solution:
- Added preprocessor flags (`-DFOLLY_HAVE_JEMALLOC=0`, `-DFOLLY_ASSUME_NO_JEMALLOC=1`, and equivalents for tcmalloc) to `jank_common_compiler_flags` to correctly signal Folly headers during compilation that these allocators are unavailable.
- Introduced `src/cpp/jank/folly_stubs.c` with minimal stub implementations for `_nallocx` and `_xallocx` to satisfy the linker.
- Created a `folly_stubs` static library for these stubs.
- Linked both `jank_exe` and `jank_test_exe` against `folly_stubs`.
- Refactored C/C++ standard setting to use CMake variables (`CMAKE_CXX_STANDARD`, `CMAKE_C_STANDARD`, etc.) instead of putting `-std=gnu++20` in common flags, fixing the C compilation error.

These changes allow the project and its tests to compile and link successfully without requiring jemalloc or tcmalloc.