### PR TITLE
Add cpp/aset support for C arrays

### DIFF
--- a/compiler+runtime/CMakeLists.txt
+++ b/compiler+runtime/CMakeLists.txt
@@ -452,6 +452,7 @@ add_library(
   src/cpp/jank/analyze/expr/cpp_unbox.cpp
   src/cpp/jank/analyze/expr/cpp_new.cpp
   src/cpp/jank/analyze/expr/cpp_delete.cpp
+  src/cpp/jank/analyze/expr/cpp_aset.cpp
   src/cpp/jank/analyze/local_frame.cpp
   src/cpp/jank/analyze/step/force_boxed.cpp
   src/cpp/jank/analyze/cpp_util.cpp

--- a/compiler+runtime/include/cpp/jank/analyze/expr/cpp_aset.hpp
+++ b/compiler+runtime/include/cpp/jank/analyze/expr/cpp_aset.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <jank/analyze/expression.hpp>
+
+namespace jank::runtime::obj
+{
+  using persistent_list_ref = oref<struct persistent_list>;
+}
+
+namespace jank::analyze::expr
+{
+  using cpp_aset_ref = jtl::ref<struct cpp_aset>;
+
+  struct cpp_aset : expression
+  {
+    static constexpr expression_kind expr_kind{ expression_kind::cpp_aset };
+
+    cpp_aset(expression_position position,
+             local_frame_ptr frame,
+             bool needs_box,
+             expression_ref array_expr,
+             expression_ref index_expr,
+             expression_ref value_expr,
+             jtl::ptr<void> element_type);
+
+    void propagate_position(expression_position const pos) override;
+    runtime::object_ref to_runtime_data() const override;
+    void walk(std::function<void(jtl::ref<expression>)> const &f) override;
+
+    expression_ref array_expr;
+    expression_ref index_expr;
+    expression_ref value_expr;
+    jtl::ptr<void> element_type{};
+  };
+}

--- a/compiler+runtime/include/cpp/jank/analyze/expression.hpp
+++ b/compiler+runtime/include/cpp/jank/analyze/expression.hpp
@@ -68,7 +68,8 @@ namespace jank::analyze
     cpp_unbox,
     cpp_new,
     cpp_delete,
-    cpp_value_max = cpp_delete,
+    cpp_aset,
+    cpp_value_max = cpp_aset,
   };
 
   constexpr char const *expression_kind_str(expression_kind const kind)
@@ -145,6 +146,8 @@ namespace jank::analyze
         return "cpp_new";
       case expression_kind::cpp_delete:
         return "cpp_delete";
+      case expression_kind::cpp_aset:
+        return "cpp_aset";
     }
     return "unknown";
   }

--- a/compiler+runtime/include/cpp/jank/analyze/processor.hpp
+++ b/compiler+runtime/include/cpp/jank/analyze/processor.hpp
@@ -222,6 +222,11 @@ namespace jank::analyze
                                                 expression_position,
                                                 jtl::option<expr::function_context_ref> const &,
                                                 bool needs_box);
+    expression_result analyze_cpp_aset(runtime::obj::persistent_list_ref const,
+                                       local_frame_ptr,
+                                       expression_position,
+                                       jtl::option<expr::function_context_ref> const &,
+                                       bool needs_box);
 
     /* Returns whether the form is a special symbol. */
     bool is_special(runtime::object_ref form);

--- a/compiler+runtime/include/cpp/jank/analyze/visit.hpp
+++ b/compiler+runtime/include/cpp/jank/analyze/visit.hpp
@@ -35,6 +35,7 @@
 #include <jank/analyze/expr/cpp_unbox.hpp>
 #include <jank/analyze/expr/cpp_new.hpp>
 #include <jank/analyze/expr/cpp_delete.hpp>
