### PR TITLE
Various jank-build fixups from initial testing

### DIFF
--- a/lein-jank/src/leiningen/jank.clj
+++ b/lein-jank/src/leiningen/jank.clj
@@ -11,17 +11,16 @@
   "Extract task-specific args from the list and return the parsed options and
   the leftover arguments."
   [project args]
-  (let [res (reduce
-             (fn [acc arg]
-               (cond
-                 (= arg ":disable-sandbox")
-                 (assoc-in acc [:opts :disable-sandbox] true)
+  (let [[args extra] (lmain/parse-options args)
+        opts         (reduce (fn [opts arg]
+                               (case arg
+                                 [:--disable-sandbox true]
+                                 (assoc opts :disable-sandbox true)
 
-                 :else
-                 (update acc :args conj arg)))
-             {:project project :opts {} :args []}
-             args)]
-    ((juxt :opts :args) res)))
+                                 project))
+                             {}
+                             args)]
+    [opts extra]))
 
 (defn native-build [project opts]
   (binding [ljb/*disable-sandbox* (or ljb/*disable-sandbox* (:disable-sandbox opts))]

--- a/lein-jank/src/leiningen/jank.clj
+++ b/lein-jank/src/leiningen/jank.clj
@@ -198,6 +198,7 @@
 (defn middleware
   "Inject jank project details into your current project."
   [project]
-  (-> (deep-merge default-project project)
-      (update :filespecs concat (verbatim->filespecs project))
-      (update :dependencies concat (build-dependencies->dependencies project))))
+  (let [project (update project :verbatim-paths conj "jank-build.bb")]
+    (-> (deep-merge default-project project)
+        (update :filespecs concat (verbatim->filespecs project))
+        (update :dependencies concat (build-dependencies->dependencies project)))))

--- a/lein-jank/src/leiningen/jank/build.clj
+++ b/lein-jank/src/leiningen/jank/build.clj
@@ -14,7 +14,6 @@
 
 (def jank-build-file "jank-build.bb")
 (def jank-build-cache-file "jank-build-cache.txt")
-(def jank-tmp-build-dir (fs/path (fs/temp-dir) "jank-build"))
 
 (def default-build-opts
   {:output-dir         "target"
@@ -124,15 +123,16 @@
   [src-dir out-dir subtree-meta]
   (fs/create-dirs out-dir)
   (let [dep-name     (first (:dep subtree-meta))
+        build-dir    (fs/create-temp-dir {:prefix "jank-build-"})
         build-meta   (merge subtree-meta {:src-dir   (str src-dir)
-                                          :build-dir (str jank-tmp-build-dir)
+                                          :build-dir (str build-dir)
                                           :out-dir   (str out-dir)})
         ;; The sandbox gets standard mounts for a scratch directory and build
         ;; output directory. It also mounts as RO each input and build input.
         sandbox-args (into [[:ro-bind src-dir src-dir]
                             [:bind out-dir out-dir]
-                            [:tmpfs jank-tmp-build-dir]
-                            [:chdir jank-tmp-build-dir]
+                            [:tmpfs build-dir]
+                            [:chdir build-dir]
                             [:net false]]
                            (map (fn [dir] [:ro-bind dir dir])
                                 (concat (vals (:inputs subtree-meta))

--- a/lein-jank/test-data/test-grandchild/project.clj
+++ b/lein-jank/test-data/test-grandchild/project.clj
@@ -5,5 +5,4 @@
             :url  "https://www.mozilla.org/en-US/MPL/2.0/"}
   :plugins [[org.jank-lang/lein-jank "0.7"]]
   :middleware [leiningen.jank/middleware]
-  :build-dependencies [[org.jank-lang/test-build-dependency "0.1.0"]]
-  :verbatim-paths ["jank-build.bb"])
+  :build-dependencies [[org.jank-lang/test-build-dependency "0.1.0"]])


### PR DESCRIPTION
- Use built-in lein argument parsing, now pass `--disable-sandbox` instead of `:disable-sandbox`
- Use a randomized /tmp build directory to avoid conflicts
- Implicitly include `jank-build.bb` in the jar if it exists in the project root