### PR TITLE
Implement `char`

### DIFF
--- a/compiler+runtime/include/cpp/jank/runtime/core.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core.hpp
@@ -128,4 +128,6 @@ namespace jank::runtime
 
   object_ref read_string(object_ref const form_string, object_ref const opts);
   object_ref read_file(object_ref const file_path, object_ref const opts);
+
+  obj::character_ref to_char(object_ref const x);
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/character.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/character.hpp
@@ -17,6 +17,7 @@ namespace jank::runtime::obj
     character(character const &) = default;
     character(jtl::immutable_string const &);
     character(char);
+    character(i64);
 
     /* behavior::object_like */
     bool equal(object const &) const override;

--- a/compiler+runtime/include/cpp/jtl/immutable_string.hpp
+++ b/compiler+runtime/include/cpp/jtl/immutable_string.hpp
@@ -64,11 +64,44 @@ namespace jtl
 
     static constexpr size_type npos{ std::numeric_limits<size_type>::max() };
 
+    static constexpr i64 max_unicode_value{ 0x10FFFF };
+
     friend struct jtl::string_builder;
 
     constexpr immutable_string() noexcept
     {
       set_small_size(0);
+    }
+
+    // Taken from imgui.cpp (ImTextCharToUtf8)
+    explicit constexpr immutable_string(i32 code_point) noexcept
+    {
+      if(code_point < 0x80)
+      {
+        init_small_fill(0, 1);
+        store.small[0] = static_cast<value_type>(code_point);
+      }
+      else if(code_point < 0x800)
+      {
+        init_small_fill(0, 2);
+        store.small[0] = static_cast<value_type>(0xc0 + (code_point >> 6));
+        store.small[1] = static_cast<value_type>(0x80 + (code_point & 0x3f));
+      }
+      else if(code_point < 0x10000)
+      {
+        init_small_fill(0, 3);
+        store.small[0] = static_cast<value_type>(0xe0 + (code_point >> 12));
+        store.small[1] = static_cast<value_type>(0x80 + ((code_point >> 6) & 0x3f));
+        store.small[2] = static_cast<value_type>(0x80 + (code_point & 0x3f));
+      }
+      else if(code_point <= 0x10FFFF)
+      {
+        init_small_fill(0, 4);
+        store.small[0] = static_cast<value_type>(0xf0 + (code_point >> 18));
+        store.small[1] = static_cast<value_type>(0x80 + ((code_point >> 12) & 0x3f));
+        store.small[2] = static_cast<value_type>(0x80 + ((code_point >> 6) & 0x3f));
+        store.small[3] = static_cast<value_type>(0x80 + (code_point & 0x3f));
+      }
     }
 
     constexpr immutable_string(immutable_string const &s) noexcept

--- a/compiler+runtime/include/cpp/jtl/immutable_string.hpp
+++ b/compiler+runtime/include/cpp/jtl/immutable_string.hpp
@@ -64,44 +64,11 @@ namespace jtl
 
     static constexpr size_type npos{ std::numeric_limits<size_type>::max() };
 
