### PR TITLE
Enable the large config, prompted by "Too many root sets" error when working with GLFW on macos.

### DIFF
--- a/compiler+runtime/cmake/dependency/bdwgc.cmake
+++ b/compiler+runtime/cmake/dependency/bdwgc.cmake
@@ -9,6 +9,7 @@ set(CMAKE_CXX_CLANG_TIDY_OLD ${CMAKE_CXX_CLANG_TIDY})
   set(enable_cplusplus ON CACHE BOOL "Enable C++")
   set(build_cord OFF CACHE BOOL "Build cord")
   set(enable_docs OFF CACHE BOOL "Enable docs")
+  set(enable_large_config ON CACHE BOOL "Optimize for large heap or root set")
   set(enable_throw_bad_alloc_library ON CACHE BOOL "Enable C++ gctba library build")
   add_subdirectory(third-party/bdwgc EXCLUDE_FROM_ALL)
 


### PR DESCRIPTION
Calling glfwInit on macos resulted in loading more dylibs than the GC could handle. Enabling the large config mode unblocked the issue.

Relevant slack thread: https://clojurians.slack.com/archives/C03SRH97FDK/p1757178657192689

cc @jeaye 