### PR TITLE
Fix `swap!` varargs arity

### DIFF
--- a/compiler+runtime/src/cpp/jank/runtime/obj/atom.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/atom.cpp
@@ -6,6 +6,8 @@
 
 namespace jank::runtime::obj
 {
+  using jank::runtime::cons;
+
   atom::atom(object_ref const o)
     : val{ o.data }
   {
@@ -111,7 +113,8 @@ namespace jank::runtime::obj
     while(true)
     {
       auto v(val.load());
-      auto const next(apply_to(fn, conj(a1, conj(a2, rest))));
+      auto args(cons(v, cons(a1, cons(a2, rest))));
+      auto const next(apply_to(fn, args));
       if(val.compare_exchange_weak(v, next.data))
       {
         return next;
@@ -167,7 +170,8 @@ namespace jank::runtime::obj
     while(true)
     {
       auto v(val.load());
-      auto const next(apply_to(fn, conj(a1, conj(a2, rest))));
+      auto args(cons(v, cons(a1, cons(a2, rest))));
+      auto const next(apply_to(fn, args));
       if(val.compare_exchange_weak(v, next.data))
       {
         return make_box<persistent_vector>(std::in_place, v, next);

--- a/compiler+runtime/src/cpp/jank/runtime/obj/atom.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/atom.cpp
@@ -111,8 +111,7 @@ namespace jank::runtime::obj
     while(true)
     {
       auto v(val.load());
-      auto const args(
-        jank::runtime::cons(v, jank::runtime::cons(a1, jank::runtime::cons(a2, rest))));
+      auto const args(runtime::cons(v, runtime::cons(a1, runtime::cons(a2, rest))));
       auto const next(apply_to(fn, args));
       if(val.compare_exchange_weak(v, next.data))
       {
@@ -169,8 +168,7 @@ namespace jank::runtime::obj
     while(true)
     {
       auto v(val.load());
-      auto const args(
-        jank::runtime::cons(v, jank::runtime::cons(a1, jank::runtime::cons(a2, rest))));
+      auto const args(runtime::cons(v, runtime::cons(a1, runtime::cons(a2, rest))));
       auto const next(apply_to(fn, args));
       if(val.compare_exchange_weak(v, next.data))
       {

--- a/compiler+runtime/src/cpp/jank/runtime/obj/atom.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/atom.cpp
@@ -6,8 +6,6 @@
 
 namespace jank::runtime::obj
 {
-  using jank::runtime::cons;
-
   atom::atom(object_ref const o)
     : val{ o.data }
   {
@@ -113,7 +111,8 @@ namespace jank::runtime::obj
     while(true)
     {
       auto v(val.load());
-      auto const args(cons(v, cons(a1, cons(a2, rest))));
+      auto const args(
+        jank::runtime::cons(v, jank::runtime::cons(a1, jank::runtime::cons(a2, rest))));
       auto const next(apply_to(fn, args));
       if(val.compare_exchange_weak(v, next.data))
       {
@@ -170,7 +169,8 @@ namespace jank::runtime::obj
     while(true)
     {
       auto v(val.load());
-      auto const args(cons(v, cons(a1, cons(a2, rest))));
+      auto const args(
+        jank::runtime::cons(v, jank::runtime::cons(a1, jank::runtime::cons(a2, rest))));
       auto const next(apply_to(fn, args));
       if(val.compare_exchange_weak(v, next.data))
       {

--- a/compiler+runtime/src/cpp/jank/runtime/obj/atom.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/atom.cpp
@@ -113,7 +113,7 @@ namespace jank::runtime::obj
     while(true)
     {
       auto v(val.load());
-      auto args(cons(v, cons(a1, cons(a2, rest))));
+      auto const args(cons(v, cons(a1, cons(a2, rest))));
       auto const next(apply_to(fn, args));
       if(val.compare_exchange_weak(v, next.data))
       {
@@ -170,7 +170,7 @@ namespace jank::runtime::obj
     while(true)
     {
       auto v(val.load());
-      auto args(cons(v, cons(a1, cons(a2, rest))));
+      auto const args(cons(v, cons(a1, cons(a2, rest))));
       auto const next(apply_to(fn, args));
       if(val.compare_exchange_weak(v, next.data))
       {


### PR DESCRIPTION
Before
```clojure
% jank repl
user=> (swap! (atom {}) update :x assoc :y :z)
Uncaught exception: not conjable: #object [clojure.core/assoc jit_function 0x70ef1044ccf8]

Stack trace (most recent call first):
#4  in jank::runtime::conj at seq.cpp:507
```
After:
```clojure
% jank repl
user=> (swap! (atom {}) update :x assoc :y :z)
{:x {:y :z}}
```