### PR TITLE
Improve `native_array_map`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ rust/jank
 # CI thingies
 /llvm.sh
 /linux-install.sh
+
+# MacOS
+.DS_Store
+

--- a/compiler+runtime/CMakeLists.txt
+++ b/compiler+runtime/CMakeLists.txt
@@ -194,7 +194,7 @@ add_library(
   src/cpp/jank/runtime/perf.cpp
   src/cpp/jank/runtime/module/loader.cpp
   src/cpp/jank/runtime/object.cpp
-  src/cpp/jank/runtime/detail/native_persistent_array_map.cpp
+  src/cpp/jank/runtime/detail/native_array_map.cpp
   src/cpp/jank/runtime/context.cpp
   src/cpp/jank/runtime/ns.cpp
   src/cpp/jank/runtime/var.cpp

--- a/compiler+runtime/include/cpp/jank/read/parse.hpp
+++ b/compiler+runtime/include/cpp/jank/read/parse.hpp
@@ -55,10 +55,9 @@ namespace jank::read::parse
       iterator &operator++();
       bool operator!=(iterator const &rhs) const;
       bool operator==(iterator const &rhs) const;
-      iterator &operator=(iterator const &);
 
       jtl::option<value_type> latest;
-      processor &p;
+      jtl::ref<processor> p;
     };
 
     processor(lex::processor::iterator const &b, lex::processor::iterator const &e);

--- a/compiler+runtime/include/cpp/jank/runtime/detail/native_array_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/detail/native_array_map.hpp
@@ -86,7 +86,7 @@ namespace jank::runtime::detail
     native_array_map clone() const;
 
     object_ref *data{};
-    usize reserved_length{};
+    usize cap{};
     usize length{};
     mutable uhash hash{};
   };

--- a/compiler+runtime/include/cpp/jank/runtime/detail/native_array_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/detail/native_array_map.hpp
@@ -15,25 +15,25 @@ namespace jank::runtime::detail
 
   /* This is a short map, storing a vector of pairs. This is only until immer has proper
    * support for short maps and map transients. */
-  struct native_persistent_array_map
+  struct native_array_map
   {
     /* Array maps are fast only for a small number of keys. Clojure JVM uses a threshold of 8
      * k/v pairs, thus 16 elements. We follow the same. */
     /* TODO: Benchmark difference thresholds. */
     static constexpr usize max_size{ 8 };
 
-    native_persistent_array_map() = default;
-    native_persistent_array_map(native_persistent_array_map const &s) = default;
-    native_persistent_array_map(native_persistent_array_map &&s) noexcept = default;
+    native_array_map() = default;
+    native_array_map(native_array_map const &s) = default;
+    native_array_map(native_array_map &&s) noexcept = default;
 
     template <typename L, typename E = std::enable_if_t<std::is_integral_v<L>>>
-    native_persistent_array_map(in_place_unique, jtl::ref<object_ref> const kvs, L const l)
+    native_array_map(in_place_unique, jtl::ref<object_ref> const kvs, L const l)
       : data{ std::move(kvs.data) }
       , length{ static_cast<decltype(length)>(l) }
     {
     }
 
-    ~native_persistent_array_map() = default;
+    ~native_array_map() = default;
 
     void insert_unique(object_ref const key, object_ref const val);
 
@@ -80,7 +80,7 @@ namespace jank::runtime::detail
 
     bool empty() const;
 
-    native_persistent_array_map clone() const;
+    native_array_map clone() const;
 
     object_ref *data{};
     usize length{};

--- a/compiler+runtime/include/cpp/jank/runtime/detail/native_array_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/detail/native_array_map.hpp
@@ -76,6 +76,9 @@ namespace jank::runtime::detail
     const_iterator begin() const;
     const_iterator end() const;
 
+    void reserve(usize const size);
+
+    usize capacity() const;
     usize size() const;
 
     bool empty() const;
@@ -83,6 +86,7 @@ namespace jank::runtime::detail
     native_array_map clone() const;
 
     object_ref *data{};
+    usize reserved_length{};
     usize length{};
     mutable uhash hash{};
   };

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_array_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_array_map.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <jank/runtime/object.hpp>
-#include <jank/runtime/detail/native_persistent_array_map.hpp>
+#include <jank/runtime/detail/native_array_map.hpp>
 #include <jank/runtime/obj/persistent_array_map_sequence.hpp>
 #include <jank/runtime/obj/detail/base_persistent_map.hpp>
 