+#include <jank/analyze/expr/cpp_aset.hpp>
 
 namespace jank::analyze
 {
@@ -112,6 +113,8 @@ namespace jank::analyze
         return f(jtl::static_ref_cast<expr::cpp_new>(e), std::forward<Args>(args)...);
       case expression_kind::cpp_delete:
         return f(jtl::static_ref_cast<expr::cpp_delete>(e), std::forward<Args>(args)...);
+      case expression_kind::cpp_aset:
+        return f(jtl::static_ref_cast<expr::cpp_aset>(e), std::forward<Args>(args)...);
 
       case expression_kind::uninitialized:
         break;

--- a/compiler+runtime/include/cpp/jank/codegen/llvm_processor.hpp
+++ b/compiler+runtime/include/cpp/jank/codegen/llvm_processor.hpp
@@ -67,6 +67,7 @@ namespace jank::analyze
     using cpp_unbox_ref = jtl::ref<struct cpp_unbox>;
     using cpp_new_ref = jtl::ref<struct cpp_new>;
     using cpp_delete_ref = jtl::ref<struct cpp_delete>;
+    using cpp_aset_ref = jtl::ref<struct cpp_aset>;
   }
 }
 

--- a/compiler+runtime/include/cpp/jank/codegen/processor.hpp
+++ b/compiler+runtime/include/cpp/jank/codegen/processor.hpp
@@ -40,6 +40,7 @@ namespace jank::analyze
     using cpp_builtin_operator_call_ref = jtl::ref<struct cpp_builtin_operator_call>;
     using cpp_box_ref = jtl::ref<struct cpp_box>;
     using cpp_unbox_ref = jtl::ref<struct cpp_unbox>;
+    using cpp_aset_ref = jtl::ref<struct cpp_aset>;
   }
 }
 
@@ -164,6 +165,9 @@ namespace jank::codegen
     gen(analyze::expr::cpp_box_ref const, analyze::expr::function_arity const &, bool box_needed);
     jtl::option<handle>
     gen(analyze::expr::cpp_unbox_ref const, analyze::expr::function_arity const &, bool box_needed);
+
+    jtl::option<handle> 
+    gen(analyze::expr::cpp_aset_ref const, analyze::expr::function_arity const &, bool);
 
     jtl::immutable_string declaration_str();
     void build_header();

--- a/compiler+runtime/include/cpp/jank/error.hpp
+++ b/compiler+runtime/include/cpp/jank/error.hpp
@@ -100,6 +100,7 @@ namespace jank::error
     analyze_invalid_cpp_new,
     analyze_invalid_cpp_delete,
     analyze_invalid_cpp_member_access,
+    analyze_invalid_cpp_aset,
     internal_analyze_failure,
 
     internal_codegen_failure,
@@ -290,6 +291,8 @@ namespace jank::error
         return "analyze/invalid-cpp-delete";
       case kind::analyze_invalid_cpp_member_access:
         return "analyze/invalid-cpp-member-access";
+      case kind::analyze_invalid_cpp_aset:
+        return "analyze/invalid-cpp-member-aset";
       case kind::internal_analyze_failure:
         return "internal/analysis-failure";
       case kind::internal_codegen_failure:

--- a/compiler+runtime/include/cpp/jank/error/analyze.hpp
+++ b/compiler+runtime/include/cpp/jank/error/analyze.hpp
@@ -149,4 +149,8 @@ namespace jank::error
   error_ref internal_analyze_failure(jtl::immutable_string const &message,
                                      read::source const &source,
                                      runtime::object_ref expansion);
+
+  error_ref analyze_invalid_cpp_aset(jtl::immutable_string const &message,
+                                     read::source const &source,
+                                     runtime::object_ref expansion);
 }

