### PR TITLE
Fix `(= (seq "hi") (seq "hi"))`

### DIFF
--- a/compiler+runtime/src/cpp/jank/runtime/core/equal.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/equal.cpp
@@ -13,7 +13,7 @@ namespace jank::runtime
     }
 
     obj::character_ref const typed_rhs{ expect_object<obj::character>(rhs) };
-    return typed_rhs->data[0] == lhs;
+    return typed_rhs->data.size() == 1 && typed_rhs->data[0] == lhs;
   }
 
   bool equal(object_ref const lhs, object_ref const rhs)

--- a/compiler+runtime/src/cpp/jank/runtime/core/equal.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/equal.cpp
@@ -12,7 +12,7 @@ namespace jank::runtime
       return false;
     }
 
-    obj::character_ref const typed_rhs{ expect_object<obj::character>(rhs) };
+    auto const typed_rhs{ expect_object<obj::character>(rhs) };
     return typed_rhs->data.size() == 1 && typed_rhs->data[0] == lhs;
   }
 

--- a/compiler+runtime/src/cpp/jank/runtime/core/equal.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/equal.cpp
@@ -12,8 +12,8 @@ namespace jank::runtime
       return false;
     }
 
-    auto const typed_rhs{ expect_object<obj::character>(rhs) };
-    return typed_rhs->to_hash() == static_cast<uhash>(lhs);
+    obj::character_ref const typed_rhs{ expect_object<obj::character>(rhs) };
+    return typed_rhs->data[0] == lhs;
   }
 
   bool equal(object_ref const lhs, object_ref const rhs)


### PR DESCRIPTION
Before:
```clojure
% jank repl
user=> (= (seq "hi") (seq "hi"))
false
```

After:
```clojure
% jank repl
user=> (= (seq "hi") (seq "hi"))
true
```

Clojure:
```clojure
% clj
Clojure 1.12.2
user=> (= (seq "hi") (seq "hi"))
true
```