### PR TITLE
Fix lex `-equiv`

### DIFF
--- a/compiler+runtime/src/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/src/cpp/jank/read/lex.cpp
@@ -759,7 +759,7 @@ namespace jank::read::lex
               }
               radix = 10; /* numbers like 02.3 should be parsed as decimal numbers. */
             }
-            else if(c == 'e' || c == 'E')
+            else if(contains_leading_digit && (c == 'e' || c == 'E'))
             {
               if(found_r)
               {

--- a/compiler+runtime/test/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/test/cpp/jank/read/lex.cpp
@@ -1625,6 +1625,16 @@ namespace jank::read::lex
         }));
       }
 
+      SUBCASE("Starting with -e")
+      {
+        processor p{ "-equiv" };
+        native_vector<jtl::result<token, error_ref>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 6, token_kind::symbol, "-equiv"sv }
+        }));
+      }
+
       SUBCASE("Double hyphen")
       {
         processor p{ "--" };


### PR DESCRIPTION
In portal, I have cljc files with code that contain `deftype`s with `-equiv` protocol methods. Even though they are part of `:cljs` reader conditional branches, they still need to be lexed and parsed.

Before
```clojure
% jank repl
user=> '-equiv
─ lex/invalid-number ───────────────────────────────────────────────────────────────────────────────
error: Extraneous 'e' found in number.                                                              
                                                                                                    
─────┬──────────────────────────────────────────────────────────────────────────────────────────────
     │ /tmp/jank-repl-ZWd35c                                                                        
─────┼──────────────────────────────────────────────────────────────────────────────────────────────
  1  │ '-equiv                                                                                      
     │   ^ Found 'e' here.                                                                          
─────┴──────────────────────────────────────────────────────────────────────────────────────────────
```

After
```clojure
% jank repl    
user=> '-equiv
-equiv
user=> (type '-equiv)
"symbol"
```