### PR TITLE
Fix `random-uuid` and enable tests

### DIFF
--- a/compiler+runtime/src/cpp/jank/runtime/obj/uuid.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/uuid.cpp
@@ -9,9 +9,8 @@ namespace jank::runtime::obj
 {
   static jtl::ref<uuids::uuid> random()
   {
-    static std::random_device rd;
-    std::mt19937 g(rd());
-    uuids::uuid_random_generator gen{ g };
+    thread_local std::mt19937 g(std::random_device{}());
+    thread_local uuids::uuid_random_generator gen{ g };
     return jtl::make_ref<uuids::uuid>(gen());
   }
 

--- a/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
+++ b/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
@@ -160,7 +160,7 @@
     clojure.core-test.rand-int
     clojure.core-test.rand-nth
     clojure.core-test.random-sample
-    ; clojure.core-test.random-uuid ; FIXME: Failing test.
+    clojure.core-test.random-uuid
     ; clojure.core-test.ratio-qmark ; FIXME: Failing test.
     ; clojure.core-test.rational-qmark ; FIXME: Failing test.
     ; clojure.core-test.rationalize ; TODO: port rationalize


### PR DESCRIPTION
My best guess as to why the tests **sometimes** failed on duplicates in `clojure.core-test.random-uuid` is because the `uuids::uuid_random_generator` is being re-constructed in the same state twice, yielding a duplicate uuid. By preserving the state of `uuids::uuid_random_generator`, we can avoid this this edge case. Also, since we are dealing with mutable state, potentialy across threads, I went for `thread_local` since generating a uuid shouldn't require coordination. I haven't used it before, please let me know if I am not using it correctly.

Before:
```clojure
nREPL server started on port 43508 on host 127.0.0.1 - nrepl://127.0.0.1:43508
user=> (count (set (repeatedly 10 random-uuid)))
9
user=> (count (set (repeatedly 10 random-uuid)))
8
user=> (count (set (repeatedly 10 random-uuid)))
8
user=> (count (set (repeatedly 10 random-uuid)))
10
user=> (count (set (repeatedly 10 random-uuid)))
9
```

After:
```clojure
% jank repl
nREPL server started on port 44022 on host 127.0.0.1 - nrepl://127.0.0.1:44022
user=> (count (set (repeatedly 10 random-uuid)))
10
user=> (count (set (repeatedly 10 random-uuid)))
10
user=> (count (set (repeatedly 10 random-uuid)))
10
user=> (count (set (repeatedly 10 random-uuid)))
10
user=> (count (set (repeatedly 10 random-uuid)))
10
```