### PR TITLE
GH ISSUE 209 | Verifying duplicate keys

### DIFF
--- a/compiler+runtime/include/cpp/jank/error.hpp
+++ b/compiler+runtime/include/cpp/jank/error.hpp
@@ -37,6 +37,7 @@ namespace jank::error
     parse_unterminated_map,
     parse_unterminated_set,
     parse_odd_entries_in_map,
+    parse_duplicate_keys_in_map,
     parse_invalid_quote,
     parse_invalid_meta_hint_value,
     parse_invalid_meta_hint_target,
@@ -129,6 +130,8 @@ namespace jank::error
         return "parse/unterminated-set";
       case kind::parse_odd_entries_in_map:
         return "parse/odd-entries-in-map";
+      case kind::parse_duplicate_keys_in_map:
+        return "parse/duplicate-keys-in-map";
       case kind::parse_invalid_quote:
         return "parse/invalid-quote";
       case kind::parse_invalid_meta_hint_value:

--- a/compiler+runtime/include/cpp/jank/error.hpp
+++ b/compiler+runtime/include/cpp/jank/error.hpp
@@ -38,6 +38,7 @@ namespace jank::error
     parse_unterminated_set,
     parse_odd_entries_in_map,
     parse_duplicate_keys_in_map,
+    parse_duplicate_items_in_set,
     parse_invalid_quote,
     parse_invalid_meta_hint_value,
     parse_invalid_meta_hint_target,
@@ -132,6 +133,8 @@ namespace jank::error
         return "parse/odd-entries-in-map";
       case kind::parse_duplicate_keys_in_map:
         return "parse/duplicate-keys-in-map";
+      case kind::parse_duplicate_items_in_set:
+        return "parse/duplicate-items-in-set";
       case kind::parse_invalid_quote:
         return "parse/invalid-quote";
       case kind::parse_invalid_meta_hint_value:

--- a/compiler+runtime/include/cpp/jank/error/parse.hpp
+++ b/compiler+runtime/include/cpp/jank/error/parse.hpp
@@ -16,6 +16,8 @@ namespace jank::error
   parse_odd_entries_in_map(read::source const &map_source, read::source const &last_key_source);
   error_ref parse_duplicate_keys_in_map(read::source const &duplicate_key_source,
                                         note const &original_key_source);
+  error_ref parse_duplicate_items_in_set(read::source const &duplicate_item_source,
+                                         note const &original_item_source);
   error_ref parse_invalid_quote(read::source const &source, jtl::immutable_string const &note);
   error_ref parse_invalid_meta_hint_value(read::source const &source);
   error_ref

--- a/compiler+runtime/include/cpp/jank/error/parse.hpp
+++ b/compiler+runtime/include/cpp/jank/error/parse.hpp
@@ -14,6 +14,8 @@ namespace jank::error
   error_ref parse_unterminated_set(read::source const &source);
   error_ref
   parse_odd_entries_in_map(read::source const &map_source, read::source const &last_key_source);
+  error_ref parse_duplicate_keys_in_map(read::source const &duplicate_key_source,
+                                        note const &original_key_source);
   error_ref parse_invalid_quote(read::source const &source, jtl::immutable_string const &note);
   error_ref parse_invalid_meta_hint_value(read::source const &source);
   error_ref

--- a/compiler+runtime/src/cpp/jank/error.cpp
+++ b/compiler+runtime/src/cpp/jank/error.cpp
@@ -57,6 +57,8 @@ namespace jank::error
         return "Odd number of entries in map.";
       case kind::parse_duplicate_keys_in_map:
         return "Duplicate keys in map literals are not allowed.";
+      case kind::parse_duplicate_items_in_set:
+        return "Duplicate items in set literals are not allowed.";
       case kind::parse_invalid_quote:
         return "Invalid quote.";
       case kind::parse_invalid_meta_hint_value:

--- a/compiler+runtime/src/cpp/jank/error.cpp
+++ b/compiler+runtime/src/cpp/jank/error.cpp
@@ -55,6 +55,8 @@ namespace jank::error
         return "Unterminated set.";
       case kind::parse_odd_entries_in_map:
         return "Odd number of entries in map.";
+      case kind::parse_duplicate_keys_in_map:
+        return "Duplicate keys in map literals are not allowed.";
       case kind::parse_invalid_quote:
         return "Invalid quote.";
       case kind::parse_invalid_meta_hint_value:

--- a/compiler+runtime/src/cpp/jank/error/parse.cpp
+++ b/compiler+runtime/src/cpp/jank/error/parse.cpp
@@ -108,6 +108,17 @@ namespace jank::error
                       note{ "No value for this key.", last_key_source });
   }
 
