### PR TITLE
Fix shuffle/re-find vector ctor usage

### DIFF
--- a/compiler+runtime/src/cpp/jank/runtime/core.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core.cpp
@@ -591,7 +591,7 @@ namespace jank::runtime
           }
 
           return make_box<obj::persistent_vector>(
-            runtime::detail::native_persistent_vector{ vec.begin(), vec.end() });
+            runtime::detail::native_persistent_vector(vec.begin(), vec.end()));
         }
     }
   }

--- a/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
@@ -1185,7 +1185,7 @@ namespace jank::runtime
         std::shuffle(vec.begin(), vec.end(), g);
 
         return make_box<obj::persistent_vector>(
-          runtime::detail::native_persistent_vector{ vec.begin(), vec.end() });
+          runtime::detail::native_persistent_vector(vec.begin(), vec.end()));
       },
       coll);
   }


### PR DESCRIPTION
`shuffle` and `re-find` native implementations were improperly calling the `vector(std::initializer_list)` constructor with 2 elements rather than the `vector(Iter first, Iter last)` constructor.

Before:
```
user=> (shuffle (range 0 10))
[0.000000 0.000000]
user=> (re-find #"(\d+) (\d+) (\d+)" "1 2 3 4 5 6 7")
[0.000000 0.000000]
```

After:
```
user=> (shuffle (range 0 10))
[4 9 2 0 5 1 6 8 3 7]
user=> (re-find #"(\d+) (\d+) (\d+)" "1 2 3 4 5 6 7")
["1 2 3" "1" "2" "3"]
```

Note there are some other similar instances in core that might need a closer look.