-    static constexpr i64 max_unicode_value{ 0x10FFFF };
-
     friend struct jtl::string_builder;
 
     constexpr immutable_string() noexcept
     {
       set_small_size(0);
-    }
-
-    // Taken from imgui.cpp (ImTextCharToUtf8)
-    explicit constexpr immutable_string(u32 const code_point) noexcept
-    {
-      if(code_point < 0x80)
-      {
-        init_small_fill(0, 1);
-        store.small[0] = static_cast<value_type>(code_point);
-      }
-      else if(code_point < 0x800)
-      {
-        init_small_fill(0, 2);
-        store.small[0] = static_cast<value_type>(0xc0 + (code_point >> 6));
-        store.small[1] = static_cast<value_type>(0x80 + (code_point & 0x3f));
-      }
-      else if(code_point < 0x10000)
-      {
-        init_small_fill(0, 3);
-        store.small[0] = static_cast<value_type>(0xe0 + (code_point >> 12));
-        store.small[1] = static_cast<value_type>(0x80 + ((code_point >> 6) & 0x3f));
-        store.small[2] = static_cast<value_type>(0x80 + (code_point & 0x3f));
-      }
-      else if(code_point <= 0x10FFFF)
-      {
-        init_small_fill(0, 4);
-        store.small[0] = static_cast<value_type>(0xf0 + (code_point >> 18));
-        store.small[1] = static_cast<value_type>(0x80 + ((code_point >> 12) & 0x3f));
-        store.small[2] = static_cast<value_type>(0x80 + ((code_point >> 6) & 0x3f));
-        store.small[3] = static_cast<value_type>(0x80 + (code_point & 0x3f));
-      }
     }
 
     constexpr immutable_string(immutable_string const &s) noexcept

--- a/compiler+runtime/include/cpp/jtl/immutable_string.hpp
+++ b/compiler+runtime/include/cpp/jtl/immutable_string.hpp
@@ -74,7 +74,7 @@ namespace jtl
     }
 
     // Taken from imgui.cpp (ImTextCharToUtf8)
-    explicit constexpr immutable_string(i32 code_point) noexcept
+    explicit constexpr immutable_string(u32 const code_point) noexcept
     {
       if(code_point < 0x80)
       {

--- a/compiler+runtime/src/cpp/jank/runtime/core.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core.cpp
@@ -924,7 +924,7 @@ namespace jank::runtime
       throw std::runtime_error{ util::format("Value out of range for char: {}", n) };
     }
 
-    jtl::immutable_string c(n);
+    jtl::immutable_string const c(static_cast<u32>(n));
     return make_box<obj::character>(c);
   }
 }

--- a/compiler+runtime/src/cpp/jank/runtime/core.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core.cpp
@@ -917,7 +917,14 @@ namespace jank::runtime
       return expect_object<obj::character>(x);
     }
 
-    jtl::immutable_string c(1, to_int(x));
+    auto const n(to_int(x));
+
+    if(n < 0 || n > jtl::immutable_string::max_unicode_value)
+    {
+      throw std::runtime_error{ util::format("Value out of range for char: {}", n) };
+    }
+
+    jtl::immutable_string c(n);
     return make_box<obj::character>(c);
   }
 }

--- a/compiler+runtime/src/cpp/jank/runtime/core.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core.cpp
@@ -909,4 +909,15 @@ namespace jank::runtime
     auto const typed_o{ expect_object<obj::persistent_string>(file_path) };
     return __rt_ctx->read_file(typed_o->data, opts);
   }
+
+  obj::character_ref to_char(object_ref const x)
+  {
+    if(x.get_type() == object_type::character)
+    {
+      return expect_object<obj::character>(x);
+    }
+
+    jtl::immutable_string c(1, to_int(x));
+    return make_box<obj::character>(c);
+  }
 }

--- a/compiler+runtime/src/cpp/jank/runtime/core.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core.cpp
@@ -917,14 +917,6 @@ namespace jank::runtime
       return expect_object<obj::character>(x);
     }
 
-    auto const n(to_int(x));
-
-    if(n < 0 || n > jtl::immutable_string::max_unicode_value)
-    {
-      throw std::runtime_error{ util::format("Value out of range for char: {}", n) };
-    }
-
-    jtl::immutable_string const c(static_cast<u32>(n));
-    return make_box<obj::character>(c);
+    return make_box<obj::character>(to_int(x));
   }
 }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/character.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/character.cpp
@@ -62,7 +62,7 @@ namespace jank::runtime::obj
     std::mbstate_t state{};
     wchar_t const wc{ static_cast<wchar_t>(ch) };
     std::string str(MB_CUR_MAX, '\0');
