### PR TITLE
Math epic - Part 1

### DIFF
--- a/compiler+runtime/include/cpp/jank/runtime/core/math.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core/math.hpp
@@ -1062,13 +1062,6 @@ namespace jank::runtime
     return static_cast<i64>(l);
   }
 
-  i64 to_long(object_ref const l);
-  i64 to_long(obj::nil_ref const l);
-  i64 to_long(obj::integer_ref const l);
-  i64 to_long(obj::real_ref const l);
-  i64 to_long(i64 const l);
-  i64 to_long(f64 const l);
-
   f64 to_real(object_ref const o);
 
   template <typename T>

--- a/compiler+runtime/include/cpp/jank/runtime/core/math.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core/math.hpp
@@ -1062,6 +1062,13 @@ namespace jank::runtime
     return static_cast<i64>(l);
   }
 
+  i64 to_long(object_ref const l);
+  i64 to_long(obj::nil_ref const l);
+  i64 to_long(obj::integer_ref const l);
+  i64 to_long(obj::real_ref const l);
+  i64 to_long(i64 l);
+  i64 to_long(f64 l);
+
   f64 to_real(object_ref const o);
 
   template <typename T>

--- a/compiler+runtime/include/cpp/jank/runtime/core/math.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core/math.hpp
@@ -1110,8 +1110,8 @@ namespace jank::runtime
   bool is_nan(object_ref const o);
   bool is_infinite(object_ref const o);
 
-  i64 parse_long(object_ref const o);
-  f64 parse_double(object_ref const o);
+  object_ref parse_long(object_ref const o);
+  object_ref parse_double(object_ref const o);
 
   bool is_big_integer(object_ref const o);
   obj::big_integer_ref to_big_integer(object_ref const o);

--- a/compiler+runtime/include/cpp/jank/runtime/core/math.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core/math.hpp
@@ -1066,8 +1066,8 @@ namespace jank::runtime
   i64 to_long(obj::nil_ref const l);
   i64 to_long(obj::integer_ref const l);
   i64 to_long(obj::real_ref const l);
-  i64 to_long(i64 l);
-  i64 to_long(f64 l);
+  i64 to_long(i64 const l);
+  i64 to_long(f64 const l);
 
   f64 to_real(object_ref const o);
 

--- a/compiler+runtime/src/cpp/clojure/core_native.cpp
+++ b/compiler+runtime/src/cpp/clojure/core_native.cpp
@@ -529,8 +529,6 @@ extern "C" void jank_load_clojure_core_native()
   intern_fn("eval", &core_native::eval);
   intern_fn("hash-unordered-coll", &core_native::hash_unordered);
   intern_fn("jank-version", &core_native::jank_version);
-  intern_fn("parse-long", &parse_long);
-  intern_fn("parse-double", &parse_double);
   intern_fn("tagged-literal", &tagged_literal);
   intern_fn("tagged-literal?", &is_tagged_literal);
   intern_fn("sorted?", &is_sorted);

--- a/compiler+runtime/src/cpp/jank/runtime/core/math.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/math.cpp
@@ -406,9 +406,23 @@ namespace jank::runtime
   {
     return visit_number_like(
       [](auto const typed_l) -> object_ref {
-        auto const ret{ make_box(typed_l->data + 1ll) };
-        object_ref r{ ret };
-        return r;
+        using T = typename decltype(typed_l)::value_type;
+
+        if constexpr(jtl::is_any_same<T, obj::integer, obj::small_integer>)
+        {
+          i64 res{};
+
+          if(__builtin_add_overflow(typed_l->data, 1ll, &res))
+          {
+            throw make_box("Overflow on increment.").erase();
+          }
+
+          return make_box<obj::integer>(res);
+        }
+        else
+        {
+          return make_box(typed_l->data + 1ll);
+        }
       },
       l);
   }
@@ -442,7 +456,25 @@ namespace jank::runtime
   object_ref dec(object_ref const l)
   {
     return visit_number_like(
-      [](auto const typed_l) -> object_ref { return make_box(typed_l->data - 1ll).erase(); },
+      [](auto const typed_l) -> object_ref {
+        using T = typename decltype(typed_l)::value_type;
+
+        if constexpr(jtl::is_any_same<T, obj::integer, obj::small_integer>)
+        {
+          i64 res{};
+
+          if(__builtin_sub_overflow(typed_l->data, 1ll, &res))
+          {
+            throw make_box("Underflow on decrement.").erase();
+          }
+
+          return make_box<obj::integer>(res);
+        }
+        else
+        {
+          return make_box(typed_l->data - 1ll);
+        }
+      },
       l);
   }
 

