### PR TITLE
Set executable runpath to include all library dirs

### DIFF
--- a/compiler+runtime/src/cpp/jank/aot/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/aot/processor.cpp
@@ -375,6 +375,11 @@ int main(int argc, const char** argv)
     compiler_args.push_back(strdup("-lpthread"));
 #endif
 
+    for(auto const &library_dir : util::cli::opts.library_dirs)
+    {
+      compiler_args.push_back(strdup(util::format("-Wl,-rpath,{}", library_dir).c_str()));
+    }
+
     for(auto const &lib : util::cli::opts.libs)
     {
       compiler_args.push_back(strdup(util::format("-l{}", lib).c_str()));


### PR DESCRIPTION
Allows executables to find the shared libraries with which they were compiled without needing to manually set `LD_LIBRARY_PATH`.

Tested with an imgui hello world project, which now automatically locates `libimgui.so` etc. from the `target/` directory.