-    auto const len{ std::wcrtomb(&str[0], wc, &state) };
+    auto const len{ std::wcrtomb(str.data(), wc, &state) };
 
     if(std::cmp_equal(len, static_cast<size_t>(-1)))
     {

--- a/compiler+runtime/src/cpp/jank/runtime/obj/character.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/character.cpp
@@ -1,3 +1,5 @@
+#include <cwchar>
+
 #include <jank/runtime/obj/character.hpp>
 #include <jank/runtime/rtti.hpp>
 #include <jank/util/escape.hpp>
@@ -47,6 +49,38 @@ namespace jank::runtime::obj
   character::character(char const ch)
     : object{ obj_type, obj_behaviors }
     , data{ 1, ch }
+  {
+  }
+
+  static jtl::immutable_string to_char(i64 const ch)
+  {
+    if(ch > 0x10FFFF)
+    {
+      throw std::runtime_error{ util::format("Value out of range for char: {}", ch) };
+    }
+
+    std::mbstate_t state{};
+    wchar_t const wc{ static_cast<wchar_t>(ch) };
+    std::string str(MB_CUR_MAX, '\0');
+    auto const len{ std::wcrtomb(&str[0], wc, &state) };
+
+    if(std::cmp_equal(len, static_cast<size_t>(-1)))
+    {
+      throw std::runtime_error{ util::format("Unfinished character: {}", ch) };
+    }
+    else if(std::cmp_equal(len, static_cast<size_t>(-2)))
+    {
+      throw std::runtime_error{ util::format("Invalid Unicode character: {}", ch) };
+    }
+
+    str.resize(len);
+
+    return str;
+  }
+
+  character::character(i64 const ch)
+    : object{ obj_type, obj_behaviors }
+    , data{ to_char(ch) }
   {
   }
 

--- a/compiler+runtime/src/jank/clojure/core.jank
+++ b/compiler+runtime/src/jank/clojure/core.jank
@@ -5766,8 +5766,7 @@
 (defn char
   "Coerce to char"
   [x]
-  ;; (. clojure.lang.RT (charCast x))
-  (throw "TODO: port char"))
+  (cpp/jank.runtime.to_char x))
 
 (defn unchecked-byte
   "Coerce to byte. Subject to rounding or truncation."

--- a/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
+++ b/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
@@ -35,7 +35,7 @@
     clojure.core-test.butlast
     ; clojure.core-test.byte ; TODO: port byte, Expecting whitespace after the last token. due to M.
     ; clojure.core-test.case ; analyze/invalid-case error: Unable to resolve symbol 'of'.
-    ; clojure.core-test.char ; TODO: port char
+    clojure.core-test.char
     clojure.core-test.char-qmark
     ; clojure.core-test.coll-qmark ; TODO: port array-map, TODO: port object-array
     clojure.core-test.comment


### PR DESCRIPTION
I initially implemented `char` without consideration for Unicode. However, I don't know Unicode outside of ASCII all that well, and the [spec](https://datatracker.ietf.org/doc/html/rfc3629#section-3) helped a bit, but I assumed other cpp projects had this problem as well. I decided to "borrow" the implementation from [`imgui`](https://github.com/ocornut/imgui/blob/master/imgui.cpp#L2691-L2724) as it's a well known popular project. The code is licensed under MIT, so I assume it is ok to use in jank?

Jank:
```clojure
% jank repl
user=> (char 65)
\A
user=> (char 65.0)
\A
user=> (char 0x1F600)
\😀
```

Clojure:
```clojure
% clj
Clojure 1.12.2
user=> (char 65)
\A
user=> (char 65.0)
\A
user=> (char 0x1F600)
Execution error (IllegalArgumentException) at user/eval5 (REPL:1).
Value out of range for char: 128512
user=> (String. (Character/toChars 0x1F600))
"😀"
```

The one thing I noticed is that for Clojure, `char` blows up much sooner since I think the underlying jvm strings are 2 bytes per "char". Do we want jank to have the same limitation, or should we support more because we can and this is more of a platform limitation?