### PR TITLE
Update CppInterOp to fix JIT CRT resolution on MS-Windows

### DIFF
--- a/compiler+runtime/test/jank/cpp/cppinterop/pass-windows-crt-resolution.jank
+++ b/compiler+runtime/test/jank/cpp/cppinterop/pass-windows-crt-resolution.jank
@@ -1,0 +1,47 @@
+; Verify JIT resolves CRT symbols from ucrtbase.dll (the host CRT),
+; not msvcrt.dll (legacy CRT loaded by system DLLs).
+; https://github.com/jank-lang/jank/discussions/803
+(cpp/raw "
+#include <cstdio>
+
+#ifdef _WIN32
+#include <windows.h>
+#include <cstring>
+#endif
+
+namespace jank::cpp::cppinterop::pass_windows_crt_resolution
+{
+  // Return the full DLL path that provides the tmpfile function.
+  const char* tmpfile_dll() {
+#ifdef _WIN32
+    static char path[MAX_PATH];
+    HMODULE hMod = nullptr;
+    GetModuleHandleExA(
+      GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+      reinterpret_cast<LPCSTR>(&tmpfile), &hMod);
+    GetModuleFileNameA(hMod, path, MAX_PATH);
+    return path;
+#else
+    return \"\";
+#endif
+  }
+
+  // True if PATH contains ucrtbase (case-insensitive).
+  bool is_ucrtbase(const char* path) {
+#ifdef _WIN32
+    for (const char* p = path; *p; ++p) {
+      if ((*p == 'u' || *p == 'U') &&
+          _strnicmp(p, \"ucrtbase\", 8) == 0)
+        return true;
+    }
+#endif
+    return false;
+  }
+}
+")
+
+(if (= cpp/jtl.current_platform cpp/jtl.platform.windows_like)
+  (if (cpp/jank.cpp.cppinterop.pass_windows_crt_resolution.is_ucrtbase
+        (cpp/jank.cpp.cppinterop.pass_windows_crt_resolution.tmpfile_dll))
+    :success)
+  :success)


### PR DESCRIPTION
Hi,

can you please consider patch to update 3rd-party CppInterOp to latest main, which picks up the ucrt/msvcrt JIT resolution fix (https://github.com/jank-lang/CppInterOp/pull/4). Addresses #803.

Also picks up an unrelated fix: "Fix GetOperators for implicit members" (https://github.com/jank-lang/CppInterOp/commit/72526fdae1a1c53e18ef8e3e8f0e81ba56ea0fe6).

Includes a regression test for the CRT resolution to test the same, that was created in collaboration with AI, will remove upon successful review per policy.

thanks