@@ -13,14 +13,13 @@ namespace jank::runtime::obj
   struct persistent_array_map
     : obj::detail::base_persistent_map<persistent_array_map,
                                        persistent_array_map_sequence,
-                                       runtime::detail::native_persistent_array_map>
+                                       runtime::detail::native_array_map>
   {
     static constexpr object_type obj_type{ object_type::persistent_array_map };
     static constexpr usize max_size{ value_type::max_size };
-    using parent_type
-      = obj::detail::base_persistent_map<persistent_array_map,
-                                         persistent_array_map_sequence,
-                                         runtime::detail::native_persistent_array_map>;
+    using parent_type = obj::detail::base_persistent_map<persistent_array_map,
+                                                         persistent_array_map_sequence,
+                                                         runtime::detail::native_array_map>;
 
 
     persistent_array_map() = default;

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_array_map_sequence.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_array_map_sequence.hpp
@@ -1,16 +1,15 @@
 #pragma once
 
 #include <jank/runtime/obj/detail/base_persistent_map_sequence.hpp>
-#include <jank/runtime/detail/native_persistent_array_map.hpp>
+#include <jank/runtime/detail/native_array_map.hpp>
 
 namespace jank::runtime::obj
 {
   using persistent_array_map_sequence_ref = oref<struct persistent_array_map_sequence>;
 
   struct persistent_array_map_sequence
-    : detail::base_persistent_map_sequence<
-        persistent_array_map_sequence,
-        runtime::detail::native_persistent_array_map::const_iterator>
+    : detail::base_persistent_map_sequence<persistent_array_map_sequence,
+                                           runtime::detail::native_array_map::const_iterator>
   {
     static constexpr object_type obj_type{ object_type::persistent_array_map_sequence };
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_hash_map.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <jank/runtime/object.hpp>
-#include <jank/runtime/detail/native_persistent_array_map.hpp>
+#include <jank/runtime/detail/native_array_map.hpp>
 #include <jank/runtime/obj/persistent_hash_map_sequence.hpp>
 #include <jank/runtime/obj/detail/base_persistent_map.hpp>
 
@@ -28,7 +28,7 @@ namespace jank::runtime::obj
     persistent_hash_map(persistent_hash_map &&) noexcept = default;
     persistent_hash_map(persistent_hash_map const &) = default;
     persistent_hash_map(jtl::option<object_ref> const &meta,
-                        runtime::detail::native_persistent_array_map const &m,
+                        runtime::detail::native_array_map const &m,
                         object_ref key,
                         object_ref val);
     persistent_hash_map(value_type &&d);

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_sorted_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_sorted_map.hpp
@@ -3,7 +3,7 @@
 #include <jank/runtime/object.hpp>
 #include <jank/runtime/obj/persistent_sorted_map_sequence.hpp>
 #include <jank/runtime/obj/detail/base_persistent_map.hpp>
-#include <jank/runtime/detail/native_persistent_array_map.hpp>
+#include <jank/runtime/detail/native_array_map.hpp>
 
 namespace jank::runtime::obj
 {

--- a/compiler+runtime/include/cpp/jank/runtime/obj/transient_hash_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/transient_hash_map.hpp
@@ -5,7 +5,7 @@
 
 namespace jank::runtime::detail
 {
-  struct native_persistent_array_map;
+  struct native_array_map;
 }
 
 namespace jank::runtime::obj
@@ -25,7 +25,7 @@ namespace jank::runtime::obj
     transient_hash_map(transient_hash_map const &) = default;
     transient_hash_map(runtime::detail::native_persistent_hash_map const &d);
     transient_hash_map(runtime::detail::native_persistent_hash_map &&d);
-    transient_hash_map(runtime::detail::native_persistent_array_map const &m);
+    transient_hash_map(runtime::detail::native_array_map const &m);
     transient_hash_map(value_type &&d);
 
     static transient_hash_map_ref empty();

--- a/compiler+runtime/src/cpp/jank/analyze/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/analyze/processor.cpp
@@ -1704,7 +1704,6 @@ namespace jank::analyze
           exprs.emplace_back(k_expr.expect_ok_move(), v_expr.expect_ok_move());
         }
 
-        /* TODO: Uniqueness check. */
         return jtl::make_ref<expr::map>(position,
                                         current_frame,
                                         true,

--- a/compiler+runtime/src/cpp/jank/read/parse.cpp
+++ b/compiler+runtime/src/cpp/jank/read/parse.cpp
@@ -421,7 +421,7 @@ namespace jank::read::parse
     });
 
     /* TODO: use transients to build up maps. */
-    if(items.size() <= runtime::detail::native_persistent_array_map::max_size)
+    if((items.size() / 2) <= runtime::detail::native_persistent_array_map::max_size)
     {
       runtime::detail::native_persistent_array_map map{};
       auto res = build_map(map);

--- a/compiler+runtime/src/cpp/jank/read/parse.cpp
+++ b/compiler+runtime/src/cpp/jank/read/parse.cpp
@@ -407,7 +407,7 @@ namespace jank::read::parse
 
         parsed_keys.insert({ key.ptr, key });
 
-        if constexpr(std::same_as<T, runtime::detail::native_persistent_array_map>)
+        if constexpr(std::same_as<T, runtime::detail::native_array_map>)
         {
           map.insert_or_assign(key.ptr, value.unwrap().ptr);
         }
@@ -421,9 +421,9 @@ namespace jank::read::parse
     });
 
     /* TODO: use transients to build up maps. */
-    if((items.size() / 2) <= runtime::detail::native_persistent_array_map::max_size)
+    if((items.size() / 2) <= runtime::detail::native_array_map::max_size)
     {
-      runtime::detail::native_persistent_array_map map{};
+      runtime::detail::native_array_map map{};
       auto res = build_map(map);
 
       if(res.is_err())

--- a/compiler+runtime/src/cpp/jank/read/parse.cpp
+++ b/compiler+runtime/src/cpp/jank/read/parse.cpp
@@ -420,10 +420,10 @@ namespace jank::read::parse
       return jtl::ok();
     });
 
