### PR TITLE
fix: pass module name while evaluating cpp modules

### DIFF
--- a/compiler+runtime/include/cpp/jank/runtime/context.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/context.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "jtl/immutable_string.hpp"
 #include <list>
 
 #include <folly/Synchronized.h>
@@ -78,7 +79,8 @@ namespace jank::runtime
 
     object_ref eval_file(jtl::immutable_string const &path);
     object_ref eval_string(native_persistent_string_view const &code);
-    void eval_cpp_string(native_persistent_string_view const &code) const;
+    void eval_cpp_string(jtl::immutable_string const &module,
+                         native_persistent_string_view const &code) const;
     object_ref read_string(native_persistent_string_view const &code);
     native_vector<analyze::expression_ref>
     analyze_string(native_persistent_string_view const &code, bool const eval = true);
@@ -131,6 +133,9 @@ namespace jank::runtime
     jtl::string_result<void> pop_thread_bindings();
     obj::persistent_hash_map_ref get_thread_bindings() const;
     jtl::option<thread_binding_frame> current_thread_binding_frame();
+
+    bool is_loaded(jtl::immutable_string const &module);
+    void set_is_loaded(jtl::immutable_string const &module);
 
     /* The analyze processor is reused across evaluations so we can keep the semantic information
      * of previous code. This is essential for REPL use. */

--- a/compiler+runtime/include/cpp/jank/runtime/module/loader.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/module/loader.hpp
@@ -142,9 +142,6 @@ namespace jank::runtime::module
 
     jtl::string_result<find_result> find(jtl::immutable_string const &module, origin const ori);
 
-    bool is_loaded(jtl::immutable_string const &module);
-    void set_is_loaded(jtl::immutable_string const &module);
-
     jtl::string_result<void> load(jtl::immutable_string const &module, origin const ori);
     jtl::string_result<void>
     load_o(jtl::immutable_string const &module, file_entry const &entry) const;


### PR DESCRIPTION
Required to compile cpp backed module into object file