### PR TITLE
Wrap up and document nix flake workflow

### DIFF
--- a/compiler+runtime/doc/install.md
+++ b/compiler+runtime/doc/install.md
@@ -66,6 +66,33 @@ yay -S jank-git   # if you installed jank-git
 yay -S jank-bin   # if you installed jank-bin
 ```
 
+## Nix
+### Install
+We have binary packages in our cachix cache, so installation is quick and easy.
+You may also skip the cache setup and artifacts will be built from source.
+
+```bash
+# Make sure cachix is installed, then follow the prompts.
+cachix use jank-lang
+```
+
+Next, you can directly run the jank binary from the nix flake derivation. For
+example, to run the `jank check-health` subcommand:
+
+```bash
+nix run git+https://github.com/jank-lang/jank.git -- check-health
+```
+
+If you pull down the jank repository locally for development, you can enter the
+dev shell and then follow the build instructions linked below. Skip the LLVM
+build step as it's done for you by nix.
+
+```bash
+git clone https://github.com/jank-lang/jank.git
+cd jank
+nix develop
+```
+
 ## Anything else
 If nothing above matches what you have, you can still build jank by following
 the docs [here](./build.md).

--- a/compiler+runtime/doc/install.md
+++ b/compiler+runtime/doc/install.md
@@ -67,30 +67,52 @@ yay -S jank-bin   # if you installed jank-bin
 ```
 
 ## Nix
-### Install
-We have binary packages in our cachix cache, so installation is quick and easy.
-You may also skip the cache setup and artifacts will be built from source.
+### Usage
+We have binary packages in our cachix cache, so usage via nix flakes is quick
+and easy. You may also skip the cache setup and artifacts will be built from
+source.
 
 ```bash
 # Make sure cachix is installed, then follow the prompts.
 cachix use jank-lang
 ```
 
-Next, you can directly run the jank binary from the nix flake derivation. For
-example, to run the `jank check-health` subcommand:
+Next, you can directly run the jank binary from the nix flake derivation. This
+will always run from the latest main branch, unless a specific ref or rev is
+given. For example, to run the `jank check-health` subcommand:
 
 ```bash
 nix run git+https://github.com/jank-lang/jank.git -- check-health
 ```
 
-If you pull down the jank repository locally for development, you can enter the
-dev shell and then follow the build instructions linked below. Skip the LLVM
-build step as it's done for you by nix.
+You can also include jank as a flake input to your NixOS system configuration or
+project. In this case, the jank version will be managed by the `flake.lock`
+file. Here's a minimal example of such a nix flake:
 
-```bash
-git clone https://github.com/jank-lang/jank.git
-cd jank
-nix develop
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    jank.url = "git+https://github.com/jank-lang/jank.git";
+  };
+  outputs = inputs @ {flake-parts, ...}:
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      systems = ["x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin"];
+      perSystem = {
+        inputs',
+        pkgs,
+        system,
+        ...
+      }: {
+        devShells.default = pkgs.mkShell {
+          packages = [
+            inputs'.jank-lang.packages.default
+          ];
+        };
+      };
+    };
+}
 ```
 
 ## Anything else