-    /* TODO: use transients to build up maps. */
     if((items.size() / 2) <= runtime::detail::native_array_map::max_size)
     {
       runtime::detail::native_array_map map{};
+      map.reserve(items.size() / 2);
       auto res = build_map(map);
 
       if(res.is_err())
@@ -439,6 +439,7 @@ namespace jank::read::parse
     }
     else
     {
+      /* TODO: use transients to build up maps. */
       runtime::detail::native_persistent_hash_map map{};
       auto res = build_map(map);
 

--- a/compiler+runtime/src/cpp/jank/runtime/detail/native_array_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/detail/native_array_map.cpp
@@ -1,4 +1,4 @@
-#include <jank/runtime/detail/native_persistent_array_map.hpp>
+#include <jank/runtime/detail/native_array_map.hpp>
 #include <jank/runtime/core/equal.hpp>
 #include <jank/util/fmt.hpp>
 
@@ -109,14 +109,14 @@ namespace jank::runtime::detail
     }
   }
 
-  void native_persistent_array_map::insert_unique(object_ref const key, object_ref const val)
+  void native_array_map::insert_unique(object_ref const key, object_ref const val)
   {
     data = make_next_array(data, length, key, val);
     length += 2;
     hash = 0;
   }
 
-  void native_persistent_array_map::insert_or_assign(object_ref const key, object_ref const val)
+  void native_array_map::insert_or_assign(object_ref const key, object_ref const val)
   {
     if(key->type == runtime::object_type::keyword)
     {
@@ -145,7 +145,7 @@ namespace jank::runtime::detail
     insert_unique(key, val);
   }
 
-  object_ref native_persistent_array_map::find(object_ref const key) const
+  object_ref native_array_map::find(object_ref const key) const
   {
     if(key->type == runtime::object_type::keyword)
     {
@@ -170,7 +170,7 @@ namespace jank::runtime::detail
     return {};
   }
 
-  void native_persistent_array_map::erase(object_ref const key)
+  void native_array_map::erase(object_ref const key)
   {
     if(key->type == runtime::object_type::keyword)
     {
@@ -210,7 +210,7 @@ namespace jank::runtime::detail
     }
   }
 
-  uhash native_persistent_array_map::to_hash() const
+  uhash native_array_map::to_hash() const
   {
     if(hash != 0)
     {
@@ -220,36 +220,35 @@ namespace jank::runtime::detail
     return hash = hash::unordered(begin(), end());
   }
 
-  native_persistent_array_map::iterator::iterator(object_ref const * const data, usize const index)
+  native_array_map::iterator::iterator(object_ref const * const data, usize const index)
     : data{ data }
     , index{ index }
   {
   }
 
-  native_persistent_array_map::iterator::value_type
-  native_persistent_array_map::iterator::operator*() const
+  native_array_map::iterator::value_type native_array_map::iterator::operator*() const
   {
     return { data[index], data[index + 1] };
   }
 
-  native_persistent_array_map::iterator &native_persistent_array_map::iterator::operator++()
+  native_array_map::iterator &native_array_map::iterator::operator++()
   {
     index += 2;
     return *this;
   }
 
-  bool native_persistent_array_map::iterator::operator!=(iterator const &rhs) const
+  bool native_array_map::iterator::operator!=(iterator const &rhs) const
   {
     return data != rhs.data || index != rhs.index;
   }
 
-  bool native_persistent_array_map::iterator::operator==(iterator const &rhs) const
+  bool native_array_map::iterator::operator==(iterator const &rhs) const
   {
     return !(*this != rhs);
   }
 
-  native_persistent_array_map::iterator &
-  native_persistent_array_map::iterator::operator=(native_persistent_array_map::iterator const &rhs)
+  native_array_map::iterator &
+  native_array_map::iterator::operator=(native_array_map::iterator const &rhs)
   {
     if(this == &rhs)
     {
@@ -261,29 +260,29 @@ namespace jank::runtime::detail
     return *this;
   }
 
-  native_persistent_array_map::const_iterator native_persistent_array_map::begin() const
+  native_array_map::const_iterator native_array_map::begin() const
   {
     return const_iterator{ data, 0 };
   }
 
-  native_persistent_array_map::const_iterator native_persistent_array_map::end() const
+  native_array_map::const_iterator native_array_map::end() const
   {
     return const_iterator{ data, length };
   }
 
-  usize native_persistent_array_map::size() const
+  usize native_array_map::size() const
   {
     return length / 2;
   }
 
-  bool native_persistent_array_map::empty() const
+  bool native_array_map::empty() const
   {
     return length == 0;
   }
 
-  native_persistent_array_map native_persistent_array_map::clone() const
+  native_array_map native_array_map::clone() const
   {
-    native_persistent_array_map ret{ *this };
+    native_array_map ret{ *this };
     ret.data = new(GC) object_ref[length];
     memcpy(ret.data, data, length * sizeof(object_ref));
     return ret;

--- a/compiler+runtime/src/cpp/jank/runtime/detail/native_persistent_array_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/detail/native_persistent_array_map.cpp
@@ -101,9 +101,11 @@ namespace jank::runtime::detail
                                                  value });
           return ret;
         }
-      // TODO: Convert to hash map.
       default:
-        throw std::runtime_error{ util::format("unsupported array size: {}", length + 2) };
+        throw std::runtime_error{ util::format(
+          "Unable to expand array map to size {}. Be sure to check the size prior to insertion and "
+          "promote to hash map if needed.",
+          (length / 2) + 1) };
     }
   }
 

