### PR TITLE
Remove bdwgc::gccpp and add bdwgc::gctba

### DIFF
--- a/compiler+runtime/CMakeLists.txt
+++ b/compiler+runtime/CMakeLists.txt
@@ -278,7 +278,7 @@ add_custom_command(
           ftxui::screen ftxui::dom
           Boost::multiprecision
           nanobench_lib
-          bdwgc::gc bdwgc::gccpp
+          bdwgc::gc bdwgc::gctba
           folly_lib
   OUTPUT ${CMAKE_BINARY_DIR}/libjank.a
   COMMAND_EXPAND_LISTS
@@ -499,7 +499,7 @@ target_link_libraries(
   ftxui::screen ftxui::dom
   Boost::multiprecision
   nanobench_lib
-  bdwgc::gc bdwgc::gccpp
+  bdwgc::gc bdwgc::gctba
 )
 
 jank_hook_llvm(jank_lib)

--- a/compiler+runtime/cmake/dependency/bdwgc.cmake
+++ b/compiler+runtime/cmake/dependency/bdwgc.cmake
@@ -9,8 +9,7 @@ set(CMAKE_CXX_CLANG_TIDY_OLD ${CMAKE_CXX_CLANG_TIDY})
   set(enable_cplusplus ON CACHE BOOL "Enable C++")
   set(build_cord OFF CACHE BOOL "Build cord")
   set(enable_docs OFF CACHE BOOL "Enable docs")
-  set(enable_throw_bad_alloc_library OFF CACHE BOOL "Enable C++ gctba library build")
-
+  set(enable_throw_bad_alloc_library ON CACHE BOOL "Enable C++ gctba library build")
   add_subdirectory(third-party/bdwgc EXCLUDE_FROM_ALL)
 
   unset(enable_cplusplus)


### PR DESCRIPTION
This is to prevent overriding the global new/deleted keywords

Overriding the global new/delete does not play well with third party libs like libtorch