### PR TITLE
fix renaming jank_tests to jank_test

### DIFF
--- a/compiler+runtime/CMakeLists.txt
+++ b/compiler+runtime/CMakeLists.txt
@@ -108,7 +108,7 @@ elseif(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWith
   list(APPEND jank_common_compiler_flags -DJANK_RELEASE)
 endif()
 
-if(jank_tests)
+if(jank_test)
   list(APPEND jank_common_compiler_flags -DJANK_TEST)
 endif()
 
@@ -472,7 +472,7 @@ jank_hook_llvm(jank_exe)
 # ---- jank executable ----
 
 # ---- Tests ----
-if(jank_tests)
+if(jank_test)
   add_executable(
     jank_test_exe
     test/cpp/main.cpp

--- a/compiler+runtime/bin/jank/compiler+runtime/build+test.clj
+++ b/compiler+runtime/bin/jank/compiler+runtime/build+test.clj
@@ -25,7 +25,7 @@
                           "CCACHE_MAXSIZE" "1G"
                           "CTCACHE_DIR" (str compiler+runtime-dir "/.ctcache")})
           configure-flags ["-GNinja"
-                           "-Djank_tests=on"
+                           "-Djank_test=on"
                            (str "-DCMAKE_BUILD_TYPE=" build-type)
                            (str "-Djank_analyze=" analyze)
                            (str "-Djank_sanitize=" sanitize)


### PR DESCRIPTION
Fix building jank-test binary. 

The CMakeLists.txt file was broken in 222d0f6