### PR TITLE
Add `re-seq`

### DIFF
--- a/compiler+runtime/src/jank/clojure/core.jank
+++ b/compiler+runtime/src/jank/clojure/core.jank
@@ -5791,17 +5791,6 @@
   [m]
   (cpp/jank.runtime.re_groups m))
 
-(defn re-seq
-  "Returns a lazy sequence of successive matches of pattern in string,
-  using java.util.regex.Matcher.find(), each such match processed with
-  re-groups."
-  [#_java.util.regex.Pattern re s]
-  ;; (let [m (re-matcher re s)]
-  ;;   ((fn step []
-  ;;      (when (. m (find))
-  ;;        (cons (re-groups m) (lazy-seq (step)))))))
-  (throw "TODO: port re-seq"))
-
 (defn re-matches
   "Returns the match, if any, of string to pattern, using
   java.util.regex.Matcher.matches().  Uses re-groups to return the
@@ -5818,6 +5807,16 @@
   ([re s]
    (let [m (re-matcher re s)]
      (re-find m))))
+
+(defn re-seq
+  "Returns a lazy sequence of successive matches of pattern in string,
+  using java.util.regex.Matcher.find(), each such match processed with
+  re-groups."
+  [re s]
+  (let [m (re-matcher re s)]
+    ((fn step []
+       (when (re-find m)
+         (cons (re-groups m) (lazy-seq (step))))))))
 
 (defn rand-int
   "Returns a random integer between 0 (inclusive) and n (exclusive)."

--- a/compiler+runtime/src/jank/clojure/core.jank
+++ b/compiler+runtime/src/jank/clojure/core.jank
@@ -5813,7 +5813,7 @@
   using java.util.regex.Matcher.find(), each such match processed with
   re-groups."
   [re s]
-  (let [m (re-matcher re s)]
+  (let [m (cpp/jank.runtime.re_matcher re s)]
     ((fn step []
        (when (re-find m)
          (cons (re-groups m) (lazy-seq (step))))))))


### PR DESCRIPTION
I tried adding direct interop calls to re-seq to avoid the extra indirection, but that generated runtime errors:

```clojure
(defn re-seq
  "Returns a lazy sequence of successive matches of pattern in string,
  using java.util.regex.Matcher.find(), each such match processed with
  re-groups."
  [re s]
  (let [m (cpp/jank.runtime.re_matcher re s)]
    ((fn step []
       (when (cpp/jank.runtime.re_find m)
         (cons (cpp/jank.runtime.re_groups m) (lazy-seq (step))))))))
```

But going through `clojure.core` fns worked just fine.