### PR TITLE
Only create `persistent_string` if `char const *` is not null

### DIFF
--- a/compiler+runtime/include/cpp/jank/runtime/convert/builtin.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/convert/builtin.hpp
@@ -233,6 +233,10 @@ namespace jank::runtime
   {
     static constexpr obj::persistent_string_ref into_object(char const * const o)
     {
+      if(o == nullptr)
+      {
+        return jank_nil;
+      }
       return make_box(o);
     }
 


### PR DESCRIPTION
Before:
```clojure
% jank repl
user=> (cpp/std.getenv (cpp/cast (cpp/type "char const*") "MISSING"))
Assertion failed! s != nullptr
Stack trace (most recent call first):
```
After:
```clojure
% jank repl                                           
user=> (cpp/std.getenv (cpp/cast (cpp/type "char const*") "MISSING"))
nil

user=> (cpp/std.getenv (cpp/cast (cpp/type "char const*") "CXX"))
"/home/chris/repos/jank/compiler+runtime//build/llvm-install/usr/local/bin/clang++"
```