### PR TITLE
Support build-time dependencies for jank-build.bb scripts.

### DIFF
--- a/.github/workflows/test-lein-jank.yml
+++ b/.github/workflows/test-lein-jank.yml
@@ -1,0 +1,53 @@
+name: Test lein-jank
+
+on:
+  pull_request:
+    paths:
+      - 'lein-jank/**'
+  push:
+    branches:
+      - main
+    paths:
+      - 'lein-jank/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Only allow one build per branch at a time. New builds will cancel existing builds.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Ubuntu
+            os: ubuntu-24.04
+
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.name }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install apt packages
+        if: runner.os == 'Linux'
+        uses: awalsh128/cache-apt-pkgs-action@5902b33ae29014e6ca012c5d8025d4346556bd40
+        with:
+          packages: clojure leiningen
+          # Increment this when the package list changes.
+          version: 1
+      - name: Install babashka
+        run: |
+          curl -sL -o install-bb https://raw.githubusercontent.com/babashka/babashka/master/install
+          chmod +x install-bb
+          sudo ./install-bb
+      - name: lein test
+        id: lein-test
+        run: |
+          cd lein-jank
+          lein test

--- a/lein-jank-template/resources/leiningen/new/jank/project.clj
+++ b/lein-jank-template/resources/leiningen/new/jank/project.clj
@@ -2,7 +2,7 @@
   :license {:name "MPL 2.0"
             :url "https://www.mozilla.org/en-US/MPL/2.0/"}
   :dependencies []
-  :plugins [[org.jank-lang/lein-jank "0.6"]]
+  :plugins [[org.jank-lang/lein-jank "0.7"]]
   :middleware [leiningen.jank/middleware]
   :main {{namespace}}
   :profiles {:base {:jank {:output-dir "target/debug"

--- a/lein-jank/project.clj
+++ b/lein-jank/project.clj
@@ -7,4 +7,5 @@
                  [babashka/process "0.6.25"]
                  [leiningen-core "2.12.0"]
                  [org.clojure/tools.namespace "1.5.1"]]
+  :profiles {:dev {:dependencies [[nubank/matcher-combinators "3.10.0"]]}}
   :eval-in-leiningen true)

--- a/lein-jank/src/leiningen/jank.clj
+++ b/lein-jank/src/leiningen/jank.clj
@@ -173,20 +173,35 @@
           (with-meta result (apply deep-merge-metadata maps))
           result)))))
 
-(defn verbatim->filespecs [{:keys [root verbatim-paths] :as project}]
+(defn verbatim->filespecs
+  "Specify filespecs to copy files or directories in the :verbatim-paths project
+  key into the output archive."
+  [{:keys [root verbatim-paths] :as project}]
   ;; TODO: I couldn't find a good way to insert paths verbatim into the output
   ;; jar. With resource-paths etc. lein always seems to strip the first
   ;; directory from the source path when copying. Need to find an alternative or
   ;; implement a better version of verbatim-paths.
   (for [path  verbatim-paths
-        f     (fs/glob (fs/path (:root project) path) "**")
-        :when (not (fs/directory? f))]
+        f     (if (fs/directory? path)
+                (fs/glob (fs/path (:root project) path) "**")
+                [(fs/path (:root project) path)])
+        :when (fs/regular-file? f)]
     {:type  :bytes
      :path  (str (fs/relativize (:root project) f))
      :bytes (fs/read-all-bytes f)}))
+
+(defn build-dependencies->dependencies
+  "Compute regular :dependencies coordinates from the jank-specific
+  :build-dependencies coordinates.
+
+  We simply add a :scope 'jank-build' to the end of the coordinate, which
+  designates it as a build-time dependency."
+  [{:keys [build-dependencies] :as project}]
+  (mapv #(conj % :scope "jank-build") build-dependencies))
 
 (defn middleware
   "Inject jank project details into your current project."
   [project]
   (-> (deep-merge default-project project)
-      (update :filespecs concat (verbatim->filespecs project))))
+      (update :filespecs concat (verbatim->filespecs project))
+      (update :dependencies concat (build-dependencies->dependencies project))))