+  error_ref parse_duplicate_keys_in_map(read::source const &duplicate_key_source,
+                                        note const &original_key_source)
+  {
+    return make_error(kind::parse_duplicate_keys_in_map,
+                      duplicate_key_source,
+                      native_vector<note>{
+                        { "Duplicate key.", duplicate_key_source },
+                        original_key_source
+    });
+  }
+
   error_ref parse_invalid_quote(read::source const &source, jtl::immutable_string const &note)
   {
     return make_error(kind::parse_invalid_quote, source, note);

--- a/compiler+runtime/src/cpp/jank/error/parse.cpp
+++ b/compiler+runtime/src/cpp/jank/error/parse.cpp
@@ -119,6 +119,17 @@ namespace jank::error
     });
   }
 
+  error_ref parse_duplicate_items_in_set(read::source const &duplicate_item_source,
+                                         note const &original_item_source)
+  {
+    return make_error(kind::parse_duplicate_items_in_set,
+                      duplicate_item_source,
+                      native_vector<note>{
+                        { "Duplicate item.", duplicate_item_source },
+                        original_item_source
+    });
+  }
+
   error_ref parse_invalid_quote(read::source const &source, jtl::immutable_string const &note)
   {
     return make_error(kind::parse_invalid_quote, source, note);

--- a/compiler+runtime/src/cpp/jank/read/parse.cpp
+++ b/compiler+runtime/src/cpp/jank/read/parse.cpp
@@ -375,12 +375,12 @@ namespace jank::read::parse
       {
         return err(it.latest.unwrap().expect_err());
       }
-      auto const key(it.latest.unwrap().expect_ok());
+      auto const key(it.latest.unwrap().expect_ok().unwrap());
 
       if(++it == end())
       {
         return error::parse_odd_entries_in_map({ start_token.start, latest_token.end },
-                                               { key.unwrap().start.start, key.unwrap().end.end });
+                                               { key.start.start, key.end.end });
       }
 
       if(it.latest.unwrap().is_err())
@@ -389,21 +389,20 @@ namespace jank::read::parse
       }
       auto const value(it.latest.unwrap().expect_ok());
 
-      if(auto const parsed_key = parsed_keys.find(key.unwrap().ptr);
-         parsed_key != parsed_keys.end())
+      if(auto const parsed_key = parsed_keys.find(key.ptr); parsed_key != parsed_keys.end())
       {
         return error::parse_duplicate_keys_in_map(
           {
-            key.unwrap().start.start,
-            key.unwrap().end.end
+            key.start.start,
+            key.end.end
         },
           { "Original key.",
             { parsed_key->second.start.start, parsed_key->second.end.end },
             error::note::kind::info });
       }
 
-      parsed_keys.insert({ key.unwrap().ptr, key.unwrap() });
-      ret.insert_or_assign(key.unwrap().ptr, value.unwrap().ptr);
+      parsed_keys.insert({ key.ptr, key });
+      ret.insert_or_assign(key.ptr, value.unwrap().ptr);
     }
     if(expected_closer.is_some())
     {

--- a/compiler+runtime/test/cpp/jank/read/parse.cpp
+++ b/compiler+runtime/test/cpp/jank/read/parse.cpp
@@ -821,6 +821,14 @@ namespace jank::read::parse
         CHECK(r1.is_err());
       }
 
+      SUBCASE("Duplicate keys")
+      {
+        lex::processor lp{ "{:k1 1 :k2 2 :k1 2}" };
+        processor p{ lp.begin(), lp.end() };
+        auto const r1(p.next());
+        CHECK(r1.is_err());
+      }
+
       SUBCASE("Extra close")
       {
         lex::processor lp{ ":foo}" };

--- a/compiler+runtime/test/cpp/jank/read/parse.cpp
+++ b/compiler+runtime/test/cpp/jank/read/parse.cpp
@@ -1030,6 +1030,14 @@ namespace jank::read::parse
                         make_box(1),
                         make_box<obj::persistent_hash_set>(std::in_place, make_box(2)))));
         }
+
+        SUBCASE("Duplicate items")
+        {
+          lex::processor lp{ "#{:k1 1 :k2 :k1 2}" };
+          processor p{ lp.begin(), lp.end() };
+          auto const r1(p.next());
+          CHECK(r1.is_err());
+        }
       }
 
       SUBCASE("Comment")


### PR DESCRIPTION
Fixes for #209.

**Note to reviewer**: Due to the LLVM@19 issues I was not able to run the entire test suite.

Preview for duplicate map literal errors:

<img width="749" alt="image" src="https://github.com/user-attachments/assets/866e6edf-2d63-49c8-99e3-e5bb54da0d2b" />

Preview for duplicate set literal errors:

![image (1)](https://github.com/user-attachments/assets/1687e104-3847-4857-8a28-c674ce345578)