--- a/compiler+runtime/src/cpp/jank/runtime/core/math.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/math.cpp
@@ -972,6 +972,36 @@ namespace jank::runtime
     return static_cast<i64>(l->data);
   }
 
+  i64 to_long(object_ref const l)
+  {
+    return to_int(l);
+  }
+
+  i64 to_long(obj::nil_ref const l)
+  {
+    return to_int(l);
+  }
+
+  i64 to_long(obj::integer_ref const l)
+  {
+    return to_int(l);
+  }
+
+  i64 to_long(obj::real_ref const l)
+  {
+    return to_int(l);
+  }
+
+  i64 to_long(i64 l)
+  {
+    return to_int(l);
+  }
+
+  i64 to_long(f64 l)
+  {
+    return to_int(l);
+  }
+
   f64 to_real(object_ref const o)
   {
     return visit_number_like(

--- a/compiler+runtime/src/cpp/jank/runtime/core/math.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/math.cpp
@@ -1055,18 +1055,6 @@ namespace jank::runtime
     if(typed_o.is_some())
     {
       auto const str_size{ static_cast<size_t>(typed_o->data.size()) };
-      auto const max_limit{ std::numeric_limits<size_t>::max() };
-
-      if(max_limit < str_size)
-      {
-        throw make_box(
-          util::format(
-            "String size ({}) exceeds the maximum allowed size ({}) for parsing to integer.",
-            str_size,
-            max_limit))
-          .erase();
-      }
-
       size_t parsed_upto{};
       i64 parsed_long{};
 
@@ -1099,18 +1087,6 @@ namespace jank::runtime
     if(typed_o.is_some())
     {
       auto const str_size{ static_cast<size_t>(typed_o->data.size()) };
-      auto const max_limit{ std::numeric_limits<size_t>::max() };
-
-      if(max_limit < str_size)
-      {
-        throw make_box(
-          util::format(
-            "String size ({}) exceeds the maximum allowed size ({}) for parsing to double.",
-            str_size,
-            max_limit))
-          .erase();
-      }
-
       size_t parsed_upto{};
       f64 parsed_double{};
 

--- a/compiler+runtime/src/cpp/jank/runtime/core/math.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/math.cpp
@@ -972,36 +972,6 @@ namespace jank::runtime
     return static_cast<i64>(l->data);
   }
 
-  i64 to_long(object_ref const l)
-  {
-    return to_int(l);
-  }
-
-  i64 to_long(obj::nil_ref const l)
-  {
-    return to_int(l);
-  }
-
-  i64 to_long(obj::integer_ref const l)
-  {
-    return to_int(l);
-  }
-
-  i64 to_long(obj::real_ref const l)
-  {
-    return to_int(l);
-  }
-
-  i64 to_long(i64 const l)
-  {
-    return to_int(l);
-  }
-
-  i64 to_long(f64 const l)
-  {
-    return to_int(l);
-  }
-
   f64 to_real(object_ref const o)
   {
     return visit_number_like(

--- a/compiler+runtime/src/cpp/jank/runtime/core/math.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/math.cpp
@@ -992,12 +992,12 @@ namespace jank::runtime
     return to_int(l);
   }
 
-  i64 to_long(i64 l)
+  i64 to_long(i64 const l)
   {
     return to_int(l);
   }
 
-  i64 to_long(f64 l)
+  i64 to_long(f64 const l)
   {
     return to_int(l);
   }

--- a/compiler+runtime/src/cpp/jank/runtime/core/math.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/math.cpp
@@ -1017,12 +1017,42 @@ namespace jank::runtime
   }
 
   /* TODO: Rename these to match the type name. */
-  i64 parse_long(object_ref const o)
+  object_ref parse_long(object_ref const o)
   {
     auto const typed_o{ dyn_cast<obj::persistent_string>(o) };
     if(typed_o.is_some())
     {
-      return std::stoll(typed_o->data);
+      auto const str_size{ static_cast<size_t>(typed_o->data.size()) };
+      auto const max_limit{ std::numeric_limits<size_t>::max() };
+
+      if(max_limit < str_size)
+      {
+        throw make_box(
+          util::format(
+            "String size ({}) exceeds the maximum allowed size ({}) for parsing to integer.",
+            str_size,
+            max_limit))
+          .erase();
+      }
+
+      size_t parsed_upto{};
+      i64 parsed_long{};
+
+      try
+      {
+        parsed_long = std::stoll(typed_o->data, &parsed_upto);
+      }
+      catch(...)
+      {
+        return jank_nil;
+      }
+
+      if(parsed_upto != str_size)
+      {
+        return jank_nil;
+      }
+
+      return make_box<obj::integer>(parsed_long);
     }
     else
     {
@@ -1031,12 +1061,42 @@ namespace jank::runtime
     }
   }
 
-  f64 parse_double(object_ref const o)
+  object_ref parse_double(object_ref const o)
   {
     auto const typed_o{ dyn_cast<obj::persistent_string>(o) };
     if(typed_o.is_some())
     {
-      return std::stod(typed_o->data);
+      auto const str_size{ static_cast<size_t>(typed_o->data.size()) };
+      auto const max_limit{ std::numeric_limits<size_t>::max() };
+
+      if(max_limit < str_size)
+      {
+        throw make_box(
+          util::format(
+            "String size ({}) exceeds the maximum allowed size ({}) for parsing to double.",
+            str_size,
+            max_limit))
+          .erase();
+      }
+
+      size_t parsed_upto{};
+      f64 parsed_double{};
+
+      try
+      {
+        parsed_double = std::stod(typed_o->data, &parsed_upto);
+      }
+      catch(...)
+      {
+        return jank_nil;
+      }
+
+      if(parsed_upto != str_size)
+      {
+        return jank_nil;
+      }
+
+      return make_box<obj::real>(parsed_double);
     }
     else
     {

--- a/compiler+runtime/src/cpp/jank/runtime/core/math.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/math.cpp
@@ -417,7 +417,7 @@ namespace jank::runtime
             throw make_box("Overflow on increment.").erase();
           }
 
-          return make_box<obj::integer>(res);
+          return make_box(res);
         }
         else
         {
@@ -468,7 +468,7 @@ namespace jank::runtime
             throw make_box("Underflow on decrement.").erase();
           }
 
-          return make_box<obj::integer>(res);
+          return make_box(res);
         }
         else
         {
@@ -1114,7 +1114,7 @@ namespace jank::runtime
         return jank_nil;
       }
 
-      return make_box<obj::integer>(parsed_long);
+      return make_box(parsed_long);
     }
     else
     {
@@ -1158,7 +1158,7 @@ namespace jank::runtime
         return jank_nil;
       }
 
-      return make_box<obj::real>(parsed_double);
+      return make_box(parsed_double);
     }
     else
     {

--- a/compiler+runtime/src/cpp/jank/runtime/obj/number.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/number.cpp
@@ -1,5 +1,6 @@
 #include <cmath>
 
+#include <jank/runtime/core/math.hpp>
 #include <jank/runtime/oref.hpp>
 #include <jank/runtime/obj/number.hpp>
 #include <jank/runtime/visit.hpp>
@@ -252,6 +253,11 @@ namespace jank::runtime::obj
 
   bool real::equal(object const &o) const
   {
+    if(is_nan(this) || is_nan(&o))
+    {
+      return false;
+    }
+
     if(o.type == object_type::big_decimal)
     {
       auto const i(expect_object<big_decimal>(runtime::detail::untagged(&o)));
@@ -353,6 +359,11 @@ namespace jank::runtime::obj
 
   bool small_real::equal(object const &o) const
   {
+    if(is_nan(this) || is_nan(&o))
+    {
+      return false;
+    }
+
     if(o.type == object_type::big_decimal)
     {
       auto const i(expect_object<big_decimal>(runtime::detail::untagged(&o)));

--- a/compiler+runtime/src/cpp/jank/runtime/obj/number.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/number.cpp
@@ -1,6 +1,5 @@
 #include <cmath>
 
-#include <jank/runtime/core/math.hpp>
 #include <jank/runtime/oref.hpp>
 #include <jank/runtime/obj/number.hpp>
 #include <jank/runtime/visit.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/obj/number.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/number.cpp
@@ -253,11 +253,6 @@ namespace jank::runtime::obj
 
   bool real::equal(object const &o) const
   {
-    if(is_nan(this) || is_nan(&o))
-    {
-      return false;
-    }
-
     if(o.type == object_type::big_decimal)
     {
       auto const i(expect_object<big_decimal>(runtime::detail::untagged(&o)));
@@ -359,11 +354,6 @@ namespace jank::runtime::obj
 
   bool small_real::equal(object const &o) const
   {
-    if(is_nan(this) || is_nan(&o))
-    {
-      return false;
-    }
-
     if(o.type == object_type::big_decimal)
     {
       auto const i(expect_object<big_decimal>(runtime::detail::untagged(&o)));

--- a/compiler+runtime/src/jank/clojure/core.jank
+++ b/compiler+runtime/src/jank/clojure/core.jank
@@ -5744,7 +5744,7 @@
 (defn long
   "Coerce to long"
   [#_Number x]
-  (cpp/jank.runtime.to_long x))
+  (cpp/jank.runtime.to_int x))
 
 (defn double
   "Coerce to double"

--- a/compiler+runtime/src/jank/clojure/core.jank
+++ b/compiler+runtime/src/jank/clojure/core.jank
@@ -5744,8 +5744,7 @@
 (defn long
   "Coerce to long"
   [#_Number x]
-  ;; (clojure.lang.RT/longCast x)
-  (throw "TODO: port long"))
+  (cpp/jank.runtime.to_long x))
 
 (defn double
   "Coerce to double"

--- a/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
+++ b/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
@@ -143,7 +143,7 @@
     clojure.core-test.peek
     clojure.core-test.persistent-bang
     ; clojure.core-test.plus ; FIXME: Failing tests.
-    ; clojure.core-test.plus-squote ; analyze/unresolved-symbol error: Unable to resolve symbol 'clojure.lang.BigInt'.
+    clojure.core-test.plus-squote
     clojure.core-test.pop
     clojure.core-test.pop-bang
     clojure.core-test.pos-int-qmark
@@ -195,7 +195,7 @@
     ; clojure.core-test.sorted-qmark ; TODO: port sorted-map-by, not yet implemented: sorted-set-by, TODO: port array-map, TODO: port object-array
     ; clojure.core-test.special-symbol-qmark ; TODO: port special-symbol?
     ; clojure.core-test.star ; FIXME: Failing tests.
-    ; clojure.core-test.star-squote ; analyze/unresolved-symbol error: Unable to resolve symbol 'clojure.lang.BigInt'.
+    clojure.core-test.star-squote
     ; clojure.core-test.str ; FIXME: Failing tests.
     clojure.core-test.string-qmark
     ; clojure.core-test.subs ; FIXME: Failing tests.

--- a/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
+++ b/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
@@ -101,7 +101,7 @@
     clojure.core-test.keyword-qmark
     clojure.core-test.last
     ; clojure.core-test.list-qmark ; TODO: port array-map, TODO: port object-array
-    ; clojure.core-test.long ; TODO: port long
+    clojure.core-test.long
     clojure.core-test.lt
     clojure.core-test.lt-eq
     clojure.core-test.make-hierarchy

--- a/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
+++ b/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
@@ -115,7 +115,7 @@
     ; clojure.core-test.mod ; FIXME: Failing tests.
     clojure.core-test.name
     clojure.core-test.namespace
-    ; clojure.core-test.nan-qmark ; Uncaught exception: not a number: nil, https://github.com/jank-lang/jank/issues/244
+    clojure.core-test.nan-qmark
     ; clojure.core-test.neg-int-qmark ; FIXME: Failing test.
     clojure.core-test.neg-qmark
     clojure.core-test.next

--- a/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
+++ b/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
@@ -48,7 +48,7 @@
     clojure.core-test.count
     ; clojure.core-test.counted-qmark ; TODO: port array-map, TODO: port object-array
     ; clojure.core-test.cycle ; Program hangs.
-    ; clojure.core-test.dec ; TODO: underflow.
+    clojure.core-test.dec
     clojure.core-test.decimal-qmark
     clojure.core-test.denominator
     ; clojure.core-test.derive ; analyze/unresolved-symbol error: Unable to resolve symbol 'String'.
@@ -87,7 +87,7 @@
     clojure.core-test.ident-qmark
     clojure.core-test.identical-qmark
     ; clojure.core-test.ifn-qmark ; TODO: port promise
-    ; clojure.core-test.inc ; overflow untested,
+    clojure.core-test.inc
     ; clojure.core-test.int ; FIXME: Failing tests.
     ; clojure.core-test.int-qmark ; FIXME: Failing tests.
     ; clojure.core-test.integer-qmark ; FIXME: Failing tests.

--- a/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
+++ b/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
@@ -136,8 +136,8 @@
     clojure.core-test.or
     ; clojure.core-test.parents ; analyze/unresolved-symbol error: Unable to resolve symbol 'defprotocol'.
     clojure.core-test.parse-boolean
-    ; clojure.core-test.parse-double ; libc++abi: terminating due to uncaught exception of type std::invalid_argument: stod: no conversio.
-    ; clojure.core-test.parse-long ; libc++abi: terminating due to uncaught exception of type std::invalid_argument: stoll: no conversion.
+    clojure.core-test.parse-double
+    clojure.core-test.parse-long
     clojure.core-test.parse-uuid
     clojure.core-test.partial
     clojure.core-test.peek


### PR DESCRIPTION
~~Requires a Clojure test suite repoint (https://github.com/jank-lang/clojure-test-suite/pull/875)~~. Done.

Brings us to **125 of 231 tests**. Goal is to get to 145, covering all "math" `clojure.core` functions with tests in the test suite.