### PR TITLE
Fix variadic arity analysis

### DIFF
--- a/compiler+runtime/src/cpp/jank/analyze/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/analyze/processor.cpp
@@ -1871,8 +1871,11 @@ namespace jank::analyze
     usize variadic_arity{};
     for(auto const &arity : arities)
     {
-      found_variadic += static_cast<int>(arity.fn_ctx->is_variadic);
-      variadic_arity = arity.params.size();
+      if(arity.fn_ctx->is_variadic)
+      {
+        found_variadic += 1;
+        variadic_arity = arity.params.size();
+      }
     }
     if(found_variadic > 1)
     {

--- a/compiler+runtime/test/jank/form/fn/arity/variadic/pass-ambiguous.jank
+++ b/compiler+runtime/test/jank/form/fn/arity/variadic/pass-ambiguous.jank
@@ -11,6 +11,17 @@
 
 (def variadic
   (fn*
+    ([& args]
+     args)
+    ([]
+     :a)))
+(assert (= (variadic) :a))
+(assert (= (variadic 1) [1]))
+(assert (= (variadic 1 2) [1 2]))
+(assert (= (variadic 1 2 3 4 5 6 7 8 9 10) [1 2 3 4 5 6 7 8 9 10]))
+
+(def variadic
+  (fn*
     ([a]
      :a)
     ([a & args]
@@ -21,10 +32,30 @@
 
 (def variadic
   (fn*
+    ([a & args]
+     [a args])
+    ([a]
+     :a)))
+(assert (= (variadic 1) :a))
+(assert (= (variadic 1 2) [1 [2]]))
+(assert (= (variadic 1 2 3 4 5 6 7 8 9 10) [1 [2 3 4 5 6 7 8 9 10]]))
+
+(def variadic
+  (fn*
     ([a b]
      :a)
     ([a b & args]
      [a b args])))
+(assert (= (variadic 1 2) :a))
+(assert (= (variadic 1 2 3) [1 2 [3]]))
+(assert (= (variadic 1 2 3 4 5 6 7 8 9 10) [1 2 [3 4 5 6 7 8 9 10]]))
+
+(def variadic
+  (fn*
+    ([a b & args]
+     [a b args])
+    ([a b]
+     :a)))
 (assert (= (variadic 1 2) :a))
 (assert (= (variadic 1 2 3) [1 2 [3]]))
 (assert (= (variadic 1 2 3 4 5 6 7 8 9 10) [1 2 [3 4 5 6 7 8 9 10]]))


### PR DESCRIPTION
This fixes https://github.com/jank-lang/jank/issues/526.

Reordering the multiple arities in descending order caused the analysis failure.