### PR TITLE
Use function pointers for specials

### DIFF
--- a/compiler+runtime/include/cpp/jank/analyze/processor.hpp
+++ b/compiler+runtime/include/cpp/jank/analyze/processor.hpp
@@ -94,7 +94,7 @@ namespace jank::analyze
                                   expression_position,
                                   jtl::option<expr::function_context_ref> const &,
                                   bool needs_box);
-    expression_result analyze_letfn(runtime::obj::persistent_list_ref const &,
+    expression_result analyze_letfn(runtime::obj::persistent_list_ref const,
                                     local_frame_ptr,
                                     expression_position,
                                     jtl::option<expr::function_context_ref> const &,
@@ -228,11 +228,11 @@ namespace jank::analyze
     bool is_special(runtime::object_ref form);
 
     using special_function_type
-      = std::function<expression_result(runtime::obj::persistent_list_ref const,
-                                        local_frame_ptr,
-                                        expression_position,
-                                        jtl::option<expr::function_context_ref> const &,
-                                        bool)>;
+      = expression_result (processor::*)(runtime::obj::persistent_list_ref const,
+                                         local_frame_ptr,
+                                         expression_position,
+                                         jtl::option<expr::function_context_ref> const &,
+                                         bool);
 
     native_unordered_map<runtime::obj::symbol_ref, special_function_type> specials;
     native_unordered_map<runtime::var_ref, expression_ref> vars;


### PR DESCRIPTION
Cleaning up our back traces some, while also improving perf marginally.

# Before
<img width="2560" height="1440" alt="2025-09-05-11-44-04" src="https://github.com/user-attachments/assets/6eccdfd2-2880-4cec-80a6-46931702f68b" />

# After
<img width="2560" height="1440" alt="2025-09-05-11-42-02" src="https://github.com/user-attachments/assets/d9c4501d-6bd9-4b15-bb11-fa30c0130d01" />

