### PR TITLE
Fix: Invalid Token for ::/ and ::/<symbol>

### DIFF
--- a/compiler+runtime/src/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/src/cpp/jank/read/lex.cpp
@@ -1125,8 +1125,23 @@ namespace jank::read::lex
           if(c == ':')
           {
             ++pos;
+            auto const after_dd_colon = peek();
+            if(after_dd_colon.is_ok() && after_dd_colon.expect_ok().character == '/')
+            {
+              /* Invalid ::/ pattern found. Consume the entire invalid token. */
+              while(true)
+              {
+                auto const result = convert_to_codepoint(file.substr(pos), pos);
+                if(result.is_err() || !is_symbol_char(result.expect_ok().character))
+                {
+                  break;
+                }
+                pos += result.expect_ok().len;
+              }
+              return error::lex_invalid_keyword("An auto-resolved keyword may not start with '/'.",
+                                                { token_start, pos });
+            }
           }
-
           while(true)
           {
             auto const oc(peek());

--- a/compiler+runtime/src/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/src/cpp/jank/read/lex.cpp
@@ -1125,13 +1125,13 @@ namespace jank::read::lex
           if(c == ':')
           {
             ++pos;
-            auto const after_dd_colon = peek();
+            auto const after_dd_colon(peek());
             if(after_dd_colon.is_ok() && after_dd_colon.expect_ok().character == '/')
             {
               /* Invalid ::/ pattern found. Consume the entire invalid token. */
               while(true)
               {
-                auto const result = convert_to_codepoint(file.substr(pos), pos);
+                auto const result(convert_to_codepoint(file.substr(pos), pos));
                 if(result.is_err() || !is_symbol_char(result.expect_ok().character))
                 {
                   break;

--- a/compiler+runtime/test/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/test/cpp/jank/read/lex.cpp
@@ -1645,6 +1645,27 @@ namespace jank::read::lex
         }));
       }
 
+      SUBCASE("Invalid auto-resolved qualified keyword")
+      {
+        processor p{ "::/foo" };
+        native_vector<jtl::result<token, error_ref>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                make_error(kind::lex_invalid_keyword, 0, 6),
+              }));
+      }
+
+      SUBCASE("Invalid ::/ pattern")
+      {
+        processor p{ "::/" };
+        native_vector<jtl::result<token, error_ref>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_results({
+                make_error(kind::lex_invalid_keyword, 0, 3),
+              }));
+      }
+
+
       SUBCASE("Too many starting colons")
       {
         processor p{ ":::foo" };


### PR DESCRIPTION
Fixes #214 

Clojure:
```
Clojure 1.12.0
user=> ::/
Syntax error reading source at (REPL:2:0).
Invalid token: ::/
user=> ::/foo
Syntax error reading source at (REPL:3:0).
Invalid token: ::/foo
```
Jank:
<img width="1014" height="464" alt="image" src="https://github.com/user-attachments/assets/e21c27fc-5940-4026-947c-61187dd15f8e" />
