### PR TITLE
Work around lein dep resolution deduplication

### DIFF
--- a/lein-jank/src/leiningen/jank/build.clj
+++ b/lein-jank/src/leiningen/jank/build.clj
@@ -4,8 +4,8 @@
             [clojure.java.io :as io]
             [babashka.fs :as fs]
             [leiningen.core.main :as lmain]
-            [leiningen.core.classpath :as lcp]
-            [leiningen.jank.sandbox.core :as sandbox])
+            [leiningen.jank.sandbox.core :as sandbox]
+            [leiningen.jank.resolve :as resolve])
   (:import (java.security MessageDigest)
            (java.util HexFormat)
            (java.util.jar JarFile)))
@@ -187,13 +187,13 @@
   searched. Deeper build-scoped dependencies will be ignored."
   [tree]
   (->> tree
-       keys
-       (filter build-scoped?)
-       (mapv #(-> % meta :file str))))
+       (filter (fn [[k v]] (build-scoped? k)))
+       (into {})
+       (resolve/dependency-files)))
 
 (defn plan-subtree-build [build-opts target-dir [dep subtree]]
   (let [subtree-ops (vec (mapcat #(plan-subtree-build build-opts target-dir %) subtree))
-        src-jar     (:file (meta dep))
+        src-jar     (first (resolve/dependency-files {dep nil}))
         jar-name    (-> src-jar fs/file-name fs/strip-ext)]
     ;; NOTE: make sure all outputs here are pure Clojure data. We use (pr ops)
     ;; to compute a subtree hash to determine if the build has changed and needs
@@ -204,7 +204,7 @@
       ;; still may have native dependencies in the subtree.
       subtree-ops
       ;; If this is a native build then we must add its build step and all of
-      ;; the its descendant build steps.
+      ;; its descendants' build steps.
       (let [src-fprint (fingerprint-file src-jar)
             src-dir    (target-subdir target-dir "src" jar-name src-fprint)
             ;; Output is fingerprinted on the source jar contents and all of the
@@ -237,7 +237,10 @@
       (println "\u001b[1;31mBuilding with sandboxing disabled is potentially dangerous!\u001b[0m"))
 
     (assoc build-opts :operations
-           (let [tree     (lcp/managed-dependency-hierarchy :dependencies :managed-dependencies project)
+           (let [tree     (->> (mapv #(resolve/dependency-hierarchy project %) (:dependencies project))
+                               (apply merge))
+                 ;; Plan the build steps just for the child dependencies,
+                 ;; recursively resolving their dependencies and so on.
                  dep-ops  (vec (mapcat #(plan-subtree-build build-opts output-dir %) tree))
                  ;; Special handling when the root project has a build script.
                  ;; 

--- a/lein-jank/src/leiningen/jank/resolve.clj
+++ b/lein-jank/src/leiningen/jank/resolve.clj
@@ -1,0 +1,51 @@
+(ns leiningen.jank.resolve
+  (:require [leiningen.core.classpath :refer [default-aether-args]]
+            [cemerick.pomegranate.aether :as aether]))
+
+(defn dependency-hierarchy
+  "Resolve the full dependency tree from a given root coordinate. All tree
+  entries are annotated with aether metadata.
+
+  This is like `aether/dependency-hierarchy`, but it does not perform
+  deduplication on the tree. If the same dependency in two or more subtrees
+  (even the same version), they will remain in the tree returned here."
+  [project dep]
+  (let [opts          (merge (default-aether-args project) {:coordinates [dep]})
+        full-tree     (aether/resolve-dependencies opts)
+        dep-with-meta (first (filter #{dep} (keys full-tree)))]
+    (when dep-with-meta
+      {dep-with-meta
+       (->> (get full-tree dep)
+            (mapv (fn [d] [d (-> (dependency-hierarchy opts d) vals first)]))
+            (into {}))})))
+
+(defn dependency-files
+  "For a dependency tree, resolve all of the artifact paths, returned as a
+  sequence of string paths.
+
+  NOTE: The coordinates must be augmented with aether metadata returned by e.g.
+  `resolve-tree`."
+  [tree]
+  (let [top-deps  (mapv str (aether/dependency-files tree))
+        rest-deps (mapv dependency-files (vals tree))]
+    (apply concat top-deps rest-deps)))
+
+(comment
+  (require 'leiningen.core.project)
+  (def project (leiningen.core.project/read "test-data/test-parent/project.clj"))
+
+  (dependency-hierarchy project '[org.jank-lang.commons/imgui-sys "2026.06-1"])
+  ;; => {[org.jank-lang.commons/imgui-sys "2026.06-1"]
+  ;;     {[org.jank-lang.commons/jank-build-cmake "2026.06-1" :scope "jank-build"] {},
+  ;;      [org.jank-lang.commons/gl-sys "2026.06-1"] {[org.jank-lang.commons/jank-build-pkg-config "2026.06-1" :scope "jank-build"] {}},
+  ;;      [org.jank-lang.commons/glfw-sys "2026.06-1"] {[org.jank-lang.commons/jank-build-pkg-config "2026.06-1" :scope "jank-build"] {}}}}
+
+  (->> (dependency-hierarchy project '[org.jank-lang.commons/imgui-sys "2026.06-1"])
+       (dependency-files))
+  ;; => ("/home/kyle/.m2/repository/org/jank-lang/commons/imgui-sys/2026.06-1/imgui-sys-2026.06-1.jar"
+  ;;     "/home/kyle/.m2/repository/org/jank-lang/commons/jank-build-cmake/2026.06-1/jank-build-cmake-2026.06-1.jar"
+  ;;     "/home/kyle/.m2/repository/org/jank-lang/commons/gl-sys/2026.06-1/gl-sys-2026.06-1.jar"
+  ;;     "/home/kyle/.m2/repository/org/jank-lang/commons/glfw-sys/2026.06-1/glfw-sys-2026.06-1.jar"
+  ;;     "/home/kyle/.m2/repository/org/jank-lang/commons/jank-build-pkg-config/2026.06-1/jank-build-pkg-config-2026.06-1.jar"
+  ;;     "/home/kyle/.m2/repository/org/jank-lang/commons/jank-build-pkg-config/2026.06-1/jank-build-pkg-config-2026.06-1.jar")
+  )

--- a/lein-jank/test-data/test-grandchild2/jank-build.bb
+++ b/lein-jank/test-data/test-grandchild2/jank-build.bb
@@ -1,0 +1,3 @@
+(require '[test-build-dependency.core :as tbd])
+
+(tbd/hello)

--- a/lein-jank/test-data/test-grandchild2/project.clj
+++ b/lein-jank/test-data/test-grandchild2/project.clj
@@ -1,9 +1,8 @@
-(defproject org.jank-lang/test-child "0.1.0"
+(defproject org.jank-lang/test-grandchild2 "0.1.0"
   :description "FIXME: write description"
   :url "https://example.com/FIXME"
   :license {:name "MPL 2.0"
             :url  "https://www.mozilla.org/en-US/MPL/2.0/"}
   :plugins [[org.jank-lang/lein-jank "0.7"]]
   :middleware [leiningen.jank/middleware]
-  :dependencies [[org.jank-lang/test-grandchild "0.1.0"]
-                 [org.jank-lang/test-grandchild2 "0.1.0"]])
+  :build-dependencies [[org.jank-lang/test-build-dependency "0.1.0"]])

--- a/lein-jank/test/leiningen/jank/integration_test.clj
+++ b/lein-jank/test/leiningen/jank/integration_test.clj
@@ -18,6 +18,7 @@
 (def parent-project (load-project "test-data/test-parent/project.clj"))
 (def child-project (load-project "test-data/test-child/project.clj"))
 (def grandchild-project (load-project "test-data/test-grandchild/project.clj"))
+(def grandchild2-project (load-project "test-data/test-grandchild2/project.clj"))
 (def build-dependency-project (load-project "test-data/test-build-dependency/project.clj"))
 
 ;; Children need to be installed into the maven cache to be properly picked up
@@ -26,6 +27,7 @@
   (binding [build/*disable-sandbox* true]
     (install build-dependency-project)
     (install grandchild-project)
+    (install grandchild2-project)
     (install child-project)
     (install parent-project)
     (f)))
@@ -48,7 +50,11 @@
                  {:op           :compile
                   :dep          '[org.jank-lang/test-grandchild "0.1.0"]
                   :build-inputs [(m/regex #".*\.jar")]
-                  :inputs       (m/equals {})}]
+                  :inputs       (m/equals {})}
+                 {:op  :extract-src
+                  :dep '[org.jank-lang/test-grandchild2 "0.1.0"]}
+                 {:op  :compile
+                  :dep '[org.jank-lang/test-grandchild2 "0.1.0"]}]
                 ops))))
 
 (deftest plan-build-with-root-jank-build-test


### PR DESCRIPTION
If you have an actual dep tree like this:

```
 [my-gl-demo "2026.06-1"]
   [org.jank-lang.commons/gl-sys "2026.06-1"]
     [org.jank-lang.commons/jank-build-pkg-config "2026.06-1" :scope "jank-build"]
   [org.jank-lang.commons/glfw-sys "2026.06-1"]
     [org.jank-lang.commons/jank-build-pkg-config "2026.06-1" :scope "jank-build"]
```

Then `lein deps :tree` and also lein's internal dependency resolution functions will perform some deduplication on the tree and give you this:

```
 [my-gl-demo "2026.06-1"]
   [org.jank-lang.commons/gl-sys "2026.06-1"]
   [org.jank-lang.commons/glfw-sys "2026.06-1"]
     [org.jank-lang.commons/jank-build-pkg-config "2026.06-1" :scope "jank-build"]
```

Presumably this is to prevent duplicate classpath entires on the JVM (?). For jank, this causes the build to fail because gl-sys will not have its necessary build inputs. This PR updates the dependency resolution logic to use aether directly and avoid the deduplication. Adds a test with this duplicated structure to verify.

This fix can result in some duplicate flags passed to jank (e.g. `-lGL -lGL`), but I don't think this is a problem.