### PR TITLE
Use __rt_ctx->jit_prc.interpreter to getTargetTriple

### DIFF
--- a/compiler+runtime/src/cpp/jank/codegen/llvm_processor.cpp
+++ b/compiler+runtime/src/cpp/jank/codegen/llvm_processor.cpp
@@ -268,7 +268,8 @@ namespace jank::codegen
     /* The LLVM front-end tips documentation suggests setting the target triple and
      * data layout to improve back-end codegen performance. */
     auto const raw_module{ module.getModuleUnlocked() };
-    raw_module->setTargetTriple(llvm::Triple{ llvm::sys::getDefaultTargetTriple() });
+    raw_module->setTargetTriple(
+      __rt_ctx->jit_prc.interpreter->getExecutionEngine()->getTargetTriple());
     raw_module->setDataLayout(__rt_ctx->jit_prc.interpreter->getExecutionEngine()->getDataLayout());
 
     /* TODO: Add more passes and measure the order of the passes. */


### PR DESCRIPTION
This resolves warnings like 

```
warning: Linking two modules of different target triples: 'incr_module_2' is 'arm64-apple-macosx15.0.0' whereas 'clojure.core$cpp_raw_12719-12724' is 'arm64-apple-darwin24.6.0'
```