### PR TITLE
Fix memory error in re-find

### DIFF
--- a/compiler+runtime/src/cpp/jank/runtime/core.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core.cpp
@@ -576,12 +576,14 @@ namespace jank::runtime
     auto const matcher(try_object<obj::re_matcher>(m));
     std::regex_search(matcher->match_input, match_results, matcher->re->regex);
 
+    // Copy out the match result substrings before mutating the source
+    // match_input string below.
+    matcher->groups = smatch_to_vector(match_results);
+
     if(!match_results.empty())
     {
       matcher->match_input = match_results.suffix().str();
     }
-
-    matcher->groups = smatch_to_vector(match_results);
 
     return matcher->groups;
   }


### PR DESCRIPTION
Fixes an issue in `re-find` caused by the original matched input string, passed to `regex_search` and held as an iterator in the match results, being mutated before collecting the match results.

Before:
```
$ echo '(re-find #"[0-9]+" "123 456")' | jank repl
user=> " 45"
```
After:
```
$ echo '(re-find #"[0-9]+" "123 456")' | jank repl
user=> "123"

```