### PR TITLE
Add nix build job to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,3 +172,27 @@ jobs:
               git push origin main
             popd
           popd
+
+  build-nix:
+    name: "nix - release"
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Set up nix"
+      uses: cachix/install-nix-action@v31
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - name: "Set up cachix"
+      uses: cachix/cachix-action@v16
+      with:
+        name: jank-lang
+        # If you chose API tokens for write access OR if you have a private cache
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+        # Only push to cache on main branch, not PRs
+        skipPush: "${{ github.ref != 'refs/heads/main' }}"
+    - uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+    - name: "Build jank"
+      run: nix build .?submodules=1 -L
+    - name: "Check health"
+      run: nix run .?submodules=1 check-health

--- a/flake.nix
+++ b/flake.nix
@@ -36,14 +36,20 @@
           pkgs.stdenv.mkDerivation (finalAttrs: {
             pname = "jank";
             version = "git";
-            src = ./.;
 
-            nativeBuildInputs = with pkgs; [
-              git
-              cmake
-              ninja
-              llvm-jank
-            ];
+            # Add only essential files so that the source hash is consistent.
+            src = lib.fileset.toSource {
+              root = ./.;
+              fileset =
+                lib.fileset.difference
+                (lib.fileset.unions [
+                  ./.clang-format
+                  ./compiler+runtime
+                ])
+                (lib.fileset.fileFilter (file: lib.strings.hasInfix ".git" file.name) ./.);
+            };
+
+            nativeBuildInputs = with pkgs; [git cmake ninja llvm-jank];
             buildInputs = with pkgs; [libzip openssl];
             checkInputs = with pkgs; [glibcLocales doctest];
 


### PR DESCRIPTION
WIP. This will require some Github/Cachix setup before merging. Example run here: https://github.com/kylc/jank/actions/runs/17479404939/job/49646646076

Some cool things:
- After the CI job finishes, users who have the exact same inputs (same checkout, not a dirty tree, etc.) can just run `nix run .?submodules=1 ...` and nix will automatically pull down the cached version, no building required (if they are using the cache, instructions via `cachix use kylc`)
- If you have write access to the cache, you can also build a clean local copy and push it into the cache, which will then be picked up by CI so the build job will be skipped.
- All of the LLVM caching is handled transparently. You can even build it locally and push it to the cache before pushing your jank changes to speed up the CI process.
- We can now trivially build docker images or even DEB/RPM packages with `nix bundle`, although the latter are less useful because they bring all of their own dependencies and install to `/nix/store/`.