### PR TITLE
Flinner/faster clone

### DIFF
--- a/compiler+runtime/bin/build-clang
+++ b/compiler+runtime/bin/build-clang
@@ -51,7 +51,7 @@ function prepare()
 {
   if [[ ! -d "${srcdir}/llvm" ]];
   then
-    git clone -b "${llvm_branch}" --shallow-submodules --single-branch "${llvm_url}" "${srcdir}"/llvm
+    git clone -b "${llvm_branch}" --depth 1 --shallow-submodules --single-branch "${llvm_url}" "${srcdir}"/llvm
   fi
 }
 

--- a/compiler+runtime/doc/build.md
+++ b/compiler+runtime/doc/build.md
@@ -41,10 +41,10 @@ export CPPFLAGS="-I/opt/homebrew/opt/llvm/include ${CPPFLAGS}"
 Clone the repo as follows:
 
 ```bash
-git clone --recurse-submodules https://github.com/jank-lang/jank.git
+git clone --depth 1 --single-branch --shallow-submodules --recurse-submodules https://github.com/jank-lang/jank.git
 
 # If you didn't recurse submodules when cloning, you'll need to run this.
-git submodule update --recursive --init
+git submodule update --init --recursive --depth 1 --jobs 8
 ```
 
 ## Compiling Clang/LLVM


### PR DESCRIPTION
While working on the AUR PKGBUILD, LLVM cloning is a bit a too slow. added `--depth 1` for the build script, and documentation,

```bash
/usr/bin/time git clone https://github.com/llvm/llvm-project.git --shallow-submodules --single-branch 
990.09user 59.99system 4:10.97elapsed 418%CPU (0avgtext+0avgdata 1458280maxresident)k
0inputs+0outputs (0major+294278minor)pagefaults 0swaps
took 4m10s


/usr/bin/time git clone https://github.com/llvm/llvm-project.git --shallow-submodules --single-branch --depth 1
32.27user 5.68system 1:11.83elapsed 52%CPU (0avgtext+0avgdata 426672maxresident)k
0inputs+0outputs (0major+65075minor)pagefaults 0swaps
/tmp took 1m11s
```