--- a/lein-jank/src/leiningen/jank.clj
+++ b/lein-jank/src/leiningen/jank.clj
@@ -169,23 +169,24 @@
 
 (defn verbatim->filespecs
   "Specify filespecs to copy files or directories in the :verbatim-paths project
-  key into the output archive."
+  key into the output archive.
+
+  These paths are copied exactly, whereas the standard keys like :source-paths
+  strip the path prefix such that the entries appear directly on the classpath
+  when the jar is loaded."
   [{:keys [root verbatim-paths] :as project}]
-  ;; TODO: I couldn't find a good way to insert paths verbatim into the output
-  ;; jar. With resource-paths etc. lein always seems to strip the first
-  ;; directory from the source path when copying.
-  ;; 
-  ;; Need to find an alternative or implement a better version of
-  ;; verbatim-paths. As it stands, every lein command which invokes the jank
-  ;; middleware will read all of these files into memory.
   (for [path  verbatim-paths
         f     (if (fs/directory? path)
                 (fs/glob (fs/path (:root project) path) "**")
                 [(fs/path (:root project) path)])
         :when (fs/regular-file? f)]
-    {:type  :bytes
-     :path  (str (fs/relativize (:root project) f))
-     :bytes (fs/read-all-bytes f)}))
+    ;; Lazy :fn type filespecs so that the file contents are only loaded when
+    ;; needed, rather than every time the middleware is executed.
+    {:type :fn
+     :fn   (fn [project]
+             {:type  :bytes
+              :path  (str (fs/relativize (:root project) f))
+              :bytes (fs/read-all-bytes f)})}))
 
 (defn build-dependencies->dependencies
   "Compute regular :dependencies coordinates from the jank-specific

--- a/lein-jank/src/leiningen/jank.clj
+++ b/lein-jank/src/leiningen/jank.clj
@@ -1,37 +1,39 @@
 (ns leiningen.jank
   (:refer-clojure :exclude [run!])
   (:require [clojure.pprint :as pp]
-            [clojure.string :as string]
             [leiningen.core.main :as lmain]
-            [leiningen.core.classpath :as cp]
             [leiningen.jank.core :as ljc]
             [leiningen.jank.test :as ljt]
             [leiningen.jank.build :as ljb]
             [babashka.fs :as fs]))
 
-(defn apply-args
-  "Extract task-specific args from the list and apply them to the project,
-  returning the updated project and the leftover arguments."
+(defn process-task-args
+  "Extract task-specific args from the list and return the parsed options and
+  the leftover arguments."
   [project args]
   (let [res (reduce
              (fn [acc arg]
                (cond
                  (= arg ":disable-sandbox")
-                 (assoc-in acc [:project :jank :disable-sandbox] true)
+                 (assoc-in acc [:opts :disable-sandbox] true)
 
                  :else
                  (update acc :args conj arg)))
-             {:project project :args []}
+             {:project project :opts {} :args []}
              args)]
-    ((juxt :project :args) res)))
+    ((juxt :opts :args) res)))
+
+(defn native-build [project opts]
+  (binding [ljb/*disable-sandbox* (or ljb/*disable-sandbox* (:disable-sandbox opts))]
+    (let [native-flags (ljb/run-build! (ljb/plan-build project))]
+      (update project :jank ljb/merge-native-flags native-flags))))
 
 (defn run!
   "Run your project, starting at the main entrypoint."
   [project & args]
-  (let [[project args] (apply-args project args)
-        cp-str         (ljc/build-module-path project)
-        native-flags   (ljb/run-build! (ljb/plan-build project))
-        project        (update project :jank ljb/merge-native-flags native-flags)]
+  (let [[opts args] (process-task-args project args)
+        project     (native-build project opts)
+        cp-str      (ljc/build-module-path project)]
     (if (:main project)
       (ljc/shell-out! project cp-str "run-main" [(:main project)] args)
       (lmain/warn "No :main entrypoint for project."))))
@@ -39,10 +41,9 @@
 (defn repl!
   "Start a terminal REPL in your :main ns."
   [project & args]
-  (let [[project args] (apply-args project args)
-        cp-str         (ljc/build-module-path project)
-        native-flags   (ljb/run-build! (ljb/plan-build project))
-        project        (update project :jank ljb/merge-native-flags native-flags)]
+  (let [[opts args] (process-task-args project args)
+        project     (native-build project opts)
+        cp-str      (ljc/build-module-path project)]
     (if (:main project)
       (ljc/shell-out! project cp-str "repl" [(:main project)] args)
       (lmain/warn "No :main entrypoint for project."))))
@@ -50,10 +51,9 @@
 (defn compile!
   "Compile your project to an executable."
   [project & args]
-  (let [[project args] (apply-args project args)
-        cp-str         (ljc/build-module-path project)
-        native-flags   (ljb/run-build! (ljb/plan-build project))
-        project        (update project :jank ljb/merge-native-flags native-flags)]
+  (let [[opts args] (process-task-args project args)
+        project     (native-build project opts)
+        cp-str      (ljc/build-module-path project)]
     (if (:main project)
       (ljc/shell-out! project cp-str "compile" [(:main project)] args)
       (lmain/warn "No :main entrypoint for project."))))
@@ -61,10 +61,9 @@
 (defn compile-module!
   "Compile a single module and its dependencies to object files."
   [project & args]
-  (let [[project args] (apply-args project args)
-        cp-str         (ljc/build-module-path project)
-        native-flags   (ljb/run-build! (ljb/plan-build project))
-        project        (update project :jank ljb/merge-native-flags native-flags)]
+  (let [[opts args] (process-task-args project args)
+        project     (native-build project opts)
+        cp-str      (ljc/build-module-path project)]
     (ljc/shell-out! project cp-str "compile-module" [] args)))
 
 (defn check-health!
@@ -92,7 +91,7 @@
            :help (-> fn-ref meta :doc)})
         subtask-kw->var)))
 
-(defn process-args [args]
+(defn process-jank-args [args]
   (loop [args args
          ret []]
     (if (empty? args)
@@ -109,7 +108,7 @@
   "Compile, run, test and repl into jank."
   [project subcmd & args]
   (if-some [handler (subtask-kw->var (keyword subcmd))]
-    (apply handler project (process-args args))
+    (apply handler project (process-jank-args args))
     (do
       (lmain/warn "Invalid subcommand!")
       (print-help!)

--- a/lein-jank/src/leiningen/jank.clj
+++ b/lein-jank/src/leiningen/jank.clj
@@ -34,9 +34,7 @@
         project        (update project :jank ljb/merge-native-flags native-flags)]
     (if (:main project)
       (ljc/shell-out! project cp-str "run-main" [(:main project)] args)
-      (do
-        (lmain/warn "No :main entrypoint for project.")
-        (lmain/exit 1)))))
+      (lmain/warn "No :main entrypoint for project."))))
 
 (defn repl!
   "Start a terminal REPL in your :main ns."
@@ -47,9 +45,7 @@
         project        (update project :jank ljb/merge-native-flags native-flags)]
     (if (:main project)
       (ljc/shell-out! project cp-str "repl" [(:main project)] args)
-      (do
-        (lmain/warn "No :main entrypoint for project.")
-        (lmain/exit 1)))))
+      (lmain/warn "No :main entrypoint for project."))))
 
 (defn compile!
   "Compile your project to an executable."
@@ -60,9 +56,7 @@
         project        (update project :jank ljb/merge-native-flags native-flags)]
     (if (:main project)
       (ljc/shell-out! project cp-str "compile" [(:main project)] args)
-      (do
-        (lmain/warn "No :main entrypoint for project.")
-        (lmain/exit 1)))))
+      (lmain/warn "No :main entrypoint for project."))))
 
 (defn compile-module!
   "Compile a single module and its dependencies to object files."
@@ -179,8 +173,11 @@
   [{:keys [root verbatim-paths] :as project}]
   ;; TODO: I couldn't find a good way to insert paths verbatim into the output
   ;; jar. With resource-paths etc. lein always seems to strip the first
-  ;; directory from the source path when copying. Need to find an alternative or
-  ;; implement a better version of verbatim-paths.
+  ;; directory from the source path when copying.
+  ;; 
+  ;; Need to find an alternative or implement a better version of
+  ;; verbatim-paths. As it stands, every lein command which invokes the jank
+  ;; middleware will read all of these files into memory.
   (for [path  verbatim-paths
         f     (if (fs/directory? path)
                 (fs/glob (fs/path (:root project) path) "**")

--- a/lein-jank/src/leiningen/jank/build.clj
+++ b/lein-jank/src/leiningen/jank/build.clj
@@ -124,7 +124,7 @@
   (fs/create-dirs out-dir)
   (let [dep-name     (first (:dep subtree-meta))
         build-meta   (merge subtree-meta {:src-dir   (str src-dir)
-                                          :build-dir jank-tmp-build-dir
+                                          :build-dir (str jank-tmp-build-dir)
                                           :out-dir   (str out-dir)})
         ;; The sandbox gets standard mounts for a scratch directory and build
         ;; output directory. It also mounts as RO each input and build input.
@@ -246,8 +246,8 @@
                  root-ops (when (has-build-file? (:root project))
                             [{:op           :compile
                               :dep          [(symbol (:group project) (:name project)) (:version project)]
-                              :src-dir      (:root project)
-                              :out-dir      (target-subdir output-dir "out" (:name project) "XXX")
+                              :src-dir      (str (:root project))
+                              :out-dir      (str (target-subdir output-dir "out" (:name project) "XXX"))
                               :build-inputs (collect-build-deps tree)
                               :inputs       (collect-out-dirs dep-ops)
                               :always-build true}])]

--- a/lein-jank/src/leiningen/jank/build.clj
+++ b/lein-jank/src/leiningen/jank/build.clj
@@ -3,18 +3,16 @@
   (:require [clojure.string :as string]
             [clojure.java.io :as io]
             [babashka.fs :as fs]
-            [cemerick.pomegranate.aether :as aether]
             [leiningen.core.main :as lmain]
             [leiningen.core.classpath :as lcp]
             [leiningen.jank.sandbox.core :as sandbox])
-  (:import (java.nio ByteBuffer)
-           (java.security MessageDigest)
+  (:import (java.security MessageDigest)
            (java.util HexFormat)
            (java.util.jar JarFile)))
 
 (def jank-build-file "jank-build.bb")
 (def jank-build-cache-file "jank-build-cache.txt")
-(def jank-tmp-build-dir "/tmp/jank-build")
+(def jank-tmp-build-dir (fs/path (fs/temp-dir) "jank-build"))
 
 (def default-build-opts
   {:output-dir         "target"
@@ -23,15 +21,25 @@
    :static-build       true
    :verbose-build      true})
 
-(defn merge-native-flags [& maps]
-  (let [valid-keys [:defines :include-dirs :library-dirs :linked-libraries]]
-    (reduce (fn [a b] (merge-with into a (select-keys b valid-keys))) maps)))
+(defn merge-native-flags
+  ([] {})
+  ([& maps]
+   (let [valid-keys [:defines :include-dirs :library-dirs :linked-libraries]]
+     (reduce (fn [a b] (merge-with into a (select-keys b valid-keys))) maps))))
 
 (defn has-build-file?
-  "Returns true if the given jar file has a `jank-build.bb` file in the root."
-  [jar]
-  (with-open [jar (JarFile. jar)]
-    (some? (.getEntry jar jank-build-file))))
+  "Returns true if the given directory or jar file has a `jank-build.bb` file in
+  the root."
+  [path]
+  (if (fs/directory? path)
+    (fs/regular-file? (fs/path path jank-build-file))
+    (with-open [jar (JarFile. path)]
+      (some? (.getEntry jar jank-build-file)))))
+
+(defn is-already-built?
+  "Returns true if the given directory has a jank build cache file."
+  [out-dir]
+  (fs/regular-file? (fs/path out-dir jank-build-cache-file)))
 
 (defn extract-jar!
   "Extract the jar file into `out-dir`, creating it if it does not exist."
@@ -42,15 +50,23 @@
   "Compute a fingerprint of the dependency. When the fingerprint changes (due to
   some change in the descendant dependencies or environment) the dependency
   needs to be recompiled."
-  [src-jar meta]
+  [data]
   ;; TODO: We should implement something like Cargo's fingerprint to better
   ;; react to changes in the environment:
   ;; 
   ;; https://doc.rust-lang.org/nightly/nightly-rustc/cargo/core/compiler/fingerprint/index.html
   (let [md     (MessageDigest/getInstance "SHA-256")
+        baos   (java.io.ByteArrayOutputStream.)]
+    (with-open [writer (io/writer baos)]
+      (binding [*out* writer]
+        (pr data)))
+    (.update md (.toByteArray baos))
+    (.formatHex (HexFormat/of) (.digest md))))
+
+(defn fingerprint-file [f]
+  (let [md     (MessageDigest/getInstance "SHA-256")
         _      (doto md
-                 (.update (fs/read-all-bytes src-jar))
-                 (.update (-> (ByteBuffer/allocate 4) (.putInt (hash meta)) .array)))
+                 (.update (fs/read-all-bytes f)))
         digest (.digest md)]
     (.formatHex (HexFormat/of) digest)))
 
@@ -72,9 +88,11 @@
                     (string/includes? line "="))
          :let  [[k v] (string/split line #"=" 2)]]
      (case k
-       "jank-build::include-path" {:include-dirs [v]}
-       "jank-build::link-path"    {:library-dirs [v]}
-       "jank-build::link-lib"     {:linked-libraries [v]}
+       "jank-build::define"       (let [[a b] (string/split v #"=" 2)]
+                                    {:defines {a b}})
+       "jank-build::include-dir"  {:include-dirs [v]}
+       "jank-build::link-dir"     {:library-dirs [v]}
+       "jank-build::link-library" {:linked-libraries [v]}
        (do (lmain/warn "invalid jank-build directive:" k)
            nil)))
    (remove nil?)))
@@ -84,11 +102,9 @@
   vector of the recorded lines (without the prefix)."
   [stream lines-atom {:keys [prefix echo]}]
   (with-open [rdr (io/reader stream)]
-    (doall
-     (for [line (line-seq rdr)]
-       (do
-         (when echo (println (str prefix " " line)))
-         (swap! lines-atom conj line))))))
+    (doseq [line (line-seq rdr)]
+      (when echo (println (str prefix " " line)))
+      (swap! lines-atom conj line))))
 
 (defn build-dep!
   "Run a sandboxed (unless :disable-sandbox is set in subtree-meta) build on the
@@ -106,31 +122,35 @@
   `out-dir/jank-build-cache.txt` plus the artifacts of the build in `out-dir`."
   [src-dir out-dir subtree-meta]
   (fs/create-dirs out-dir)
-  (let [build-meta   (merge subtree-meta {:src-dir   (str src-dir)
+  (let [dep-name     (first (:dep subtree-meta))
+        build-meta   (merge subtree-meta {:src-dir   (str src-dir)
                                           :build-dir jank-tmp-build-dir
                                           :out-dir   (str out-dir)})
         ;; The sandbox gets standard mounts for a scratch directory and build
-        ;; output directory. It also mounts as RO each build output from its
-        ;; dependencies.
+        ;; output directory. It also mounts as RO each input and build input.
         sandbox-args (into [[:ro-bind src-dir src-dir]
                             [:bind out-dir out-dir]
                             [:tmpfs jank-tmp-build-dir]
                             [:chdir jank-tmp-build-dir]
                             [:net false]]
-                           (map (fn [dir] [:ro-bind dir dir]) (vals (:outputs subtree-meta))))
+                           (map (fn [dir] [:ro-bind dir dir])
+                                (concat (vals (:inputs subtree-meta))
+                                        (:build-inputs subtree-meta))))
         ;; Pass `bb --stream` and provide the EDN-formatted build metadata on
         ;; stdin so that it is available in the build script on `*input*`.
+        ;; Include all build input jars into the classpath.
+        bb-classpath (string/join ":" (:build-inputs subtree-meta))
         proc         (sandbox/process
                       (not (:disable-sandbox subtree-meta))
                       sandbox-args
-                      ["bb" "--stream" (fs/path src-dir jank-build-file)]
+                      ["bb" "--classpath" bb-classpath "--stream" (fs/path src-dir jank-build-file)]
                       {:in       (pr-str build-meta)
                        :continue true})
         out-lines    (atom [])]
     (future (wrap-stream (:out proc) out-lines {:echo   (:verbose-build subtree-meta)
-                                                :prefix "  \u001b[0;34mjank-build>\u001b[0m"}))
+                                                :prefix (str "  \u001b[0;34m" dep-name ">\u001b[0m")}))
     (future (wrap-stream (:err proc) out-lines {:echo   (:verbose-build subtree-meta)
-                                                :prefix "  \u001b[0;31mjank-build>\u001b[0m"}))
+                                                :prefix (str "  \u001b[0;31m" dep-name ">\u001b[0m")}))
     (if (zero? (:exit @proc))
       ;; Build succeeded. Cache all of the build stdout output. Later we will
       ;; parse the build directives.
@@ -154,34 +174,55 @@
                            (str (:out-dir op))])))
          (into {}))))
 
+(defn build-scoped? [coord]
+  (let [m (apply hash-map coord)]
+    (= (:scope m) "jank-build")))
+
+(defn collect-build-deps
+  "Given a dependency tree, identify its jank-build scoped elements and resolve
+  them.
+
+  Build dependencies are not transitive, so only the first layer of the tree is
+  searched. Deeper build-scoped dependencies will be ignored."
+  [tree]
+  (->> tree
+       keys
+       (filter build-scoped?)
+       (mapv #(-> % meta :file str))))
+
 (defn plan-subtree-build [build-opts target-dir [dep subtree]]
-  (let [subtree-ops    (vec (mapcat #(plan-subtree-build build-opts target-dir %) subtree))
-        src-jar        (first (aether/dependency-files {dep nil}))
-        jar-name       (-> src-jar fs/file-name fs/strip-ext)
-        src-fprint     (fingerprint src-jar {})
-        src-dir        (target-subdir target-dir "src" jar-name src-fprint)
-        ;; Output is fingerprinted on the source jar contents and all of the
-        ;; build steps which produce its descendant outputs. If any of these
-        ;; change then a fresh build is triggered.
-        out-fprint     (fingerprint src-jar subtree-ops)
-        out-dir        (target-subdir target-dir "out" jar-name out-fprint)
-        is-native-dep? (has-build-file? src-jar)]
-    (if-not is-native-dep?
+  (let [subtree-ops (vec (mapcat #(plan-subtree-build build-opts target-dir %) subtree))
+        src-jar     (:file (meta dep))
+        jar-name    (-> src-jar fs/file-name fs/strip-ext)]
+    ;; NOTE: make sure all outputs here are pure Clojure data. We use (pr ops)
+    ;; to compute a subtree hash to determine if the build has changed and needs
+    ;; to rerun. Java data (like a fs/path, a native array, etc.) will cause
+    ;; unstable hashes and spurious rebuilds.
+    (if-not (has-build-file? src-jar)
       ;; If this is a plain jank jar then no build step is required, but it
       ;; still may have native dependencies in the subtree.
       subtree-ops
       ;; If this is a native build then we must add its build step and all of
       ;; the its descendant build steps.
-      (into subtree-ops
-            [{:op  :extract-src
-              :dep dep
-              :jar src-jar
-              :dir src-dir}
-             {:op         :run-build
-              :dep        dep
-              :src-dir    src-dir
-              :out-dir    out-dir
-              :child-outs (collect-out-dirs subtree-ops)}]))))
+      (let [src-fprint (fingerprint-file src-jar)
+            src-dir    (target-subdir target-dir "src" jar-name src-fprint)
+            ;; Output is fingerprinted on the source jar contents and all of the
+            ;; build steps which produce its descendant outputs. If any of these
+            ;; change then a fresh build is triggered.
+            out-fprint (fingerprint subtree-ops)
+            out-dir    (target-subdir target-dir "out" jar-name out-fprint)]
+        (into subtree-ops
+              [{:op     :extract-src
+                :dep    dep
+                :jar    (str src-jar)
+                :fprint (fingerprint-file src-jar)
+                :dir    (str src-dir)}
+               {:op           :compile
+                :dep          dep
+                :src-dir      (str src-dir)
+                :out-dir      (str out-dir)
+                :build-inputs (collect-build-deps subtree)
+                :inputs       (collect-out-dirs subtree-ops)}])))))
 
 (defn plan-build
   "Compute a build plan, i.e. a linear sequence of operations, which will
@@ -202,12 +243,13 @@
                  ;; TODO: For now we always run the root build script, but we
                  ;; could cache it if we knew its input files. Cargo does this
                  ;; by outputting rerun-if-changed flags from the build script.
-                 root-ops (when (fs/exists? (fs/path (:root project) jank-build-file))
-                            [{:op           :run-build
-                              :dep          [(:name project) (:version project)]
+                 root-ops (when (has-build-file? (:root project))
+                            [{:op           :compile
+                              :dep          [(symbol (:group project) (:name project)) (:version project)]
                               :src-dir      (:root project)
                               :out-dir      (target-subdir output-dir "out" (:name project) "XXX")
-                              :child-outs   (collect-out-dirs dep-ops)
+                              :build-inputs (collect-build-deps tree)
+                              :inputs       (collect-out-dirs dep-ops)
                               :always-build true}])]
              (into dep-ops root-ops)))))
 
@@ -223,12 +265,12 @@
   ;; does not produce any jank flags
   nil)
 
-(defmethod run-build-op! :run-build
-  [plan {:keys [dep src-dir out-dir child-outs always-build]}]
-  (let [needs-build? (or always-build (not (fs/exists? (fs/path out-dir jank-build-cache-file))))]
+(defmethod run-build-op! :compile
+  [plan {:keys [dep src-dir out-dir build-inputs inputs always-build]}]
+  (let [needs-build? (or always-build (not (is-already-built? out-dir)))]
     (when needs-build?
       (println (str "\u001b[1;32m" (format "%10s" "Compiling") "\u001b[0m") dep)
-      (build-dep! src-dir out-dir (assoc plan :outputs child-outs)))
+      (build-dep! src-dir out-dir (assoc plan :dep dep :inputs inputs :build-inputs build-inputs)))
 
     ;; jank flags are extracted from the build cache file
     (process-build-directives (fs/read-all-lines (fs/path out-dir jank-build-cache-file)))))

--- a/lein-jank/src/leiningen/jank/build.clj
+++ b/lein-jank/src/leiningen/jank/build.clj
@@ -10,13 +10,14 @@
            (java.util HexFormat)
            (java.util.jar JarFile)))
 
+(def ^:dynamic *disable-sandbox* false)
+
 (def jank-build-file "jank-build.bb")
 (def jank-build-cache-file "jank-build-cache.txt")
 (def jank-tmp-build-dir (fs/path (fs/temp-dir) "jank-build"))
 
 (def default-build-opts
   {:output-dir         "target"
-   :disable-sandbox    false
    :optimization-level 2
    :static-build       true
    :verbose-build      true})
@@ -107,9 +108,9 @@
       (swap! lines-atom conj line))))
 
 (defn build-dep!
-  "Run a sandboxed (unless :disable-sandbox is set in subtree-meta) build on the
-  dependency located at `src-dir`, and instruct the build script to place
-  artifacts in the `out-dir`.
+  "Run a sandboxed (unless disable-sandbox is set) build on the dependency
+  located at `src-dir`, and instruct the build script to place artifacts in the
+  `out-dir`.
 
   The `src-dir` is expected to contain a `jank-build.bb` file. This file is run
   in the sandbox by `bb --stream jank-build.bb`, and is passed the build
@@ -141,7 +142,7 @@
         ;; Include all build input jars into the classpath.
         bb-classpath (string/join ":" (:build-inputs subtree-meta))
         proc         (sandbox/process
-                      (not (:disable-sandbox subtree-meta))
+                      (not *disable-sandbox*)
                       sandbox-args
                       ["bb" "--classpath" bb-classpath "--stream" (fs/path src-dir jank-build-file)]
                       {:in       (pr-str build-meta)
@@ -232,7 +233,7 @@
   which can be executed by `run-build!`."
   [project]
   (let [{:keys [output-dir] :as build-opts} (merge default-build-opts (:jank project))]
-    (when (:disable-sandbox build-opts)
+    (when *disable-sandbox*
       (println "\u001b[1;31mBuilding with sandboxing disabled is potentially dangerous!\u001b[0m"))
 
     (assoc build-opts :operations

--- a/lein-jank/src/leiningen/jank/core.clj
+++ b/lein-jank/src/leiningen/jank/core.clj
@@ -50,9 +50,6 @@
     :linked-libraries
     (map (fn [v] (str "-l" v)) value)
 
-    :disable-sandbox
-    [] ;; ignore, used in build process
-
     (lmain/warn (str "Unknown flag " flag))))
 
 (defn build-declarative-flags [project]

--- a/lein-jank/test-data/test-build-dependency/project.clj
+++ b/lein-jank/test-data/test-build-dependency/project.clj
@@ -1,0 +1,6 @@
+(defproject org.jank-lang/test-build-dependency "0.1.0"
+  :description "FIXME: write description"
+  :url "https://example.com/FIXME"
+  :license {:name "MPL 2.0"
+            :url  "https://www.mozilla.org/en-US/MPL/2.0/"}
+  :source-paths ["src"])

--- a/lein-jank/test-data/test-build-dependency/src/test_build_dependency/core.bb
+++ b/lein-jank/test-data/test-build-dependency/src/test_build_dependency/core.bb
@@ -1,0 +1,4 @@
+(ns test-build-dependency.core)
+
+(defn hello []
+  (println "Hello from the build dependency"))

--- a/lein-jank/test-data/test-child/project.clj
+++ b/lein-jank/test-data/test-child/project.clj
@@ -1,0 +1,8 @@
+(defproject org.jank-lang/test-child "0.1.0"
+  :description "FIXME: write description"
+  :url "https://example.com/FIXME"
+  :license {:name "MPL 2.0"
+            :url  "https://www.mozilla.org/en-US/MPL/2.0/"}
+  :plugins [[org.jank-lang/lein-jank "0.7"]]
+  :middleware [leiningen.jank/middleware]
+  :dependencies [[org.jank-lang/test-grandchild "0.1.0"]])

--- a/lein-jank/test-data/test-grandchild/jank-build.bb
+++ b/lein-jank/test-data/test-grandchild/jank-build.bb
@@ -1,0 +1,9 @@
+(require '[test-build-dependency.core :as tbd])
+
+(println "jank-build::define=I_LIKE=TURTLES")
+(println "jank-build::include-dir=foobar")
+(println "jank-build::link-dir=somepath")
+(println "jank-build::link-library=foolib")
+(println "jank-build::link-library=barlib")
+(println "Hello jank build!")
+(tbd/hello)

--- a/lein-jank/test-data/test-grandchild/project.clj
+++ b/lein-jank/test-data/test-grandchild/project.clj
@@ -1,0 +1,9 @@
+(defproject org.jank-lang/test-grandchild "0.1.0"
+  :description "FIXME: write description"
+  :url "https://example.com/FIXME"
+  :license {:name "MPL 2.0"
+            :url  "https://www.mozilla.org/en-US/MPL/2.0/"}
+  :plugins [[org.jank-lang/lein-jank "0.7"]]
+  :middleware [leiningen.jank/middleware]
+  :build-dependencies [[org.jank-lang/test-build-dependency "0.1.0"]]
+  :verbatim-paths ["jank-build.bb"])

--- a/lein-jank/test-data/test-parent/project.clj
+++ b/lein-jank/test-data/test-parent/project.clj
@@ -1,0 +1,8 @@
+(defproject org.jank-lang/test-parent "0.1.0"
+  :description "FIXME: write description"
+  :url "https://example.com/FIXME"
+  :license {:name "MPL 2.0"
+            :url  "https://www.mozilla.org/en-US/MPL/2.0/"}
+  :plugins [[org.jank-lang/lein-jank "0.7"]]
+  :middleware [leiningen.jank/middleware]
+  :dependencies [[org.jank-lang/test-child "0.1.0"]])

--- a/lein-jank/test-project/project.clj
+++ b/lein-jank/test-project/project.clj
@@ -1,7 +1,7 @@
 (defproject test-project "0.1.0-SNAPSHOT"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
-  :plugins [[org.jank-lang/lein-jank "0.6"]]
+  :plugins [[org.jank-lang/lein-jank "0.7"]]
   ;; include a native dependency for testing
   :dependencies [[org.clojars.kylc/jank-glfw3 "0.1-SNAPSHOT"]]
   :main test-project.core

--- a/lein-jank/test/leiningen/jank/integration_test.clj
+++ b/lein-jank/test/leiningen/jank/integration_test.clj
@@ -1,0 +1,83 @@
+(ns leiningen.jank.integration-test
+  (:require [clojure.test :refer [deftest is use-fixtures]]
+            [matcher-combinators.test :refer [match?]]
+            [matcher-combinators.matchers :as m]
+            [babashka.fs :as fs]
+            [leiningen.install :refer [install]]
+            [leiningen.core.project :as lproj]
+            [leiningen.jank.build :as build]))
+
+(def temp-m2-repo (str (fs/create-temp-dir {:prefix "lein-jank-test-m2"})))
+
+(defn load-project [path]
+  (-> (lproj/read path)
+      (assoc :local-repo temp-m2-repo)))
+
+;; Set up an example dependency tree where parent-project -> child-project ->
+;; grandchild-project -> (build dep) build-dependency.
+(def parent-project (load-project "test-data/test-parent/project.clj"))
+(def child-project (load-project "test-data/test-child/project.clj"))
+(def grandchild-project (load-project "test-data/test-grandchild/project.clj"))
+(def build-dependency-project (load-project "test-data/test-build-dependency/project.clj"))
+
+;; Children need to be installed into the maven cache to be properly picked up
+;; by parents.
+(defn setup-fixture [f]
+  (try
+    (install build-dependency-project)
+    (install grandchild-project)
+    (install child-project)
+    (install parent-project)
+    (catch Exception e
+      ;; ignore lein exit calls
+      (when (not= (ex-message e) "Suppressed exit")
+        (throw e))))
+  (f))
+
+(use-fixtures :once setup-fixture)
+
+(deftest detect-jank-build-file-test
+  (is (false? (build/has-build-file? (:root parent-project))))
+  (is (false? (build/has-build-file? (:root child-project))))
+  (is (true? (build/has-build-file? (:root grandchild-project)))))
+
+(deftest plan-build-test
+  (let [plan (build/plan-build parent-project)
+        ops  (:operations plan)]
+    ;; Only test-grandchild has a jank-build file, so it is the only dep which
+    ;; will generate build plan steps.
+    (is (match? [{:op     :extract-src
+                  :dep    '[org.jank-lang/test-grandchild "0.1.0"]
+                  :fprint string?}
+                 {:op           :compile
+                  :dep          '[org.jank-lang/test-grandchild "0.1.0"]
+                  :build-inputs [(m/regex #".*\.jar")]
+                  :inputs       (m/equals {})}]
+                ops))))
+
+(deftest plan-build-with-root-jank-build-test
+  (let [plan (build/plan-build grandchild-project)
+        ops  (:operations plan)]
+    (is (match? [;; no extract-src since we are building the root from source
+                 {:op           :compile
+                  :dep          '[org.jank-lang/test-grandchild "0.1.0"]
+                  :build-inputs [(m/regex #".*\.jar")]
+                  :inputs       (m/equals {})
+                  ;; root project always builds
+                  :always-build true}]
+                ops))))
+
+(deftest run-build-test
+  (let [output-dir (fs/create-temp-dir {:prefix "lein-jank-test-out"})
+        plan       (-> parent-project
+                       (assoc-in [:jank :disable-sandbox] true)
+                       (assoc-in [:jank :output-dir] output-dir)
+                       (build/plan-build))
+        result     (build/run-build! plan)]
+    ;; These are the results from the test-grandchild jank-build.bb script.
+    (is (match?
+         {:defines          {"I_LIKE" "TURTLES"}
+          :include-dirs     ["foobar"]
+          :library-dirs     ["somepath"]
+          :linked-libraries ["foolib" "barlib"]}
+         result))))

--- a/lein-jank/test/leiningen/jank/integration_test.clj
+++ b/lein-jank/test/leiningen/jank/integration_test.clj
@@ -23,11 +23,12 @@
 ;; Children need to be installed into the maven cache to be properly picked up
 ;; by parents.
 (defn setup-fixture [f]
-  (install build-dependency-project)
-  (install grandchild-project)
-  (install child-project)
-  (install parent-project)
-  (f))
+  (binding [build/*disable-sandbox* true]
+    (install build-dependency-project)
+    (install grandchild-project)
+    (install child-project)
+    (install parent-project)
+    (f)))
 
 (use-fixtures :once setup-fixture)
 
@@ -65,10 +66,10 @@
 (deftest run-build-test
   (let [output-dir (fs/create-temp-dir {:prefix "lein-jank-test-out"})
         plan       (-> parent-project
-                       (assoc-in [:jank :disable-sandbox] true)
                        (assoc-in [:jank :output-dir] output-dir)
                        (build/plan-build))
-        result     (build/run-build! plan)]
+        result     (binding [build/*disable-sandbox* true]
+                     (build/run-build! plan))]
     ;; These are the results from the test-grandchild jank-build.bb script.
     (is (match?
          {:defines          {"I_LIKE" "TURTLES"}

--- a/lein-jank/test/leiningen/jank/integration_test.clj
+++ b/lein-jank/test/leiningen/jank/integration_test.clj
@@ -23,15 +23,10 @@
 ;; Children need to be installed into the maven cache to be properly picked up
 ;; by parents.
 (defn setup-fixture [f]
-  (try
-    (install build-dependency-project)
-    (install grandchild-project)
-    (install child-project)
-    (install parent-project)
-    (catch Exception e
-      ;; ignore lein exit calls
-      (when (not= (ex-message e) "Suppressed exit")
-        (throw e))))
+  (install build-dependency-project)
+  (install grandchild-project)
+  (install child-project)
+  (install parent-project)
   (f))
 
 (use-fixtures :once setup-fixture)

--- a/lein-jank/test/leiningen/jank/test_build.clj
+++ b/lein-jank/test/leiningen/jank/test_build.clj
@@ -1,40 +1,45 @@
 (ns leiningen.jank.test-build
-  (:require [babashka.fs :as fs]
+  (:require [clojure.test :refer [deftest testing is]]
+            [babashka.fs :as fs]
             [leiningen.core.project :as proj]
-            [leiningen.jank.build :as sut]
-            [clojure.test :refer [deftest testing is]]))
+            [leiningen.jank.build :as build]))
 
 (def test-project (proj/read "test-project/project.clj"))
 
 (deftest native-flags
-  (is (= (sut/merge-native-flags {:include-dirs ["a"]}
-                                 {:include-dirs ["b"]
-                                  :library-dirs ["c"]})
-         {:include-dirs ["a" "b"]
+  (is (= (build/merge-native-flags {:defines      {"A" "B"}
+                                    :include-dirs ["a"]}
+                                   {:defines      {"C" "D"}
+                                    :include-dirs ["b"]
+                                    :library-dirs ["c"]})
+         {:defines      {"A" "B" "C" "D"}
+          :include-dirs ["a" "b"]
           :library-dirs ["c"]})))
 
 (deftest build-directives
-  (is (empty? (sut/process-build-directives [])))
+  (is (empty? (build/process-build-directives [])))
   
-  (is (empty? (sut/process-build-directives
+  (is (empty? (build/process-build-directives
                ["not a build directive"
                 "also not a build directive"])))
 
-  (is (empty? (sut/process-build-directives
+  (is (empty? (build/process-build-directives
                ["jank-build::an-invalid-directive=123"])))
   
-  (is (= (sut/process-build-directives
-          ["jank-build::include-path=some-include-path"
-           "jank-build::include-path=another-include-path"
+  (is (= (build/process-build-directives
+          ["jank-build::define=A=B"
+           "jank-build::include-dir=some-include-path"
+           "jank-build::include-dir=another-include-path"
            "some text"
-           "jank-build::link-path=a-link-path"
-           "jank-build::link-lib=a-lib"])
-         [{:include-dirs ["some-include-path"]}
+           "jank-build::link-dir=a-link-path"
+           "jank-build::link-library=a-lib"])
+         [{:defines {"A" "B"}}
+          {:include-dirs ["some-include-path"]}
           {:include-dirs ["another-include-path"]}
           {:library-dirs ["a-link-path"]}
           {:linked-libraries ["a-lib"]}])))
 
-(deftest plan-build
-  (let [plan (sut/plan-build test-project)]
-    (is some? (:operations plan))
-    (is (every? #(#{:extract-src :run-build} (:op %)) (:operations plan)))))
+(deftest build-scoped
+  (is (false? (build/build-scoped? '[org.jank/some-dependency "1.0.0"])))
+  (is (false? (build/build-scoped? '[org.jank/some-dependency "1.0.0" :exclusions [foo] :classifier "asdf"])))
+  (is (true? (build/build-scoped? '[org.jank/some-dependency "1.0.0" :scope "jank-build"]))))


### PR DESCRIPTION
Adds support for build dependencies: dependencies for your `jank-build.bb` script. For example, a common `jank-build-cmake` library which includes helpers for executing CMake, to be used by all `jank-build.bb` scripts in the wild which drive a CMake build.

This mimics the Cargo [build-dependencies](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#build-dependencies) feature.

I have updated my lein-jank-playground to demo this:
1. jank-json-sys declares a `:build-dependencies` entry in [its project.clj file](https://github.com/kylc/lein-jank-playground/blob/main/jank-json-sys/project.clj#L6)
2. It uses the dependency in [its `jank-build.bb` file](https://github.com/kylc/lein-jank-playground/blob/main/jank-json-sys/jank-build.bb#L5)
3. This dependency is resolved via Maven as usual, in this case to an artifact on clojars (source: https://github.com/kylc/lein-jank-playground/tree/main/jank-build-cmake). It is added to the babashka classpath when the build script is executed.

Also includes some misc. fixups and some integration tests for the build system.

### TODO
- ~Validate (build?)-dependencies-of-build-dependencies behavior~
- ~Think about whether using this non-standard pom.xml dependency scope `jank-build` will cause any problems down the line~