### PR TITLE
Fix `identical?`

### DIFF
--- a/compiler+runtime/src/cpp/jank/analyze/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/analyze/processor.cpp
@@ -714,7 +714,9 @@ namespace jank::analyze
       }
       /* Handle assigning to a jank object from a primitive. */
       else if(arg_types.size() == 2 && cpp_util::is_trait_convertible(arg_types[1].m_Type)
-              && cpp_util::is_any_object(Cpp::GetNonReferenceType(obj_type)))
+              && cpp_util::is_any_object(Cpp::GetNonReferenceType(obj_type))
+              && !(cpp_util::is_any_object(Cpp::GetNonReferenceType(arg_types[1].m_Type))
+                   && (op == Cpp::OP_EqualEqual || op == Cpp::OP_ExclaimEqual)))
       {
         auto const conversion_res{
           apply_implicit_conversion(arg_exprs[1], arg_types[1].m_Type, obj_type, macro_expansions)

--- a/compiler+runtime/src/cpp/jank/analyze/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/analyze/processor.cpp
@@ -715,8 +715,8 @@ namespace jank::analyze
       /* Handle assigning to a jank object from a primitive. */
       else if(arg_types.size() == 2 && cpp_util::is_trait_convertible(arg_types[1].m_Type)
               && cpp_util::is_any_object(Cpp::GetNonReferenceType(obj_type))
-              && !(cpp_util::is_any_object(Cpp::GetNonReferenceType(arg_types[1].m_Type))
-                   && (op == Cpp::OP_EqualEqual || op == Cpp::OP_ExclaimEqual)))
+              && (!cpp_util::is_any_object(Cpp::GetNonReferenceType(arg_types[1].m_Type))
+                  || (op != Cpp::OP_EqualEqual && op != Cpp::OP_ExclaimEqual)))
       {
         auto const conversion_res{
           apply_implicit_conversion(arg_exprs[1], arg_types[1].m_Type, obj_type, macro_expansions)

--- a/compiler+runtime/test/jank/form/identical/pass-identical.jank
+++ b/compiler+runtime/test/jank/form/identical/pass-identical.jank
@@ -1,0 +1,3 @@
+((fn [o] (cpp/== :foo o)) [])
+((fn [o] (identical? :foo o)) [])
+:success


### PR DESCRIPTION
So when trying to use `tap>` recently, I noticed it would stop working randomly. It did appear to work fine when tapping keywords, but would stop working with `[]` or `{}`. When connecting the debugger, I got the following exception:

```
libstdc++.so.6!__cxa_throw (Unknown Source:0)
jank::runtime::try_object<jank::runtime::obj::keyword>(jank::runtime::oref<jank::runtime::object>) requires behavior::object_like<jank::runtime::obj::keyword>(const jank::runtime::object_ref o) (\home\chris\repos\jank\compiler+runtime\include\cpp\jank\runtime\rtti.hpp:42)
jank::runtime::convert<jank::runtime::oref<jank::runtime::obj::keyword> >::from_object(const jank::runtime::object_ref t) (\home\chris\repos\jank\compiler+runtime\include\cpp\jank\runtime\convert\builtin.hpp:66)
clojure_core_fn_38724_0() (\home\chris\repos\jank\compiler+runtime\build\input_line_199:90342)
jank::runtime::obj::jit_function::call(const jank::runtime::obj::jit_function * this) (\home\chris\repos\jank\compiler+runtime\src\cpp\jank\runtime\obj\jit_function.cpp:61)
jank::runtime::oref<jank::runtime::object>::call(const jank::runtime::oref<jank::runtime::object> * this) (\home\chris\repos\jank\compiler+runtime\include\cpp\jank\runtime\oref.hpp:524)
jank::runtime::dynamic_call(const jank::runtime::object_ref source) (\home\chris\repos\jank\compiler+runtime\src\cpp\jank\runtime\core\call.cpp:22)
jank::runtime::future(jank::runtime::oref<jank::runtime::object>)::$_0::operator()() const(const class {...} * this) (\home\chris\repos\jank\compiler+runtime\src\cpp\jank\runtime\core.cpp:756)
std::__invoke_impl<void, jank::runtime::future(jank::runtime::oref<jank::runtime::object>)::$_0>(std::__invoke_other, jank::runtime::future(jank::runtime::oref<jank::runtime::object>)::$_0&&)(class {...} && __f) (\usr\include\c++\16.1.1\bits\invoke.h:63)
std::__invoke<jank::runtime::future(jank::runtime::oref<jank::runtime::object>)::$_0>(jank::runtime::future(jank::runtime::oref<jank::runtime::object>)::$_0&&)(class {...} && __fn) (\usr\include\c++\16.1.1\bits\invoke.h:98)
std::thread::_Invoker<std::tuple<jank::runtime::future(jank::runtime::oref<jank::runtime::object>)::$_0> >::_M_invoke<0ul>(std::thread::_Invoker<std::tuple<(lambda at /home/chris/repos/jank/compiler+runtime/src/cpp/jank/runtime/core.cpp:744:32)> > * this) (\usr\include\c++\16.1.1\bits\std_thread.h:303)
std::thread::_Invoker<std::tuple<jank::runtime::future(jank::runtime::oref<jank::runtime::object>)::$_0> >::operator()(std::thread::_Invoker<std::tuple<(lambda at /home/chris/repos/jank/compiler+runtime/src/cpp/jank/runtime/core.cpp:744:32)> > * this) (\usr\include\c++\16.1.1\bits\std_thread.h:310)
std::thread::_State_impl<std::thread::_Invoker<std::tuple<jank::runtime::future(jank::runtime::oref<jank::runtime::object>)::$_0> > >::_M_run(std::thread::_State_impl<std::thread::_Invoker<std::tuple<(lambda at /home/chris/repos/jank/compiler+runtime/src/cpp/jank/runtime/core.cpp:744:32)> > > * this) (\usr\include\c++\16.1.1\bits\std_thread.h:255)
libstdc++.so.6!??? (Unknown Source:0)
libc.so.6!??? (Unknown Source:0)
libc.so.6!??? (Unknown Source:0)
```

It turns out the issue is related to the in-lining of `identical?`. I think it happens when one of the values has a known type, but the other doesn't. For the [tap-loop](https://github.com/jank-lang/jank/blob/main/compiler%2Bruntime/src/jank/clojure/core.jank#L7658-L7668), we do the following check: `(identical? ::tap-nil t)`. I added some tests so we could catch this issue in the future. However, since I don't understand how the implicit conversion code works, I had an LLM generate an example solution. I verified that the example solution fixed my tap issue locally. If the correct solution is a bit more involved, I am happy to work on it more directly with some pointers 👍 