--- a/compiler+runtime/src/cpp/jank/runtime/obj/detail/base_persistent_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/detail/base_persistent_map.cpp
@@ -198,7 +198,7 @@ namespace jank::runtime::obj::detail
 
   template struct base_persistent_map<persistent_array_map,
                                       persistent_array_map_sequence,
-                                      runtime::detail::native_persistent_array_map>;
+                                      runtime::detail::native_array_map>;
   template struct base_persistent_map<persistent_hash_map,
                                       persistent_hash_map_sequence,
                                       runtime::detail::native_persistent_hash_map>;

--- a/compiler+runtime/src/cpp/jank/runtime/obj/detail/base_persistent_map_sequence.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/detail/base_persistent_map_sequence.cpp
@@ -146,9 +146,8 @@ namespace jank::runtime::obj::detail
   template struct base_persistent_map_sequence<
     persistent_hash_map_sequence,
     runtime::detail::native_persistent_hash_map::const_iterator>;
-  template struct base_persistent_map_sequence<
-    persistent_array_map_sequence,
-    runtime::detail::native_persistent_array_map::const_iterator>;
+  template struct base_persistent_map_sequence<persistent_array_map_sequence,
+                                               runtime::detail::native_array_map::const_iterator>;
   template struct base_persistent_map_sequence<
     persistent_sorted_map_sequence,
     runtime::detail::native_persistent_sorted_map::const_iterator>;

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_array_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_array_map.cpp
@@ -66,7 +66,7 @@ namespace jank::runtime::obj
      * promoting to a hash map.
      *
      * TODO: Benchmark if it's faster to have this behavior or to check first. */