--- a/compiler+runtime/src/cpp/jank/analyze/expr/cpp_aset.cpp
+++ b/compiler+runtime/src/cpp/jank/analyze/expr/cpp_aset.cpp
@@ -1,0 +1,44 @@
+#include <jank/analyze/expr/cpp_aset.hpp>
+#include <jank/detail/to_runtime_data.hpp>
+
+namespace jank::analyze::expr
+{
+  using namespace jank::runtime;
+
+  cpp_aset::cpp_aset(expression_position const position,
+                     local_frame_ptr const frame,
+                     bool const needs_box,
+                     expression_ref const array_expr,
+                     expression_ref const index_expr,
+                     expression_ref const value_expr,
+                     jtl::ptr<void> const element_type) 
+    : expression{ expr_kind, position, frame, needs_box }
+    , array_expr{ array_expr }
+    , index_expr{ index_expr }
+    , value_expr{ value_expr }
+    , element_type{ element_type }
+  {
+  }
+
+  void cpp_aset::propagate_position(expression_position const pos)
+  {
+    position = pos;
+  }
+
+  object_ref cpp_aset::to_runtime_data() const
+  {
+    return merge(expression::to_runtime_data(),
+                 obj::persistent_array_map::create_unique(
+                   make_box("array_expr"), array_expr->to_runtime_data(),
+                   make_box("index_expr"), index_expr->to_runtime_data(),
+                   make_box("value_expr"), value_expr->to_runtime_data()));
+  }
+
+  void cpp_aset::walk(std::function<void(jtl::ref<expression>)> const &f)
+  {
+    f(array_expr);
+    f(index_expr);
+    f(value_expr);
+    expression::walk(f);
+  }
+}

--- a/compiler+runtime/src/cpp/jank/analyze/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/analyze/processor.cpp
@@ -4452,38 +4452,14 @@ namespace jank::analyze
     auto const array_expr = array_expr_res.expect_ok();
     auto const array_type = cpp_util::expression_type(array_expr.data);
 
-    // Check if type supports subscripting
-    bool can_subscript = false;
     jtl::ptr<void> element_type = nullptr;
 
     if(Cpp::IsPointerType(array_type)) {
-        can_subscript = true;
         element_type = Cpp::GetPointeeType(array_type);
     }
     else {
         // Check for operator[] support on class types
-        auto const scope = Cpp::GetScopeFromType(array_type);
-        if(scope) {
-            // Look for operator[] overloads using CppInterOp
-            std::vector<void*> operators;
-            std::vector<Cpp::TemplateArgInfo> arg_types; // May need to be populated
-            Cpp::GetOperator(Cpp::OP_Subscript, arg_types, operators, Cpp::kBinary);
-
-            if(!operators.empty()) {
-                can_subscript = true;
-                // Get the return type from the first operator[] overload
-                element_type = Cpp::GetFunctionReturnType(operators[0]);
-            }
-        }
-    }
-
-    if(!can_subscript) {
-        return error::analyze_invalid_cpp_aset(
-            util::format("Type '{}' does not support array subscripting.",
-                        Cpp::GetTypeAsString(array_type)),
-            object_source(array_obj),
-            latest_expansion(macro_expansions))
-            ->add_usage(read::parse::reparse_nth(l, 1));
+        throw std::runtime_error("operator[] support not implemented yet");
     }
 
     // Analyze index expression

--- a/compiler+runtime/src/cpp/jank/codegen/llvm_processor.cpp
+++ b/compiler+runtime/src/cpp/jank/codegen/llvm_processor.cpp
@@ -2256,16 +2256,15 @@ namespace jank::codegen
     auto const index_val{ gen(expr->index_expr, arity) };
     auto const value_val{ gen(expr->value_expr, arity) };
 
-    // The fundamental issue: we need to handle subscript operations at the C++ level
-    // rather than trying to do low-level LLVM pointer arithmetic
-    // For now, revert to the simpler approach but make it more robust
     auto const array_loaded{ ctx->builder->CreateLoad(ctx->builder->getPtrTy(), array_val) };
     auto const index_loaded{ ctx->builder->CreateLoad(ctx->builder->getInt32Ty(), index_val) };
-    auto const value_loaded{ ctx->builder->CreateLoad(ctx->builder->getInt32Ty(), value_val) };
 
     // Create GEP (GetElementPtr) instruction for array access
     llvm::SmallVector<llvm::Value *, 2> const indices{ index_loaded };
     auto const gep{ ctx->builder->CreateGEP(ctx->builder->getInt32Ty(), array_loaded, indices) };
+
+    // Store the value at the computed address
+    auto const value_loaded{ ctx->builder->CreateLoad(ctx->builder->getInt32Ty(), value_val) };
 
     // Store the value at the computed address
     ctx->builder->CreateStore(value_loaded, gep);

--- a/compiler+runtime/src/cpp/jank/codegen/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/codegen/processor.cpp
@@ -1957,6 +1957,30 @@ namespace jank::codegen
     return ret_tmp;
   }
 
