### PR TITLE
Fix building with sanitizers on Nix

### DIFF
--- a/llvm.nix
+++ b/llvm.nix
@@ -68,6 +68,9 @@ in
       # nix-specific changes
       (lib.cmakeFeature "C_INCLUDE_DIRS" "${gcc.libc.dev}/include")
       (lib.cmakeFeature "LLVM_ENABLE_RUNTIMES" "libunwind")
+      # fix linking path for compiler-rt sanitize libs with
+      # -fsanitize={address,undefined}
+      (lib.cmakeBool "LLVM_ENABLE_PER_TARGET_RUNTIME_DIR" false)
       # libunwind shared library fails to compile, use static instead
       (lib.cmakeBool "LIBUNWIND_ENABLE_SHARED" false)
       (lib.cmakeBool "LIBUNWIND_ENABLE_STATIC" true)


### PR DESCRIPTION
Currently, compiling with `-Djank_sanitize=address` or `-Djank_sanitize=undefined` on Nix gives linker errors due to some mismatch of the target triple for which `compiler-rt` is built vs. that of the sanitize libs to which jank is linked (`x86_64-pc-...` vs `x86_64-unknown-...` on my system).

This PR enables a simplified directory structure in the installed clang runtime libs so this issue is avoided. Probably it has some implications for cross-compiling which I ignore for now.

Compiling jank with sanitizers enabled now succeeds on Nix.