### PR TITLE
Fully qualify symbol for `resolve`

### DIFF
--- a/compiler+runtime/src/cpp/jank/runtime/ns.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/ns.cpp
@@ -119,7 +119,8 @@ namespace jank::runtime
   {
     if(!sym->ns.empty())
     {
-      return __rt_ctx->find_var(sym);
+      auto const qualified_sym(__rt_ctx->qualify_symbol(sym));
+      return __rt_ctx->find_var(qualified_sym);
     }
 
     auto const locked_vars(vars.rlock());


### PR DESCRIPTION
In trying to enable some of the [clojure.string tests in clojure-test-suite](https://github.com/jank-lang/clojure-test-suite/tree/main/test/clojure/string_test) for https://github.com/jank-lang/jank/pull/819, I noticed that the tests kept getting skipped due to [when-var-exists](https://github.com/jank-lang/clojure-test-suite/blob/main/test/clojure/core_test/portability.cljc#L10). It appears we need to qualify the symbol before we try to look it up.

Before:
```clojure
% jank repl
nREPL server started on port 44158 on host 127.0.0.1 - nrepl://127.0.0.1:44158
user=> (require '[clojure.string :as str])
nil
user=> (resolve 'str/upper-case)
nil
```

After:
```clojure
% jank repl
nREPL server started on port 44994 on host 127.0.0.1 - nrepl://127.0.0.1:44994
user=> (require '[clojure.string :as str])
nil
user=> (resolve 'str/upper-case)
#'clojure.string/upper-case
```

Clojure:
```clojure
% clj
Clojure 1.12.2
user=> (require '[clojure.string :as str])
nil
user=> (resolve 'str/upper-case)
#'clojure.string/upper-case
```