### PR TITLE
Remove mentions of `import`

### DIFF
--- a/compiler+runtime/src/jank/clojure/core.jank
+++ b/compiler+runtime/src/jank/clojure/core.jank
@@ -5102,7 +5102,7 @@
   (throw "TODO: port await-for"))
 
 (defn import
-  "import is not implemented for jank, but var is still bound for portability. import always throws an exception"
+  "import is not implemented for jank, but a var is still bound to its symbol for portability. import always throws an exception"
   [& _]
   (throw "import is not supported in jank, for C/C++ dependency interoperability use cpp/raw with #include, e.g. (cpp/raw \"#include \"dependency.h\")\")"))
 
@@ -5487,9 +5487,8 @@
 (defn make-array
   "Creates and returns an array of instances of the specified class of
   the specified dimension(s).  Note that a class object is required.
-  Class objects can be obtained by using their imported or
-  fully-qualified name.  Class objects for the primitive types can be
-  obtained using, e.g., Integer/TYPE."
+  Class objects can be obtained by using their name.
+  Class objects for the primitive types can be obtained using, e.g., Integer/TYPE."
   ([#_Class type len]
   ;;  (. Array (newInstance type (int len)))
    (throw "TODO: port make-array"))

--- a/compiler+runtime/src/jank/clojure/core.jank
+++ b/compiler+runtime/src/jank/clojure/core.jank
@@ -4142,8 +4142,8 @@
 (defmacro ns
   "Sets *ns* to the namespace named by name (unevaluated), creating it
    if needed. References can be zero or more of: (:refer-clojure ...)
-   (:require ...) (:use ...) (:import ...) (:load ...)
-   with the syntax of refer-clojure/require/use/import/load respectively."
+   (:require ...) (:use ...) (:load ...)
+   with the syntax of refer-clojure/require/use/load respectively."
   [name & references]
   (let [process-reference (fn [reference]
                             (let [kname (first reference)
@@ -5101,22 +5101,10 @@
     ;;    (. latch (await  timeout-ms (. java.util.concurrent.TimeUnit MILLISECONDS)))))
   (throw "TODO: port await-for"))
 
-(defmacro import
-  "import-list => (package-symbol class-name-symbols*)
-
-  For each name in class-name-symbols, adds a mapping from name to the
-  class named by package.name to the current namespace. Use :import in the ns
-  macro in preference to calling this directly."
-  [& import-symbols-or-lists]
-  (let [specs (map #(if (and (seq? %) (= 'quote (first %))) (second %) %)
-                   import-symbols-or-lists)]
-    `(do ~@(map #(list 'clojure.core/import* %)
-                (reduce (fn [v spec]
-                          (if (symbol? spec)
-                            (conj v (name spec))
-                            (let [p (first spec) cs (rest spec)]
-                              (into v (map #(str p "." %) cs)))))
-                        [] specs)))))
+(defn import
+  "import is not implemented for jank, but var is still bound for portability. import always throws an exception"
+  [& _]
+  (throw "import is not supported in jank, for C/C++ dependency interoperability use cpp/raw with #include, e.g. (cpp/raw \"#include \"dependency.h\")\")"))
 
 (defn into-array
   "Returns an array with components set to the values in aseq. The array's
@@ -5418,8 +5406,6 @@
   ;;   `(fn [~t ~@args]
   ;;      (. ~t (~name ~@args))))
   (throw "TODO: port memfn"))
-
-;; (import '(java.lang.reflect Array))
 
 (defn alength
   "Returns the length of the Java array. Works on arrays of all


### PR DESCRIPTION
As per https://clojurians.slack.com/archives/C03SRH97FDK/p1755641194640599, `import` and `:import` are not officially supported in jank, though the var for `import` should still be bound, though to a function that always throws.

I did my best to keep docstrings and error messages as grammatically correct, full sentences, but I'm open to suggestions since I know a lot of the existing examples are carry-overs from clj/cljs that don't match the intent of comments/docstrings/error messages in jank.