--- a/compiler+runtime/doc/install.md
+++ b/compiler+runtime/doc/install.md
@@ -94,7 +94,7 @@ file. Here's a minimal example of such a nix flake:
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
-    jank.url = "git+https://github.com/jank-lang/jank.git";
+    jank-lang.url = "git+https://github.com/jank-lang/jank.git";
   };
   outputs = inputs @ {flake-parts, ...}:
     flake-parts.lib.mkFlake {inherit inputs;} {

--- a/flake.nix
+++ b/flake.nix
@@ -4,50 +4,59 @@
   inputs = {
     flake-parts.url = "github:hercules-ci/flake-parts";
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    self.submodules = true;
   };
 
   outputs = inputs @ {flake-parts, ...}:
     flake-parts.lib.mkFlake {inherit inputs;} {
       systems = ["x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin"];
       perSystem = {
+        self',
         pkgs,
         lib,
         ...
-      }: {
+      }: let
+        # remember to bump this rev/sha with new llvm commits
+        llvm-jank = pkgs.callPackage ./llvm.nix {
+          src = pkgs.fetchFromGitHub {
+            owner = "jank-lang";
+            repo = "llvm-project";
+            rev = "57bb1edd1923ee85736cec8a2d7ca57e5f961d58";
+            sha256 = "sha256-u9HHAjYjnoiW++66YaFY9SCgDPByfXZa1/y1TBavhLo=";
+          };
+        };
+        # for cpptrace; versions from cpptrace/cmake/OptionVariables.cmake
+        libdwarf-lite-src = pkgs.fetchFromGitHub {
+          owner = "jeremy-rifkin";
+          repo = "libdwarf-lite";
+          rev = "5e71a74491dddc231664bbcd6a8cf8a8643918e9";
+          sha256 = "sha256-qHikjAG5xuuHquqqKGuiDHXVZSlg/MbNp9JNSAKM/Hs=";
+        };
+        zstd-src = pkgs.fetchFromGitHub {
+          owner = "facebook";
+          repo = "zstd";
+          rev = "v1.5.7";
+          sha256 = "sha256-tNFWIT9ydfozB8dWcmTMuZLCQmQudTFJIkSr0aG7S44=";
+        };
+      in {
         legacyPackages = pkgs;
         formatter = pkgs.alejandra;
 
-        packages.default = let
-          llvm-jank = pkgs.callPackage ./llvm.nix {};
-          # versions from cpptrace/cmake/OptionVariables.cmake
-          libdwarf-lite-src = pkgs.fetchFromGitHub {
-            owner = "jeremy-rifkin";
-            repo = "libdwarf-lite";
-            rev = "5e71a74491dddc231664bbcd6a8cf8a8643918e9";
-            sha256 = "sha256-qHikjAG5xuuHquqqKGuiDHXVZSlg/MbNp9JNSAKM/Hs=";
-          };
-          zstd-src = pkgs.fetchFromGitHub {
-            owner = "facebook";
-            repo = "zstd";
-            rev = "v1.5.7";
-            sha256 = "sha256-tNFWIT9ydfozB8dWcmTMuZLCQmQudTFJIkSr0aG7S44=";
-          };
-        in
-          pkgs.stdenv.mkDerivation (finalAttrs: {
+        packages = rec {
+          default = jank-release;
+
+          jank-release = pkgs.stdenv.mkDerivation (finalAttrs: {
             pname = "jank";
             version = "git";
 
             # Add only essential files so that the source hash is consistent.
-            src = lib.fileset.toSource {
+            src = lib.cleanSource (lib.fileset.toSource {
               root = ./.;
-              fileset =
-                lib.fileset.difference
-                (lib.fileset.unions [
-                  ./.clang-format
-                  ./compiler+runtime
-                ])
-                (lib.fileset.fileFilter (file: lib.strings.hasInfix ".git" file.name) ./.);
-            };
+              fileset = lib.fileset.unions [
+                ./.clang-format
+                ./compiler+runtime
+              ];
+            });
 
             nativeBuildInputs = with pkgs; [git cmake ninja llvm-jank];
             buildInputs = with pkgs; [libzip openssl];
@@ -86,6 +95,7 @@
               popd
             '';
           });
+        };
 
         devShells.default = pkgs.mkShell {
           packages = with pkgs; [
@@ -95,7 +105,7 @@
             cmake
             ninja
             pkg-config
-            (pkgs.callPackage ./llvm.nix { })
+            llvm-jank
 
             ## Required libs.
             boehmgc
@@ -120,18 +130,17 @@
             doctest
           ];
 
-          shellHook =
-          ''
-          export CC=clang
-          export CXX=clang++
-          export ASAN_OPTIONS=detect_leaks=0
+          shellHook = ''
+            export CC=${llvm-jank}/bin/clang
+            export CXX=${llvm-jank}/bin/clang++
+            export ASAN_OPTIONS=detect_leaks=0
           '';
 
           # Nix assumes fortification by default, but that fails with debug builds.
           # Since this shell is used for development, we disabled fortification. It's
           # still enabled for our release builds in build.nix.
           # https://github.com/NixOS/nixpkgs/issues/18995
-          hardeningDisable = [ "fortify" ];
+          hardeningDisable = ["fortify"];
         };
       };
     };

--- a/llvm.nix
+++ b/llvm.nix
@@ -1,7 +1,14 @@
 {
-  stdenv,
+  src,
+  clang,
+  cmake,
+  gcc,
   lib,
-  pkgs,
+  makeWrapper,
+  ninja,
+  python3,
+  stdenv,
+  targetPlatform,
   wrapCC,
   ...
 }: let
@@ -11,12 +18,12 @@
   # executable. Since we will be compiling clang's runtime with our custom
   # (unwrapped) clang/clang++ executables, we need to provide them manually.
   runtimeCompileFlags = lib.strings.concatStringsSep " " [
-    "-B${gccForLibs}/lib/gcc/${pkgs.targetPlatform.config}/${gccForLibs.version}"
+    "-B${gccForLibs}/lib/gcc/${targetPlatform.config}/${gccForLibs.version}"
     "-B${stdenv.cc.libc}/lib"
 
-    "-isystem ${pkgs.gcc.cc}/include/c++/${pkgs.gcc.version}"
-    "-isystem ${pkgs.gcc.cc}/include/c++/${pkgs.gcc.version}/${pkgs.targetPlatform.config}"
-    "-isystem ${pkgs.gcc.libc.dev}/include"
+    "-isystem ${gcc.cc}/include/c++/${gcc.version}"
+    "-isystem ${gcc.cc}/include/c++/${gcc.version}/${targetPlatform.config}"
+    "-isystem ${gcc.libc.dev}/include"
 
     # some of these flags won't be used all the time
     "-Wno-unused-command-line-argument"
@@ -24,30 +31,24 @@
 
   runtimeLinkFlags = lib.strings.concatStringsSep " " [
     "-L${gccForLibs}/lib"
-    "-L${gccForLibs}/lib/gcc/${pkgs.targetPlatform.config}/${gccForLibs.version}"
+    "-L${gccForLibs}/lib/gcc/${targetPlatform.config}/${gccForLibs.version}"
     "-L${stdenv.cc.libc}/lib"
   ];
 in
   wrapCC (stdenv.mkDerivation {
     pname = "llvm-jank";
     version = "21.0.0-git";
+    inherit src;
 
-    src = pkgs.fetchFromGitHub {
-      owner = "jank-lang";
-      repo = "llvm-project";
-      rev = "57bb1edd1923ee85736cec8a2d7ca57e5f961d58";
-      sha256 = "sha256-u9HHAjYjnoiW++66YaFY9SCgDPByfXZa1/y1TBavhLo=";
-    };
-
-    nativeBuildInputs = [pkgs.cmake pkgs.ninja pkgs.clang pkgs.python3 pkgs.makeWrapper];
+    nativeBuildInputs = [cmake ninja clang python3 makeWrapper];
 
     cmakeDir = "../llvm";
     cmakeFlags = [
       (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
 
       # use clang to compile clang
-      (lib.cmakeFeature "CMAKE_C_COMPILER" "${pkgs.clang}/bin/clang")
-      (lib.cmakeFeature "CMAKE_CXX_COMPILER" "${pkgs.clang}/bin/clang++")
+      (lib.cmakeFeature "CMAKE_C_COMPILER" "${clang}/bin/clang")
+      (lib.cmakeFeature "CMAKE_CXX_COMPILER" "${clang}/bin/clang++")
 
       # from compiler+runtime/bin/build-clang
       (lib.cmakeBool "LLVM_BUILD_LLVM_DYLIB" true)
@@ -65,7 +66,7 @@ in
       (lib.cmakeBool "LLVM_ENABLE_OCAMLDOC" false)
 
       # nix-specific changes
-      (lib.cmakeFeature "C_INCLUDE_DIRS" "${pkgs.gcc.libc.dev}/include")
+      (lib.cmakeFeature "C_INCLUDE_DIRS" "${gcc.libc.dev}/include")
       (lib.cmakeFeature "LLVM_ENABLE_RUNTIMES" "libunwind")
       # libunwind shared library fails to compile, use static instead
       (lib.cmakeBool "LIBUNWIND_ENABLE_SHARED" false)


### PR DESCRIPTION
- Add instructions for "installing"/running from remote nix flake
- Final changes to support `nix run git+https://...`
- Move some source definitions to the top-level flake.nix to make updating them easier to remember
- Run `nix fmt`, misc. cleanup

To test you can run directly from my PR branch. The cache will only be populated once this is merged, so until then it will build jank from source.
```
nix run git+https://github.com/kylc/jank.git?ref=nix-cleanup -- check-health
```