### PR TITLE
Fix equality for certain seq types

### DIFF
--- a/compiler+runtime/src/cpp/jank/runtime/obj/detail/base_persistent_map_sequence.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/detail/base_persistent_map_sequence.cpp
@@ -19,7 +19,7 @@ namespace jank::runtime::obj::detail
   template <typename PT, typename IT>
   bool base_persistent_map_sequence<PT, IT>::equal(object const &o) const
   {
-    return runtime::sequence_equal(static_cast<PT const *>(this), runtime::detail::untagged(&o));
+    return runtime::sequence_equal(runtime::detail::untagged(this), runtime::detail::untagged(&o));
   }
 
   template <typename PT, typename IT>

--- a/compiler+runtime/src/cpp/jank/runtime/obj/detail/iterator_sequence.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/detail/iterator_sequence.cpp
@@ -36,8 +36,7 @@ namespace jank::runtime::obj::detail
   template <typename Derived, typename It>
   bool iterator_sequence<Derived, It>::equal(object const &o) const
   {
-    return runtime::sequence_equal(static_cast<Derived const *>(this),
-                                   runtime::detail::untagged(&o));
+    return runtime::sequence_equal(runtime::detail::untagged(this), runtime::detail::untagged(&o));
   }
 
   template <typename Derived, typename It>


### PR DESCRIPTION
In porting some serialization code in portal, I ran into some seq equality issues. In the debugger, I noticed that for [`runtime::sequence_equal`](https://github.com/jank-lang/jank/blob/main/compiler%2Bruntime/src/cpp/jank/runtime/core/seq.cpp#L976) `l` was `0.000` which led me to believe this was a pointer tagging issue. Also, I noticed for all other calls of `runtime::sequence_equal`, we wrapped `this` with `runtime::detail::untagged`, so I think this is the proper fix?

Before:
```clojure
% jank repl
user=> (= (seq #{0}) (seq [0]))
false
user=> (= (seq {0 0}) (seq {0 0}))
false
```

After:
```clojure
% jank repl
user=> (= (seq #{0}) (seq [0]))
true
user=> (= (seq {0 0}) (seq {0 0}))
true
```

Clojure:
```clojure
% clj
Clojure 1.12.2
user=> (= (seq #{0}) (seq [0]))
true
user=> (= (seq {0 0}) (seq {0 0}))
true
```