### PR TITLE
Add nix package declaration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,41 @@
       }: {
         legacyPackages = pkgs;
         formatter = pkgs.alejandra;
+
+        packages.default = pkgs.stdenv.mkDerivation {
+          pname = "jank";
+          version = "git";
+          src = ./.;
+
+          nativeBuildInputs = with pkgs; [
+            git
+            cmake
+            ninja
+            (pkgs.callPackage ./llvm.nix {})
+          ];
+          buildInputs = with pkgs; [libzip openssl];
+
+          postPatch = ''
+            patchShebangs ./compiler+runtime/bin/ar-merge
+          '';
+
+          cmakeBuildDir = "./compiler+runtime/build";
+          cmakeDir = "..";
+          cmakeFlags = [
+            "-DCMAKE_C_COMPILER=clang"
+            "-DCMAKE_CXX_COMPILER=clang++"
+            # TODO: Updating RPATHs during install causes the step to fail as it
+            # tries to rewrite non-existent RPATHs like /lib. Needs more
+            # investigation.
+            "-DCMAKE_SKIP_RPATH=ON"
+            # TODO: To use libdwarf (recommended) we need to build the custom
+            # patched version available from CppTrace. Normally this is done via
+            # FetchContent, but that's not allowed in a nix build. As a
+            # workaround we use libdl which is always available.
+            "-DCPPTRACE_GET_SYMBOLS_WITH_LIBDL=ON"
+          ];
+        };
+
         devShells.default = pkgs.mkShell {
           packages = with pkgs; [
             stdenv.cc.cc.lib


### PR DESCRIPTION
What works:
```
# from within local jank checkout
nix build .?submodules=1
nix run .?submodules=1 check-health
nix run .?submodules=1 repl
# etc.
```

What doesn't work yet:
- Building without the submodules flag: nix will not copy any of the third-party sources into the build environment, so the build will fail.
- Building via a remote source like `nix build github:jank-lang/jank`: when pulling from GitHub, nix will download a .tar.gz which will not contain submodule sources. It seems like there is still active discussions around how to handle this within the nix community.
- Stack traces are probably somewhat limited in this build, see TODO comment in the code.

For future investigation:
- Deploy a binary cache via cachix so users on standard platforms don't need to build manually
- Run nix build step in CI (and push to cache?)
- Submit to nixpkgs, perhaps on the first official release 