### PR TITLE
Add native build support to lein-jank

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -160,6 +160,7 @@
             llvmPackages.clang
             llvmPackages.libclang
             llvmPackages.libllvm
+            bubblewrap
 
             ## Required libs.
             boehmgc
@@ -179,6 +180,7 @@
             gdb
             clangbuildanalyzer
             openjdk
+            leiningen
 
             ## Book.
             mdbook

--- a/lein-jank/project.clj
+++ b/lein-jank/project.clj
@@ -3,8 +3,8 @@
   :url "https://jank-lang.org/"
   :license {:name "MPL 2.0"
             :url "https://www.mozilla.org/en-US/MPL/2.0/"}
-  :dependencies [[babashka/fs "0.5.20"]
-                 [babashka/process "0.5.22"]
-                 [leiningen-core "2.11.2"]
+  :dependencies [[babashka/fs "0.5.33"]
+                 [babashka/process "0.6.25"]
+                 [leiningen-core "2.12.0"]
                  [org.clojure/tools.namespace "1.5.1"]]
   :eval-in-leiningen true)

--- a/lein-jank/src/leiningen/jank.clj
+++ b/lein-jank/src/leiningen/jank.clj
@@ -1,15 +1,20 @@
 (ns leiningen.jank
   (:refer-clojure :exclude [run!])
   (:require [clojure.pprint :as pp]
-
+            [clojure.string :as string]
             [leiningen.core.main :as lmain]
+            [leiningen.core.classpath :as cp]
             [leiningen.jank.core :as ljc]
-            [leiningen.jank.test :as ljt]))
+            [leiningen.jank.test :as ljt]
+            [leiningen.jank.build :as ljb]
+            [babashka.fs :as fs]))
 
 (defn run!
   "Run your project, starting at the main entrypoint."
   [project & args]
-  (let [cp-str (ljc/build-module-path project)]
+  (let [cp-str       (ljc/build-module-path project)
+        native-flags (ljb/run-build! (ljb/plan-build project))
+        project      (update project :jank ljb/merge-native-flags native-flags)]
     (if (:main project)
       (ljc/shell-out! project cp-str "run-main" [(:main project)] args)
       (do
@@ -19,7 +24,9 @@
 (defn repl!
   "Start a terminal REPL in your :main ns."
   [project & args]
-  (let [cp-str (ljc/build-module-path project)]
+  (let [cp-str       (ljc/build-module-path project)
+        native-flags (ljb/run-build! (ljb/plan-build project))
+        project      (update project :jank ljb/merge-native-flags native-flags)]
     (if (:main project)
       (ljc/shell-out! project cp-str "repl" [(:main project)] args)
       (do
@@ -29,7 +36,9 @@
 (defn compile!
   "Compile your project to an executable."
   [project & args]
-  (let [cp-str (ljc/build-module-path project)]
+  (let [cp-str       (ljc/build-module-path project)
+        native-flags (ljb/run-build! (ljb/plan-build project))
+        project      (update project :jank ljb/merge-native-flags native-flags)]
     (if (:main project)
       (ljc/shell-out! project cp-str "compile" [(:main project)] args)
       (do
@@ -39,7 +48,9 @@
 (defn compile-module!
   "Compile a single module and its dependencies to object files."
   [project & args]
-  (let [cp-str (ljc/build-module-path project)]
+  (let [cp-str       (ljc/build-module-path project)
+        native-flags (ljb/run-build! (ljb/plan-build project))
+        project      (update project :jank ljb/merge-native-flags native-flags)]
     (ljc/shell-out! project cp-str "compile-module" [] args)))
 
 (defn check-health!
@@ -142,7 +153,20 @@
           (with-meta result (apply deep-merge-metadata maps))
           result)))))
 
+(defn verbatim->filespecs [{:keys [root verbatim-paths] :as project}]
+  ;; TODO: I couldn't find a good way to insert paths verbatim into the output
+  ;; jar. With resource-paths etc. lein always seems to strip the first
+  ;; directory from the source path when copying. Need to find an alternative or
+  ;; implement a better version of verbatim-paths.
+  (for [path  verbatim-paths
+        f     (fs/glob (fs/path (:root project) path) "**")
+        :when (not (fs/directory? f))]
+    {:type  :bytes
+     :path  (str (fs/relativize (:root project) f))
+     :bytes (fs/read-all-bytes f)}))
+
 (defn middleware
   "Inject jank project details into your current project."
   [project]
-  (deep-merge default-project project))
+  (-> (deep-merge default-project project)
+      (update :filespecs concat (verbatim->filespecs project))))

--- a/lein-jank/src/leiningen/jank.clj
+++ b/lein-jank/src/leiningen/jank.clj
@@ -9,12 +9,29 @@
             [leiningen.jank.build :as ljb]
             [babashka.fs :as fs]))
 
+(defn apply-args
+  "Extract task-specific args from the list and apply them to the project,
+  returning the updated project and the leftover arguments."
+  [project args]
+  (let [res (reduce
+             (fn [acc arg]
+               (cond
+                 (= arg ":disable-sandbox")
+                 (assoc-in acc [:project :jank :disable-sandbox] true)
+
+                 :else
+                 (update acc :args conj arg)))
+             {:project project :args []}
+             args)]
+    ((juxt :project :args) res)))
+
 (defn run!
   "Run your project, starting at the main entrypoint."
   [project & args]
-  (let [cp-str       (ljc/build-module-path project)
-        native-flags (ljb/run-build! (ljb/plan-build project))
-        project      (update project :jank ljb/merge-native-flags native-flags)]
+  (let [[project args] (apply-args project args)
+        cp-str         (ljc/build-module-path project)
+        native-flags   (ljb/run-build! (ljb/plan-build project))
+        project        (update project :jank ljb/merge-native-flags native-flags)]
     (if (:main project)
       (ljc/shell-out! project cp-str "run-main" [(:main project)] args)
       (do
@@ -24,9 +41,10 @@
 (defn repl!
   "Start a terminal REPL in your :main ns."
   [project & args]
-  (let [cp-str       (ljc/build-module-path project)
-        native-flags (ljb/run-build! (ljb/plan-build project))
-        project      (update project :jank ljb/merge-native-flags native-flags)]
+  (let [[project args] (apply-args project args)
+        cp-str         (ljc/build-module-path project)
+        native-flags   (ljb/run-build! (ljb/plan-build project))
+        project        (update project :jank ljb/merge-native-flags native-flags)]
     (if (:main project)
       (ljc/shell-out! project cp-str "repl" [(:main project)] args)
       (do
@@ -36,9 +54,10 @@
 (defn compile!
   "Compile your project to an executable."
   [project & args]
-  (let [cp-str       (ljc/build-module-path project)
-        native-flags (ljb/run-build! (ljb/plan-build project))
-        project      (update project :jank ljb/merge-native-flags native-flags)]
+  (let [[project args] (apply-args project args)
+        cp-str         (ljc/build-module-path project)
+        native-flags   (ljb/run-build! (ljb/plan-build project))
+        project        (update project :jank ljb/merge-native-flags native-flags)]
     (if (:main project)
       (ljc/shell-out! project cp-str "compile" [(:main project)] args)
       (do
@@ -48,9 +67,10 @@
 (defn compile-module!
   "Compile a single module and its dependencies to object files."
   [project & args]
-  (let [cp-str       (ljc/build-module-path project)
-        native-flags (ljb/run-build! (ljb/plan-build project))
-        project      (update project :jank ljb/merge-native-flags native-flags)]
+  (let [[project args] (apply-args project args)
+        cp-str         (ljc/build-module-path project)
+        native-flags   (ljb/run-build! (ljb/plan-build project))
+        project        (update project :jank ljb/merge-native-flags native-flags)]
     (ljc/shell-out! project cp-str "compile-module" [] args)))
 
 (defn check-health!

--- a/lein-jank/src/leiningen/jank/build.clj
+++ b/lein-jank/src/leiningen/jank/build.clj
@@ -14,6 +14,7 @@
 
 (def jank-build-file "jank-build.bb")
 (def jank-build-cache-file "jank-build-cache.txt")
+(def jank-tmp-build-dir "/tmp/jank-build")
 
 (def default-build-opts
   {:output-dir         "target"
@@ -106,15 +107,15 @@
   [src-dir out-dir subtree-meta]
   (fs/create-dirs out-dir)
   (let [build-meta   (merge subtree-meta {:src-dir   (str src-dir)
-                                          :build-dir "/tmp"
+                                          :build-dir jank-tmp-build-dir
                                           :out-dir   (str out-dir)})
         ;; The sandbox gets standard mounts for a scratch directory and build
         ;; output directory. It also mounts as RO each build output from its
         ;; dependencies.
         sandbox-args (into [[:ro-bind src-dir src-dir]
                             [:bind out-dir out-dir]
-                            [:tmpfs "/tmp"]
-                            [:chdir src-dir]
+                            [:tmpfs jank-tmp-build-dir]
+                            [:chdir jank-tmp-build-dir]
                             [:net false]]
                            (map (fn [dir] [:ro-bind dir dir]) (vals (:outputs subtree-meta))))
         ;; Pass `bb --stream` and provide the EDN-formatted build metadata on

--- a/lein-jank/src/leiningen/jank/build.clj
+++ b/lein-jank/src/leiningen/jank/build.clj
@@ -12,6 +12,13 @@
 (def jank-build-file "jank-build.bb")
 (def jank-build-cache-file "jank-build-cache.txt")
 
+(def default-build-opts
+  {:output-dir         "target"
+   :disable-sandbox    false
+   :optimization-level 2
+   :static-build       true
+   :verbose-build      true})
+
 (defn merge-native-flags [& maps]
   (let [valid-keys [:defines :include-dirs :library-dirs :linked-libraries]]
     (reduce (fn [a b] (merge-with into a (select-keys b valid-keys))) maps)))
@@ -108,6 +115,7 @@
         ;; Pass `bb --stream` and provide the EDN-formatted build metadata on
         ;; stdin so that it is available in the build script on `*input*`.
         proc         (sandbox/process
+                      (not (:disable-sandbox subtree-meta))
                       sandbox-args
                       ["bb" "--stream" (fs/path src-dir jank-build-file)]
                       {:in       (pr-str build-meta)
@@ -146,8 +154,8 @@
              plan-ops)
        (into {})))
 
-(defn plan-subtree-build [project target-dir [dep subtree]]
-  (let [subtree-ops    (vec (mapcat #(plan-subtree-build project target-dir %) subtree))
+(defn plan-subtree-build [build-opts target-dir [dep subtree]]
+  (let [subtree-ops    (vec (mapcat #(plan-subtree-build build-opts target-dir %) subtree))
         src-jar        (first (aether/dependency-files {dep nil}))
         jar-name       (-> src-jar fs/file-name fs/strip-ext)
         src-dir        (get-target-dir target-dir "src" jar-name (sha256sum src-jar))
@@ -164,11 +172,12 @@
       ;; If this is a native build then we must add its build step and all of
       ;; the child build steps.
       (into subtree-ops
-            [{:op :extract-src
+            [{:op  :extract-src
               :dep dep :jar src-jar :dir src-dir}
-             {:op :run-build
-              :dep dep :src-dir src-dir :out-dir out-dir
-              :child-outs (collect-outputs subtree-ops)}]))))
+             {:op              :run-build
+              :dep             dep :src-dir src-dir :out-dir out-dir
+              :disable-sandbox (:disable-sandbox build-opts)
+              :child-outs      (collect-outputs subtree-ops)}]))))
 
 (defn plan-build
   "Compute a build plan, i.e. a linear sequence of operations, which will
@@ -177,37 +186,30 @@
   Returns a map, including the build operations and additional build metadata,
   which can be executed by `run-build!`."
   [project]
-  (let [{:keys [output-dir optimization-level static-build verbose-build]
-         :or   {output-dir         "target"
-                optimization-level 2
-                static-build       true
-                verbose-build      true}}
-        (:jank project)]
-    {:target-dir         (fs/absolutize output-dir)
-     :optimization-level optimization-level
-     :static-build       static-build
-     :verbose-build      verbose-build
-     :operations         (let [tree     (lcp/managed-dependency-hierarchy :dependencies :managed-dependencies project)
-                               dep-ops  (vec (mapcat #(plan-subtree-build project output-dir %) tree))
-                               ;; Special handling when the root project has a
-                               ;; build script.
-                               ;; 
-                               ;; TODO: For now we always run the root build
-                               ;; script, but we could cache it if we knew its
-                               ;; input files. Cargo does this by outputting
-                               ;; rerun-if-changed flags from the build script.
-                               root-ops (when (fs/exists? (fs/path (:root project) jank-build-file))
-                                          [{:op           :run-build
-                                            :dep          [(:name project) (:version project)]
-                                            :src-dir      (:root project)
-                                            :out-dir      (get-target-dir output-dir "out" (:name project) "XXX")
-                                            :child-outs   (collect-outputs dep-ops)
-                                            :always-build true}])]
-                           (into dep-ops root-ops))}))
+  (let [{:keys [output-dir disable-sandbox] :as build-opts}
+        (merge default-build-opts (:jank project))]
+    (assoc build-opts :operations
+           (let [tree     (lcp/managed-dependency-hierarchy :dependencies :managed-dependencies project)
+                 dep-ops  (vec (mapcat #(plan-subtree-build build-opts output-dir %) tree))
+                 ;; Special handling when the root project has a build script.
+                 ;; 
+                 ;; TODO: For now we always run the root build script, but we
+                 ;; could cache it if we knew its input files. Cargo does this
+                 ;; by outputting rerun-if-changed flags from the build script.
+                 root-ops (when (fs/exists? (fs/path (:root project) jank-build-file))
+                            [{:op              :run-build
+                              :dep             [(:name project) (:version project)]
+                              :src-dir         (:root project)
+                              :out-dir         (get-target-dir output-dir "out" (:name project) "XXX")
+                              :child-outs      (collect-outputs dep-ops)
+                              :disable-sandbox disable-sandbox
+                              :always-build    true}])]
+             (into dep-ops root-ops)))))
 
 (defmulti run-build-op! (fn [_ op] (:op op)))
 
-(defmethod run-build-op! :extract-src [plan {:keys [dep jar dir]}]
+(defmethod run-build-op! :extract-src
+  [plan {:keys [dep jar dir]}]
   ;; If the output dir already exists then the jar has already been extracted.
   (when-not (fs/exists? dir)
     (println "\u001b[1;36mExtracting\u001b[0m" dep)
@@ -216,7 +218,8 @@
   ;; does not produce any jank flags
   nil)
 
-(defmethod run-build-op! :run-build [plan {:keys [dep src-dir out-dir child-outs always-build]}]
+(defmethod run-build-op! :run-build
+  [plan {:keys [dep src-dir out-dir child-outs disable-sandbox always-build]}]
   (let [needs-build? (or always-build (not (fs/exists? (fs/path out-dir jank-build-cache-file))))]
     (when needs-build?
       (println "\u001b[1;32mCompiling\u001b[0m" dep)
@@ -228,6 +231,8 @@
 (defn run-build!
   "Run the sequence of build steps planned by `plan-build`."
   [plan]
+  (when (some :disable-sandbox (:operations plan))
+    (println "\u001b[1;31mBuilding with sandboxing disabled is potentially dangerous!\u001b[0m"))
   (->> (mapv #(run-build-op! plan %) (:operations plan))
        (flatten)
        (apply merge-native-flags)))

--- a/lein-jank/src/leiningen/jank/build.clj
+++ b/lein-jank/src/leiningen/jank/build.clj
@@ -1,0 +1,233 @@
+(ns leiningen.jank.build
+  (:require [cemerick.pomegranate.aether :as aether]
+            [clojure.string :as string]
+            [clojure.java.io :as io]
+            [leiningen.core.main :as lmain]
+            [leiningen.core.classpath :as lcp]
+            [leiningen.jank.sandbox.core :as sandbox]
+            [babashka.fs :as fs]
+            [babashka.process :as proc])
+  (:import (java.util.jar JarFile)))
+
+(def jank-build-file "jank-build.bb")
+(def jank-build-cache-file "jank-build-cache.txt")
+
+(defn merge-native-flags [& maps]
+  (let [valid-keys [:defines :include-dirs :library-dirs :linked-libraries]]
+    (reduce (fn [a b] (merge-with into a (select-keys b valid-keys))) maps)))
+
+(defn has-build-file?
+  "Returns true if the given jar file has a `jank-build.bb` file in the root."
+  [jar]
+  (with-open [jar (JarFile. jar)]
+    (some? (.getEntry jar jank-build-file))))
+
+(defn extract-jar!
+  "Extract the jar file into `out-dir`, creating it if it does not exist."
+  [file out-dir]
+  (fs/create-dirs out-dir)
+  (fs/unzip file out-dir {:replace-existing true}))
+
+(defn sha256sum [f]
+  (-> (proc/sh ["sha256sum" f]) :out (subs 0 64)))
+
+(defn fingerprint
+  "Compute a fingerprint of the dependency. When the fingerprint changes (due to
+  some change in the descendant dependencies or environment) the dependency
+  needs to be recompiled."
+  [src-jar subtree-meta]
+  ;; TODO: We should implement something like Cargo's fingerprint to better
+  ;; react to changes in the environment:
+  ;; 
+  ;; https://doc.rust-lang.org/nightly/nightly-rustc/cargo/core/compiler/fingerprint/index.html
+  (hash [(sha256sum src-jar) subtree-meta]))
+
+(defn indent [depth]
+  (apply str (repeat (* 2 depth) " ")))
+
+(defn get-target-dir
+  "Returns a path located in the target directory which is unique based on the
+  `type`, the dependency's name, and the dependency's fingerprint."
+  [base-dir type dep-name fprint]
+  (-> base-dir
+      (fs/path (str dep-name "-" type "-" fprint))
+      (fs/absolutize)))
+
+(defn process-build-directives [lines]
+  (->>
+   (for [line  lines
+         :when (and (string/starts-with? line "jank-build::")
+                    (string/includes? line "="))
+         :let  [[k v] (string/split line #"=" 2)]]
+     (case k
+       "jank-build::include-path" {:include-dirs [v]}
+       "jank-build::link-path"    {:library-dirs [v]}
+       "jank-build::link-lib"     {:linked-libraries [v]}
+       (do (lmain/warn "invalid jank-build directive:" k)
+           nil)))
+   (remove nil?)))
+
+(defn wrap-stream
+  "Wrap an IO stream, redirecting the output to stdout with a prefix. Returns a
+  vector of the recorded lines (without the prefix)."
+  [stream {:keys [prefix depth echo]}]
+  (with-open [rdr (io/reader stream)]
+    (doall
+     (for [line (line-seq rdr)]
+       (do
+         (when echo (println (str (indent depth) prefix " " line)))
+         line)))))
+
+(defn build-dep!
+  "Run a sandboxed build on the dependency located at `src-dir`, and instruct
+  the build script to place artifacts in the `out-dir`.
+
+  The `src-dir` is expected to contain a `jank-build.bb` file. This file is run
+  in the sandbox by `bb --stream jank-build.bb`, and is passed the build
+  metadata as EDN on stdin (automatically bound to *input* in the script).
+
+  The script is expected to output `jank-build::` directives, and any arbitrary
+  build output will be ignored.
+
+  The result will be a cached build result file located at
+  `out-dir/jank-build-cache.txt` plus the artifacts of the build in `out-dir`."
+  [src-dir out-dir subtree-meta]
+  (fs/create-dirs out-dir)
+  (let [build-meta   (merge subtree-meta {:src-dir   (str src-dir)
+                                          :build-dir "/tmp"
+                                          :out-dir   (str out-dir)})
+        ;; The sandbox gets standard mounts for a scratch directory and build
+        ;; output directory. It also mounts as RO each build output from its
+        ;; dependencies.
+        sandbox-args (into [[:ro-bind src-dir src-dir]
+                            [:bind out-dir out-dir]
+                            [:tmpfs "/tmp"]
+                            [:chdir src-dir]
+                            [:net false]]
+                           (map (fn [dir] [:ro-bind dir dir]) (vals (:outputs subtree-meta))))
+        ;; Pass `bb --stream` and provide the EDN-formatted build metadata on
+        ;; stdin so that it is available in the build script on `*input*`.
+        proc         (sandbox/process
+                      sandbox-args
+                      ["bb" "--stream" (fs/path src-dir jank-build-file)]
+                      {:in       (pr-str build-meta)
+                       :continue true})
+        stdout-lines (future (wrap-stream (:out proc)
+                                          {:depth  1
+                                           :echo   (:verbose-build subtree-meta)
+                                           :prefix "\u001b[0;34mjank-build>\u001b[0m"}))
+        stderr-lines (future (wrap-stream (:err proc)
+                                          {:depth  1
+                                           :echo   (:verbose-build subtree-meta)
+                                           :prefix "\u001b[0;31mjank-build>\u001b[0m"}))
+        result       @proc]
+    (if (zero? (:exit result))
+      (fs/write-lines (fs/path out-dir jank-build-cache-file) @stdout-lines)
+      ;; NOTE: jank-build-cache-file will not be generated, so the build cannot
+      ;; proceed.
+      (do
+        ;; Echo stdout/stderr on build failure, only when it was not echoed
+        ;; above.
+        ;; 
+        ;; TODO: This will show all stderr output after all stdout output,
+        ;; instead of interleaving as they were originally printed.
+        (when-not (:verbose-build subtree-meta)
+          (println (string/join "\n" @stdout-lines))
+          (println (string/join "\n" @stderr-lines)))
+        (lmain/abort "failed to run build command")))))
+
+(defn collect-outputs
+  "Collect the output directories from all build steps in the given operations
+  list."
+  [plan-ops]
+  (->> (keep (fn [op] (when (:out-dir op)
+                        [(-> (:dep op) first str)
+                         (str (:out-dir op))]))
+             plan-ops)
+       (into {})))
+
+(defn plan-subtree-build [project target-dir [dep subtree]]
+  (let [subtree-ops    (vec (mapcat #(plan-subtree-build project target-dir %) subtree))
+        src-jar        (first (aether/dependency-files {dep nil}))
+        jar-name       (-> src-jar fs/file-name fs/strip-ext)
+        src-dir        (get-target-dir target-dir "src" jar-name (sha256sum src-jar))
+        ;; Output is fingerprinted on the source jar contents and all of the
+        ;; build steps which produce its descendant outputs. If any of these
+        ;; change then a fresh build is triggered.
+        fprint         (fingerprint src-jar subtree-ops)
+        out-dir        (get-target-dir target-dir "out" jar-name fprint)
+        is-native-dep? (has-build-file? src-jar)]
+    (if-not is-native-dep?
+      ;; If this is a plain jank jar then no build step is required, but it
+      ;; still may have native dependencies in the subtree.
+      subtree-ops
+      ;; If this is a native build then we must add its build step and all of
+      ;; the child build steps.
+      (into subtree-ops
+            [{:op :extract-src
+              :dep dep :jar src-jar :dir src-dir}
+             {:op :run-build
+              :dep dep :src-dir src-dir :out-dir out-dir
+              :child-outs (collect-outputs subtree-ops)}]))))
+
+(defn plan-build
+  "Compute a build plan, i.e. a linear sequence of operations, which will
+  produce the final native build artifacts required by this project.
+
+  Returns a map, including the build operations and additional build metadata,
+  which can be executed by `run-build!`."
+  [project]
+  (let [{:keys [output-dir optimization-level static-build verbose-build]
+         :or   {output-dir         "target"
+                optimization-level 2
+                static-build       true
+                verbose-build      true}}
+        (:jank project)]
+    {:target-dir         (fs/absolutize output-dir)
+     :optimization-level optimization-level
+     :static-build       static-build
+     :verbose-build      verbose-build
+     :operations         (let [tree     (lcp/managed-dependency-hierarchy :dependencies :managed-dependencies project)
+                               dep-ops  (vec (mapcat #(plan-subtree-build project output-dir %) tree))
+                               ;; Special handling when the root project has a
+                               ;; build script.
+                               ;; 
+                               ;; TODO: For now we always run the root build
+                               ;; script, but we could cache it if we knew its
+                               ;; input files. Cargo does this by outputting
+                               ;; rerun-if-changed flags from the build script.
+                               root-ops (when (fs/exists? (fs/path (:root project) jank-build-file))
+                                          [{:op           :run-build
+                                            :dep          [(:name project) (:version project)]
+                                            :src-dir      (:root project)
+                                            :out-dir      (get-target-dir output-dir "out" (:name project) "XXX")
+                                            :child-outs   (collect-outputs dep-ops)
+                                            :always-build true}])]
+                           (into dep-ops root-ops))}))
+
+(defmulti run-build-op! (fn [_ op] (:op op)))
+
+(defmethod run-build-op! :extract-src [plan {:keys [dep jar dir]}]
+  ;; If the output dir already exists then the jar has already been extracted.
+  (when-not (fs/exists? dir)
+    (println "\u001b[1;36mExtracting\u001b[0m" dep)
+    (extract-jar! jar dir))
+
+  ;; does not produce any jank flags
+  nil)
+
+(defmethod run-build-op! :run-build [plan {:keys [dep src-dir out-dir child-outs always-build]}]
+  (let [needs-build? (or always-build (not (fs/exists? (fs/path out-dir jank-build-cache-file))))]
+    (when needs-build?
+      (println "\u001b[1;32mCompiling\u001b[0m" dep)
+      (build-dep! src-dir out-dir (assoc plan :outputs child-outs)))
+
+    ;; jank flags are extracted from the build cache file
+    (process-build-directives (fs/read-all-lines (fs/path out-dir jank-build-cache-file)))))
+
+(defn run-build!
+  "Run the sequence of build steps planned by `plan-build`."
+  [plan]
+  (->> (mapv #(run-build-op! plan %) (:operations plan))
+       (flatten)
+       (apply merge-native-flags)))

--- a/lein-jank/src/leiningen/jank/build.clj
+++ b/lein-jank/src/leiningen/jank/build.clj
@@ -7,9 +7,10 @@
             [leiningen.core.main :as lmain]
             [leiningen.core.classpath :as lcp]
             [leiningen.jank.sandbox.core :as sandbox])
-  (:import (java.util HexFormat)
-           (java.util.jar JarFile)
-           (java.security MessageDigest)))
+  (:import (java.nio ByteBuffer)
+           (java.security MessageDigest)
+           (java.util HexFormat)
+           (java.util.jar JarFile)))
 
 (def jank-build-file "jank-build.bb")
 (def jank-build-cache-file "jank-build-cache.txt")
@@ -36,24 +37,21 @@
   [file out-dir]
   (fs/unzip file out-dir {:replace-existing true}))
 
-(defn sha256sum
-  "Equivalent to the standard coreutils/sha256sum tool."
-  [f]
-  (let [bytes (fs/read-all-bytes f)
-        hash  (-> (MessageDigest/getInstance "SHA-256")
-                  (.digest bytes))]
-    (.formatHex (HexFormat/of) hash)))
-
 (defn fingerprint
   "Compute a fingerprint of the dependency. When the fingerprint changes (due to
   some change in the descendant dependencies or environment) the dependency
   needs to be recompiled."
-  [src-jar subtree-meta]
+  [src-jar meta]
   ;; TODO: We should implement something like Cargo's fingerprint to better
   ;; react to changes in the environment:
   ;; 
   ;; https://doc.rust-lang.org/nightly/nightly-rustc/cargo/core/compiler/fingerprint/index.html
-  (hash [(sha256sum src-jar) subtree-meta]))
+  (let [md     (MessageDigest/getInstance "SHA-256")
+        _      (doto md
+                 (.update (fs/read-all-bytes src-jar))
+                 (.update (-> (ByteBuffer/allocate 4) (.putInt (hash meta)) .array)))
+        digest (.digest md)]
+    (.formatHex (HexFormat/of) digest)))
 
 (defn target-subdir
   "Returns a path located in the target directory which is unique based on the
@@ -159,12 +157,13 @@
   (let [subtree-ops    (vec (mapcat #(plan-subtree-build build-opts target-dir %) subtree))
         src-jar        (first (aether/dependency-files {dep nil}))
         jar-name       (-> src-jar fs/file-name fs/strip-ext)
-        src-dir        (target-subdir target-dir "src" jar-name (sha256sum src-jar))
+        src-fprint     (fingerprint src-jar {})
+        src-dir        (target-subdir target-dir "src" jar-name src-fprint)
         ;; Output is fingerprinted on the source jar contents and all of the
         ;; build steps which produce its descendant outputs. If any of these
         ;; change then a fresh build is triggered.
-        fprint         (fingerprint src-jar subtree-ops)
-        out-dir        (target-subdir target-dir "out" jar-name fprint)
+        out-fprint     (fingerprint src-jar subtree-ops)
+        out-dir        (target-subdir target-dir "out" jar-name out-fprint)
         is-native-dep? (has-build-file? src-jar)]
     (if-not is-native-dep?
       ;; If this is a plain jank jar then no build step is required, but it

--- a/lein-jank/src/leiningen/jank/build.clj
+++ b/lein-jank/src/leiningen/jank/build.clj
@@ -217,7 +217,7 @@
   [plan {:keys [dep jar dir]}]
   ;; If the output dir already exists then the jar has already been extracted.
   (when-not (fs/exists? dir)
-    (println "\u001b[1;36mExtracting\u001b[0m" dep)
+    (println (str "\u001b[1;36m" (format "%10s" "Extracting") "\u001b[0m") dep)
     (extract-jar! jar dir))
 
   ;; does not produce any jank flags
@@ -227,7 +227,7 @@
   [plan {:keys [dep src-dir out-dir child-outs always-build]}]
   (let [needs-build? (or always-build (not (fs/exists? (fs/path out-dir jank-build-cache-file))))]
     (when needs-build?
-      (println "\u001b[1;32mCompiling\u001b[0m" dep)
+      (println (str "\u001b[1;32m" (format "%10s" "Compiling") "\u001b[0m") dep)
       (build-dep! src-dir out-dir (assoc plan :outputs child-outs)))
 
     ;; jank flags are extracted from the build cache file

--- a/lein-jank/src/leiningen/jank/build.clj
+++ b/lein-jank/src/leiningen/jank/build.clj
@@ -1,13 +1,15 @@
 (ns leiningen.jank.build
-  (:require [cemerick.pomegranate.aether :as aether]
-            [clojure.string :as string]
+  "Tools for building jank libraries which include native code."
+  (:require [clojure.string :as string]
             [clojure.java.io :as io]
+            [babashka.fs :as fs]
+            [cemerick.pomegranate.aether :as aether]
             [leiningen.core.main :as lmain]
             [leiningen.core.classpath :as lcp]
-            [leiningen.jank.sandbox.core :as sandbox]
-            [babashka.fs :as fs]
-            [babashka.process :as proc])
-  (:import (java.util.jar JarFile)))
+            [leiningen.jank.sandbox.core :as sandbox])
+  (:import (java.util HexFormat)
+           (java.util.jar JarFile)
+           (java.security MessageDigest)))
 
 (def jank-build-file "jank-build.bb")
 (def jank-build-cache-file "jank-build-cache.txt")
@@ -32,11 +34,15 @@
 (defn extract-jar!
   "Extract the jar file into `out-dir`, creating it if it does not exist."
   [file out-dir]
-  (fs/create-dirs out-dir)
   (fs/unzip file out-dir {:replace-existing true}))
 
-(defn sha256sum [f]
-  (-> (proc/sh ["sha256sum" f]) :out (subs 0 64)))
+(defn sha256sum
+  "Equivalent to the standard coreutils/sha256sum tool."
+  [f]
+  (let [bytes (fs/read-all-bytes f)
+        hash  (-> (MessageDigest/getInstance "SHA-256")
+                  (.digest bytes))]
+    (.formatHex (HexFormat/of) hash)))
 
 (defn fingerprint
   "Compute a fingerprint of the dependency. When the fingerprint changes (due to
@@ -49,10 +55,7 @@
   ;; https://doc.rust-lang.org/nightly/nightly-rustc/cargo/core/compiler/fingerprint/index.html
   (hash [(sha256sum src-jar) subtree-meta]))
 
-(defn indent [depth]
-  (apply str (repeat (* 2 depth) " ")))
-
-(defn get-target-dir
+(defn target-subdir
   "Returns a path located in the target directory which is unique based on the
   `type`, the dependency's name, and the dependency's fingerprint."
   [base-dir type dep-name fprint]
@@ -60,7 +63,10 @@
       (fs/path (str dep-name "-" type "-" fprint))
       (fs/absolutize)))
 
-(defn process-build-directives [lines]
+(defn process-build-directives
+  "Process a sequence of output lines from a build script, parsing those that
+  begin with the jank-build:: prefix and discarding all others."
+  [lines]
   (->>
    (for [line  lines
          :when (and (string/starts-with? line "jank-build::")
@@ -77,23 +83,24 @@
 (defn wrap-stream
   "Wrap an IO stream, redirecting the output to stdout with a prefix. Returns a
   vector of the recorded lines (without the prefix)."
-  [stream {:keys [prefix depth echo]}]
+  [stream lines-atom {:keys [prefix echo]}]
   (with-open [rdr (io/reader stream)]
     (doall
      (for [line (line-seq rdr)]
        (do
-         (when echo (println (str (indent depth) prefix " " line)))
-         line)))))
+         (when echo (println (str prefix " " line)))
+         (swap! lines-atom conj line))))))
 
 (defn build-dep!
-  "Run a sandboxed build on the dependency located at `src-dir`, and instruct
-  the build script to place artifacts in the `out-dir`.
+  "Run a sandboxed (unless :disable-sandbox is set in subtree-meta) build on the
+  dependency located at `src-dir`, and instruct the build script to place
+  artifacts in the `out-dir`.
 
   The `src-dir` is expected to contain a `jank-build.bb` file. This file is run
   in the sandbox by `bb --stream jank-build.bb`, and is passed the build
   metadata as EDN on stdin (automatically bound to *input* in the script).
 
-  The script is expected to output `jank-build::` directives, and any arbitrary
+  The script is expected to output `jank-build::` directives, and any other
   build output will be ignored.
 
   The result will be a cached build result file located at
@@ -120,64 +127,61 @@
                       ["bb" "--stream" (fs/path src-dir jank-build-file)]
                       {:in       (pr-str build-meta)
                        :continue true})
-        stdout-lines (future (wrap-stream (:out proc)
-                                          {:depth  1
-                                           :echo   (:verbose-build subtree-meta)
-                                           :prefix "\u001b[0;34mjank-build>\u001b[0m"}))
-        stderr-lines (future (wrap-stream (:err proc)
-                                          {:depth  1
-                                           :echo   (:verbose-build subtree-meta)
-                                           :prefix "\u001b[0;31mjank-build>\u001b[0m"}))
-        result       @proc]
-    (if (zero? (:exit result))
-      (fs/write-lines (fs/path out-dir jank-build-cache-file) @stdout-lines)
-      ;; NOTE: jank-build-cache-file will not be generated, so the build cannot
-      ;; proceed.
+        out-lines    (atom [])]
+    (future (wrap-stream (:out proc) out-lines {:echo   (:verbose-build subtree-meta)
+                                                :prefix "  \u001b[0;34mjank-build>\u001b[0m"}))
+    (future (wrap-stream (:err proc) out-lines {:echo   (:verbose-build subtree-meta)
+                                                :prefix "  \u001b[0;31mjank-build>\u001b[0m"}))
+    (if (zero? (:exit @proc))
+      ;; Build succeeded. Cache all of the build stdout output. Later we will
+      ;; parse the build directives.
+      (fs/write-lines (fs/path out-dir jank-build-cache-file) @out-lines)
+      ;; Build failed. Echo stdout/stderr on build failure, only when it was not
+      ;; already live-echoed above. Abort the build.
       (do
-        ;; Echo stdout/stderr on build failure, only when it was not echoed
-        ;; above.
-        ;; 
-        ;; TODO: This will show all stderr output after all stdout output,
-        ;; instead of interleaving as they were originally printed.
         (when-not (:verbose-build subtree-meta)
-          (println (string/join "\n" @stdout-lines))
-          (println (string/join "\n" @stderr-lines)))
+          (println (string/join "\n" @out-lines))
+          (println (string/join "\n" @out-lines)))
         (lmain/abort "failed to run build command")))))
 
-(defn collect-outputs
+(defn collect-out-dirs
   "Collect the output directories from all build steps in the given operations
   list."
   [plan-ops]
-  (->> (keep (fn [op] (when (:out-dir op)
-                        [(-> (:dep op) first str)
-                         (str (:out-dir op))]))
-             plan-ops)
-       (into {})))
+  (letfn [(simple-dep-name [coord] (-> coord first str))]
+    (->> plan-ops
+         (keep (fn [op] (when (:out-dir op)
+                          [(simple-dep-name (:dep op))
+                           (str (:out-dir op))])))
+         (into {}))))
 
 (defn plan-subtree-build [build-opts target-dir [dep subtree]]
   (let [subtree-ops    (vec (mapcat #(plan-subtree-build build-opts target-dir %) subtree))
         src-jar        (first (aether/dependency-files {dep nil}))
         jar-name       (-> src-jar fs/file-name fs/strip-ext)
-        src-dir        (get-target-dir target-dir "src" jar-name (sha256sum src-jar))
+        src-dir        (target-subdir target-dir "src" jar-name (sha256sum src-jar))
         ;; Output is fingerprinted on the source jar contents and all of the
         ;; build steps which produce its descendant outputs. If any of these
         ;; change then a fresh build is triggered.
         fprint         (fingerprint src-jar subtree-ops)
-        out-dir        (get-target-dir target-dir "out" jar-name fprint)
+        out-dir        (target-subdir target-dir "out" jar-name fprint)
         is-native-dep? (has-build-file? src-jar)]
     (if-not is-native-dep?
       ;; If this is a plain jank jar then no build step is required, but it
       ;; still may have native dependencies in the subtree.
       subtree-ops
       ;; If this is a native build then we must add its build step and all of
-      ;; the child build steps.
+      ;; the its descendant build steps.
       (into subtree-ops
             [{:op  :extract-src
-              :dep dep :jar src-jar :dir src-dir}
-             {:op              :run-build
-              :dep             dep :src-dir src-dir :out-dir out-dir
-              :disable-sandbox (:disable-sandbox build-opts)
-              :child-outs      (collect-outputs subtree-ops)}]))))
+              :dep dep
+              :jar src-jar
+              :dir src-dir}
+             {:op         :run-build
+              :dep        dep
+              :src-dir    src-dir
+              :out-dir    out-dir
+              :child-outs (collect-out-dirs subtree-ops)}]))))
 
 (defn plan-build
   "Compute a build plan, i.e. a linear sequence of operations, which will
@@ -186,8 +190,10 @@
   Returns a map, including the build operations and additional build metadata,
   which can be executed by `run-build!`."
   [project]
-  (let [{:keys [output-dir disable-sandbox] :as build-opts}
-        (merge default-build-opts (:jank project))]
+  (let [{:keys [output-dir] :as build-opts} (merge default-build-opts (:jank project))]
+    (when (:disable-sandbox build-opts)
+      (println "\u001b[1;31mBuilding with sandboxing disabled is potentially dangerous!\u001b[0m"))
+
     (assoc build-opts :operations
            (let [tree     (lcp/managed-dependency-hierarchy :dependencies :managed-dependencies project)
                  dep-ops  (vec (mapcat #(plan-subtree-build build-opts output-dir %) tree))
@@ -197,13 +203,12 @@
                  ;; could cache it if we knew its input files. Cargo does this
                  ;; by outputting rerun-if-changed flags from the build script.
                  root-ops (when (fs/exists? (fs/path (:root project) jank-build-file))
-                            [{:op              :run-build
-                              :dep             [(:name project) (:version project)]
-                              :src-dir         (:root project)
-                              :out-dir         (get-target-dir output-dir "out" (:name project) "XXX")
-                              :child-outs      (collect-outputs dep-ops)
-                              :disable-sandbox disable-sandbox
-                              :always-build    true}])]
+                            [{:op           :run-build
+                              :dep          [(:name project) (:version project)]
+                              :src-dir      (:root project)
+                              :out-dir      (target-subdir output-dir "out" (:name project) "XXX")
+                              :child-outs   (collect-out-dirs dep-ops)
+                              :always-build true}])]
              (into dep-ops root-ops)))))
 
 (defmulti run-build-op! (fn [_ op] (:op op)))
@@ -219,7 +224,7 @@
   nil)
 
 (defmethod run-build-op! :run-build
-  [plan {:keys [dep src-dir out-dir child-outs disable-sandbox always-build]}]
+  [plan {:keys [dep src-dir out-dir child-outs always-build]}]
   (let [needs-build? (or always-build (not (fs/exists? (fs/path out-dir jank-build-cache-file))))]
     (when needs-build?
       (println "\u001b[1;32mCompiling\u001b[0m" dep)
@@ -231,8 +236,6 @@
 (defn run-build!
   "Run the sequence of build steps planned by `plan-build`."
   [plan]
-  (when (some :disable-sandbox (:operations plan))
-    (println "\u001b[1;31mBuilding with sandboxing disabled is potentially dangerous!\u001b[0m"))
   (->> (mapv #(run-build-op! plan %) (:operations plan))
        (flatten)
        (apply merge-native-flags)))

--- a/lein-jank/src/leiningen/jank/core.clj
+++ b/lein-jank/src/leiningen/jank/core.clj
@@ -50,6 +50,9 @@
     :linked-libraries
     (map (fn [v] (str "-l" v)) value)
 
+    :disable-sandbox
+    [] ;; ignore, used in build process
+
     (lmain/warn (str "Unknown flag " flag))))
 
 (defn build-declarative-flags [project]

--- a/lein-jank/src/leiningen/jank/core.clj
+++ b/lein-jank/src/leiningen/jank/core.clj
@@ -14,10 +14,17 @@
        lcp/get-classpath
        (string/join File/pathSeparatorChar)))
 
-(defn build-declarative-flag [flag value]
+(defn build-declarative-flag [project-name flag value]
   (case flag
+    ;; When a user specifies an :output-dir in the project.clj, this is the
+    ;; output for all artifacts. All dependency sources and builds will go into
+    ;; subdirectories in :output-dir.
+    ;;
+    ;; To prevent jank from placing artifacts for _this_ project in the
+    ;; top-level output-dir and potentially trampling files from dependencies,
+    ;; we pass it an output directory suffixed by the project name.
     :output-dir
-    ["--output-dir" value]
+    ["--output-dir" (fs/path value project-name)]
 
     :direct-call
     (if value
@@ -47,7 +54,7 @@
 
 (defn build-declarative-flags [project]
   (flatten (map (fn [[flag value]]
-                  (build-declarative-flag flag value))
+                  (build-declarative-flag (:name project) flag value))
                 (:jank project))))
 
 (defn shell-out! [project classpath command compiler-args runtime-args]

--- a/lein-jank/src/leiningen/jank/sandbox/bwrap.clj
+++ b/lein-jank/src/leiningen/jank/sandbox/bwrap.clj
@@ -1,6 +1,6 @@
 (ns leiningen.jank.sandbox.bwrap
-  (:require [babashka.process :as proc]
-            [babashka.fs :as fs]))
+  (:require [babashka.fs :as fs]
+            [babashka.process :as proc]))
 
 ;; TODO: consider the merits of an allowlist vs. denylist of mounts. Per the
 ;; bwrap documentation, we definitely want to avoid mounting /var which may
@@ -27,12 +27,17 @@
   []
   (fs/which "bwrap"))
 
-(defn bind-valid? [src dst]
-  (fs/exists? src))
-
 (defn bwrap
+  "Build a `bwrap` command with the given options, returning the command.
+
+  Valid options are:
+    - [:ro-bind src dst]
+    - [:bind src dst]
+    - [:tmpfs dir]
+    - [:chdir dir]
+    - [:net enabled?]"
   [cmds]
-  (concat
+  (->>
    ["bwrap"
     ;; Without this bwrap processes could outlive this process which spawned it.
     "--die-with-parent"
@@ -41,18 +46,18 @@
     "--new-session"
     ;; Start with a clean slate and add namespaces back via '--share-*'
     ;; commands.
-    "--unshare-all"]
-   (->> (for [[k & rst] cmds]
-          (case k
-            :ro-bind (let [[src dst] rst] (when (bind-valid? src dst) ["--ro-bind" src dst]))
-            :bind    (let [[src dst] rst] (when (bind-valid? src dst) ["--bind" src dst]))
-            :tmpfs   (let [dir rst] ["--tmpfs" dir])
-            :chdir   (let [dir rst] ["--chdir" dir])
-            :net     (let [share rst] (when share ["--share-net"]))))
-        (flatten)
-        (remove nil?))
-   ["--proc" "/proc"
-    "--dev" "/dev"]))
+    "--unshare-all"
+    "--proc" "/proc"
+    "--dev" "/dev"
+    (for [[k & rst] cmds]
+      (case k
+        :ro-bind (let [[src dst] rst] (when (fs/exists? src) ["--ro-bind" src dst]))
+        :bind    (let [[src dst] rst] (when (fs/exists? src) ["--bind" src dst]))
+        :tmpfs   (let [dir rst] ["--tmpfs" dir])
+        :chdir   (let [dir rst] ["--chdir" dir])
+        :net     (let [share rst] (when share ["--share-net"]))))]
+   (flatten)
+   (remove nil?)))
 
 (comment
   (bwrap

--- a/lein-jank/src/leiningen/jank/sandbox/bwrap.clj
+++ b/lein-jank/src/leiningen/jank/sandbox/bwrap.clj
@@ -1,0 +1,61 @@
+(ns leiningen.jank.sandbox.bwrap
+  (:require [babashka.process :as proc]
+            [babashka.fs :as fs]))
+
+;; TODO: consider the merits of an allowlist vs. denylist of mounts. Per the
+;; bwrap documentation, we definitely want to avoid mounting /var which may
+;; contain the Docker or dbus sockets allowing privilege escalation.
+;;
+;; An allowlist avoids this issue, but if some OS uses non-standard mount points
+;; (for example /nix is required on NixOS) then the container may not be fully
+;; functional.
+;;
+;; Is a blanket mount of / with a denylist including /var safe?
+(def standard-binds
+  "Directories which are required for typical program execution.
+
+  Some of these may not exist on all systems."
+  [[:ro-bind "/usr" "/usr"]
+   [:ro-bind "/bin" "/bin"]
+   [:ro-bind "/lib" "/lib"]
+   [:ro-bind "/lib64" "/lib64"]
+   [:ro-bind "/etc" "/etc"]
+   [:ro-bind "/nix" "/nix"]])
+
+(defn which-bwrap
+  "Find the `bwrap` executable on the path, or nil if it cannot be found."
+  []
+  (fs/which "bwrap"))
+
+(defn bind-valid? [src dst]
+  (fs/exists? src))
+
+(defn bwrap
+  [cmds]
+  (concat
+   ["bwrap"
+    ;; Without this bwrap processes could outlive this process which spawned it.
+    "--die-with-parent"
+    ;; Prevent the child process from injecting keystrokes into the parent
+    ;; terminal.
+    "--new-session"
+    ;; Start with a clean slate and add namespaces back via '--share-*'
+    ;; commands.
+    "--unshare-all"]
+   (->> (for [[k & rst] cmds]
+          (case k
+            :ro-bind (let [[src dst] rst] (when (bind-valid? src dst) ["--ro-bind" src dst]))
+            :bind    (let [[src dst] rst] (when (bind-valid? src dst) ["--bind" src dst]))
+            :tmpfs   (let [dir rst] ["--tmpfs" dir])
+            :chdir   (let [dir rst] ["--chdir" dir])
+            :net     (let [share rst] (when share ["--share-net"]))))
+        (flatten)
+        (remove nil?))
+   ["--proc" "/proc"
+    "--dev" "/dev"]))
+
+(comment
+  (bwrap
+   [[:ro-bind "/src" "/dest"]
+    [:tmpfs "/tmp"]
+    [:net true]]))

--- a/lein-jank/src/leiningen/jank/sandbox/core.clj
+++ b/lein-jank/src/leiningen/jank/sandbox/core.clj
@@ -1,12 +1,28 @@
 (ns leiningen.jank.sandbox.core
   (:require [babashka.process :as proc]
-            [leiningen.jank.sandbox.bwrap :as bwrap]))
+            [leiningen.jank.sandbox.bwrap :as bwrap]
+            [leiningen.core.main :as lmain]))
 
 (defn process
   "Pass `cmd` and `sh-opts` to `babashka.process/process` running inside of a
-  sandboxed container specified by `sandbox-opts`."
-  [sandbox-opts cmd sh-opts]
+  sandboxed container specified by `sandbox-opts`.
+
+  Setting the `enable?` flag to false allows sandboxing to be skipped entirely
+  and the command will be run as a standard shell process."
+  [enable? sandbox-opts cmd sh-opts]
   ;; TODO: handle Windows and MacOS, either by a fake sandbox or using their
   ;; native constructs for containerization.
-  (let [bwrap-prefix (bwrap/bwrap (into bwrap/standard-binds sandbox-opts))]
-    (proc/process (concat bwrap-prefix cmd) sh-opts)))
+  (cond
+    (not enable?)
+    (proc/process cmd sh-opts)
+
+    (not (bwrap/which-bwrap))
+    (lmain/abort
+     (str "No 'bwrap' executable found. If bubblewrap is not available on your"
+          " platform then you can build with the lein option :disable-sandbox,"
+          " however this allows potentially nefarious build scripts free rein"
+          " over your system. Use with care!"))
+
+    :else
+    (let [bwrap-prefix (bwrap/bwrap (into bwrap/standard-binds sandbox-opts))]
+      (proc/process (concat bwrap-prefix cmd) sh-opts))))

--- a/lein-jank/src/leiningen/jank/sandbox/core.clj
+++ b/lein-jank/src/leiningen/jank/sandbox/core.clj
@@ -1,0 +1,12 @@
+(ns leiningen.jank.sandbox.core
+  (:require [babashka.process :as proc]
+            [leiningen.jank.sandbox.bwrap :as bwrap]))
+
+(defn process
+  "Pass `cmd` and `sh-opts` to `babashka.process/process` running inside of a
+  sandboxed container specified by `sandbox-opts`."
+  [sandbox-opts cmd sh-opts]
+  ;; TODO: handle Windows and MacOS, either by a fake sandbox or using their
+  ;; native constructs for containerization.
+  (let [bwrap-prefix (bwrap/bwrap (into bwrap/standard-binds sandbox-opts))]
+    (proc/process (concat bwrap-prefix cmd) sh-opts)))

--- a/lein-jank/test-project/project.clj
+++ b/lein-jank/test-project/project.clj
@@ -2,6 +2,8 @@
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :plugins [[org.jank-lang/lein-jank "0.6"]]
+  ;; include a native dependency for testing
+  :dependencies [[org.clojars.kylc/jank-glfw3 "0.1-SNAPSHOT"]]
   :main test-project.core
   :jank {;:disable-locals-clearing false
          ;:elide-meta false

--- a/lein-jank/test/leiningen/jank/test_build.clj
+++ b/lein-jank/test/leiningen/jank/test_build.clj
@@ -1,0 +1,40 @@
+(ns leiningen.jank.test-build
+  (:require [babashka.fs :as fs]
+            [leiningen.core.project :as proj]
+            [leiningen.jank.build :as sut]
+            [clojure.test :refer [deftest testing is]]))
+
+(def test-project (proj/read "test-project/project.clj"))
+
+(deftest native-flags
+  (is (= (sut/merge-native-flags {:include-dirs ["a"]}
+                                 {:include-dirs ["b"]
+                                  :library-dirs ["c"]})
+         {:include-dirs ["a" "b"]
+          :library-dirs ["c"]})))
+
+(deftest build-directives
+  (is (empty? (sut/process-build-directives [])))
+  
+  (is (empty? (sut/process-build-directives
+               ["not a build directive"
+                "also not a build directive"])))
+
+  (is (empty? (sut/process-build-directives
+               ["jank-build::an-invalid-directive=123"])))
+  
+  (is (= (sut/process-build-directives
+          ["jank-build::include-path=some-include-path"
+           "jank-build::include-path=another-include-path"
+           "some text"
+           "jank-build::link-path=a-link-path"
+           "jank-build::link-lib=a-lib"])
+         [{:include-dirs ["some-include-path"]}
+          {:include-dirs ["another-include-path"]}
+          {:library-dirs ["a-link-path"]}
+          {:linked-libraries ["a-lib"]}])))
+
+(deftest plan-build
+  (let [plan (sut/plan-build test-project)]
+    (is some? (:operations plan))
+    (is (every? #(#{:extract-src :run-build} (:op %)) (:operations plan)))))


### PR DESCRIPTION
Adds initial support to `lein-jank` for for jank projects which either include their own native build step specified by `jank-build.bb`, or have dependencies which do.

What works:
- Native jars are downloaded, extracted, build scripts are run, and relevant jank flags are included in the main executable
- If a dependency does not change, and none of its inputs change, then its output will be cached
- Build scripts are run in a jail constructed by bubblewrap on Linux
- A build script in the project root is always run

What is TODO:
- Build out standard libraries for use in build scripts to interface with CMake, pkg-config, etc.
- The build cache fingerprint should include more things like $CC/$CXX, etc. (see TODO in code)
- Wire up more of the build options to lein CLI flags like `lein --verbose-build run` (is this possible in lein?)
- Wire up more project.clj flags to the build metadata (like `:static-build`)
- Will not work on non-Linux platforms due to bubblewrap, will need to add a `--disable-sandbox` option, eventually add Mac support with seatbelt
- Eventually, needs a book chapter on how to write build scripts

To test, first `lein install` in this checkout of `lein-jank`. Then check out https://github.com/kylc/lein-jank-playground and do a `lein run` inside `json-formatter`. You will need a C++ build toolchain, CMake, and glfw3 (at least). This repo shows off some different build scripts, and a hierarchy of native dependencies in `jank-json-sys` -> `jank-json` -> `json-formatter`.

Implements most of https://github.com/jank-lang/jank/issues/566