-    if(data.size() == runtime::detail::native_persistent_array_map::max_size)
+    if(data.size() == runtime::detail::native_array_map::max_size)
     {
       return make_box<persistent_hash_map>(meta, data, key, val);
     }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_hash_map.cpp
@@ -10,7 +10,7 @@
 namespace jank::runtime::obj
 {
   persistent_hash_map::persistent_hash_map(jtl::option<object_ref> const &meta,
-                                           runtime::detail::native_persistent_array_map const &m,
+                                           runtime::detail::native_array_map const &m,
                                            object_ref const key,
                                            object_ref const val)
     : parent_type{ meta }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/transient_hash_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/transient_hash_map.cpp
@@ -5,7 +5,7 @@
 #include <jank/runtime/rtti.hpp>
 #include <jank/runtime/core/to_string.hpp>
 #include <jank/runtime/core/seq.hpp>
-#include <jank/runtime/detail/native_persistent_array_map.hpp>
+#include <jank/runtime/detail/native_array_map.hpp>
 #include <jank/util/fmt.hpp>
 
 namespace jank::runtime::obj
@@ -25,7 +25,7 @@ namespace jank::runtime::obj
   {
   }
 
-  transient_hash_map::transient_hash_map(runtime::detail::native_persistent_array_map const &m)
+  transient_hash_map::transient_hash_map(runtime::detail::native_array_map const &m)
   {
     for(auto const &e : m)
     {

--- a/compiler+runtime/test/cpp/jank/read/parse.cpp
+++ b/compiler+runtime/test/cpp/jank/read/parse.cpp
@@ -823,20 +823,36 @@ namespace jank::read::parse
 
       SUBCASE("Promoted maps")
       {
-        jtl::immutable_string const source{
-          "{:k1 1 :k2 2 :k3 3 :k4 4 :k5 5 :k6 6 :k7 7 :k8 8 :k9 9 :k10 10}"
+        jtl::immutable_string const array_map_source{
+          "{:k1 1 :k2 2 :k3 3 :k4 4 :k5 5 :k6 6 :k7 7 :k8 8}"
         };
-        lex::processor lp{ source };
-        processor p{ lp.begin(), lp.end() };
-        auto const r(p.next());
+        lex::processor lp1{ array_map_source };
+        processor p1{ lp1.begin(), lp1.end() };
+        auto const r1(p1.next());
 
-        CHECK(r.is_ok());
+        CHECK(r1.is_ok());
 
-        auto const t(r.expect_ok().unwrap());
+        auto const t1(r1.expect_ok().unwrap().ptr);
 
-        CHECK(t.ptr.data->type == object_type::persistent_hash_map);
-        CHECK(t.start == lex::token{ 0, 1, lex::token_kind::open_curly_bracket });
-        CHECK(t.end == lex::token{ source.size() - 1, 1, lex::token_kind::close_curly_bracket });
+        CHECK(expect_object<obj::persistent_array_map>(t1)->data.size()
+              <= detail::native_persistent_array_map::max_size);
+
+        jtl::immutable_string const hash_map_source{
+          "{:k1 1 :k2 2 :k3 3 :k4 4 :k5 5 :k6 6 :k7 7 :k8 8 :k9 9}"
+        };
+        lex::processor lp2{ hash_map_source };
+        processor p2{ lp2.begin(), lp2.end() };
+        auto const r2(p2.next());
+
+        CHECK(r2.is_ok());
+
+        auto const t2(r2.expect_ok().unwrap().ptr);
+
+        CHECK(t2.data->type == object_type::persistent_hash_map);
+        CHECK(r2.expect_ok().unwrap().start
+              == lex::token{ 0, 1, lex::token_kind::open_curly_bracket });
+        CHECK(r2.expect_ok().unwrap().end
+              == lex::token{ hash_map_source.size() - 1, 1, lex::token_kind::close_curly_bracket });
       }
 
       SUBCASE("Duplicate keys")

--- a/compiler+runtime/test/cpp/jank/read/parse.cpp
+++ b/compiler+runtime/test/cpp/jank/read/parse.cpp
@@ -821,6 +821,14 @@ namespace jank::read::parse
         CHECK(r1.is_err());
       }
 
+      SUBCASE("Promoted maps")
+      {
+        lex::processor lp{ "{:k1 1 :k2 2 :k3 3 :k4 4 :k5 5 :k6 6 :k7 7 :k8 8 :k9 9 :k10 10}" };
+        processor p{ lp.begin(), lp.end() };
+        auto const r1(p.next());
+        CHECK(r1.is_ok());
+      }
+
       SUBCASE("Duplicate keys")
       {
         lex::processor lp{ "{:k1 1 :k2 2 :k1 2}" };

--- a/compiler+runtime/test/cpp/jank/read/parse.cpp
+++ b/compiler+runtime/test/cpp/jank/read/parse.cpp
@@ -823,10 +823,20 @@ namespace jank::read::parse
 
       SUBCASE("Promoted maps")
       {
-        lex::processor lp{ "{:k1 1 :k2 2 :k3 3 :k4 4 :k5 5 :k6 6 :k7 7 :k8 8 :k9 9 :k10 10}" };
+        jtl::immutable_string const source{
+          "{:k1 1 :k2 2 :k3 3 :k4 4 :k5 5 :k6 6 :k7 7 :k8 8 :k9 9 :k10 10}"
+        };
+        lex::processor lp{ source };
         processor p{ lp.begin(), lp.end() };
-        auto const r1(p.next());
-        CHECK(r1.is_ok());
+        auto const r(p.next());
+
+        CHECK(r.is_ok());
+
+        auto const t(r.expect_ok().unwrap());
+
+        CHECK(t.ptr.data->type == object_type::persistent_hash_map);
+        CHECK(t.start == lex::token{ 0, 1, lex::token_kind::open_curly_bracket });
+        CHECK(t.end == lex::token{ source.size() - 1, 1, lex::token_kind::close_curly_bracket });
       }
 
       SUBCASE("Duplicate keys")

--- a/compiler+runtime/test/cpp/jank/read/parse.cpp
+++ b/compiler+runtime/test/cpp/jank/read/parse.cpp
@@ -12,6 +12,7 @@
 #include <jank/runtime/obj/persistent_hash_set.hpp>
 #include <jank/runtime/obj/persistent_vector.hpp>
 #include <jank/runtime/obj/persistent_array_map.hpp>
+#include <jank/runtime/obj/persistent_hash_map.hpp>
 #include <jank/runtime/obj/keyword.hpp>
 #include <jank/util/escape.hpp>
 #include <jank/util/fmt.hpp>
@@ -832,10 +833,9 @@ namespace jank::read::parse
 
         CHECK(r1.is_ok());
 
-        auto const t1(r1.expect_ok().unwrap().ptr);
+        auto const t1(try_object<obj::persistent_array_map>(r1.expect_ok().unwrap().ptr));
 
-        CHECK(expect_object<obj::persistent_array_map>(t1)->data.size()
-              <= detail::native_persistent_array_map::max_size);
+        CHECK(t1->data.size() <= detail::native_persistent_array_map::max_size);
 
         jtl::immutable_string const hash_map_source{
           "{:k1 1 :k2 2 :k3 3 :k4 4 :k5 5 :k6 6 :k7 7 :k8 8 :k9 9}"
@@ -846,13 +846,9 @@ namespace jank::read::parse
 
         CHECK(r2.is_ok());
 
-        auto const t2(r2.expect_ok().unwrap().ptr);
+        auto const t2(try_object<obj::persistent_hash_map>(r2.expect_ok().unwrap().ptr));
 
-        CHECK(t2.data->type == object_type::persistent_hash_map);
-        CHECK(r2.expect_ok().unwrap().start
-              == lex::token{ 0, 1, lex::token_kind::open_curly_bracket });
-        CHECK(r2.expect_ok().unwrap().end
-              == lex::token{ hash_map_source.size() - 1, 1, lex::token_kind::close_curly_bracket });
+        CHECK(t2->data.size() > detail::native_persistent_array_map::max_size);
       }
 
       SUBCASE("Duplicate keys")

--- a/compiler+runtime/test/cpp/jank/read/parse.cpp
+++ b/compiler+runtime/test/cpp/jank/read/parse.cpp
@@ -835,7 +835,7 @@ namespace jank::read::parse
 
         auto const t1(try_object<obj::persistent_array_map>(r1.expect_ok().unwrap().ptr));
 
-        CHECK(t1->data.size() <= detail::native_persistent_array_map::max_size);
+        CHECK(t1->data.size() <= detail::native_array_map::max_size);
 
         jtl::immutable_string const hash_map_source{
           "{:k1 1 :k2 2 :k3 3 :k4 4 :k5 5 :k6 6 :k7 7 :k8 8 :k9 9}"
@@ -848,7 +848,7 @@ namespace jank::read::parse
 
         auto const t2(try_object<obj::persistent_hash_map>(r2.expect_ok().unwrap().ptr));
 
-        CHECK(t2->data.size() > detail::native_persistent_array_map::max_size);
+        CHECK(t2->data.size() > detail::native_array_map::max_size);
       }
 
       SUBCASE("Duplicate keys")


### PR DESCRIPTION
- Rename the incorrectly named `native_persistent_array_map` to `native_array_map`.
- Add capability to preallocate the backing array.