+  jtl::option<handle> processor::gen(analyze::expr::cpp_aset_ref const expr,
+                                     analyze::expr::function_arity const &arity,
+                                     bool)
+  {
+    auto ret_tmp{ runtime::munge(__rt_ctx->unique_namespaced_string("cpp_aset")) };
+
+    auto array_tmp{ gen(expr->array_expr, arity, false) };
+    auto index_tmp{ gen(expr->index_expr, arity, false) };
+    auto value_tmp{ gen(expr->value_expr, arity, false) };
+
+    util::format_to(deps_buffer,
+                    "auto {} = ({}[{}] = {});\n",
+                    ret_tmp,
+                    array_tmp.unwrap().str(false),
+                    index_tmp.unwrap().str(false),
+                    value_tmp.unwrap().str(false));
+
+    if(expr->position == analyze::expression_position::tail)
+    {
+      return none;
+    }
+    return ret_tmp;
+  }
+
   jtl::immutable_string processor::declaration_str()
   {
     if(!generated_declaration)

--- a/compiler+runtime/src/cpp/jank/error.cpp
+++ b/compiler+runtime/src/cpp/jank/error.cpp
@@ -180,6 +180,10 @@ namespace jank::error
         return "Invalid C++ delete.";
       case kind::analyze_invalid_cpp_member_access:
         return "Invalid C++ member access.";
+
+      case kind::analyze_invalid_cpp_aset:
+        return "Invalid C++ array set.";
+
       case kind::internal_analyze_failure:
         return "Internal analysis failure.";
 

--- a/compiler+runtime/src/cpp/jank/error/analyze.cpp
+++ b/compiler+runtime/src/cpp/jank/error/analyze.cpp
@@ -346,6 +346,13 @@ namespace jank::error
     return make_error(kind::analyze_invalid_cpp_member_access, message, source, expansion);
   }
 
+  error_ref analyze_invalid_cpp_aset(jtl::immutable_string const &message,
+                                     read::source const &source,
+                                     runtime::object_ref expansion)
+  {
+    return make_error(kind::analyze_invalid_cpp_aset, message, source, expansion);
+  }
+
   error_ref internal_analyze_failure(jtl::immutable_string const &message,
                                      runtime::object_ref const expansion)
   {

--- a/compiler+runtime/test/jank/cpp/aset/fail-cpp-std-array.jank
+++ b/compiler+runtime/test/jank/cpp/aset/fail-cpp-std-array.jank
@@ -1,0 +1,14 @@
+(cpp/raw "namespace jank::cpp::aset::pass_std_array
+          {
+            #include <array>
+            
+            std::array<int, 1> arr;
+
+            int aget(int index) {
+              return arr[index];
+            }
+          }")
+
+(let* [_ (cpp/aset cpp/jank.cpp.aset.pass_std_array.arr (cpp/int 0) (cpp/int 1))
+       v (cpp/jank.cpp.aset.pass_std_array.aget (cpp/int 0))]
+      (if (= 1 v) :success))

--- a/compiler+runtime/test/jank/cpp/aset/pass-c-array.jank
+++ b/compiler+runtime/test/jank/cpp/aset/pass-c-array.jank
@@ -1,0 +1,13 @@
+(cpp/raw "namespace jank::cpp::aset::pass_c_array
+          {
+            int arr[1];
+          
+            int aget (int index) {
+              return arr[index];
+            }
+          }")
+
+(let* [_ (cpp/aset cpp/jank.cpp.aset.pass_c_array.arr (cpp/int 0) (cpp/int 1))
+       v (cpp/jank.cpp.aset.pass_c_array.aget (cpp/int 0))]
+      (if (= 1 v) :success))
+


### PR DESCRIPTION
Working through adding `cpp/aset` support. I got to working C arrays, but supporting all types with op[] support got hairy and so I backtracked and stopped short of that, throwing an exception if the analyzer detects that the type does not qualify as something that looks like a C array.

I thought this might be a useful starting point or at least a good demonstration of all the places that we have to touch to add a new `cpp/...` form to the compiler.

Maybe we can also guide this PR in the direction of op[] support?