### PR TITLE
Improve jank-build input change detection/caching

### DIFF
--- a/lein-jank/src/leiningen/jank.clj
+++ b/lein-jank/src/leiningen/jank.clj
@@ -14,6 +14,9 @@
   (let [[args extra] (lmain/parse-options args)
         opts         (reduce (fn [opts arg]
                                (case arg
+                                 [:--verbose-build true]
+                                 (assoc opts :verbose-build true)
+
                                  [:--disable-sandbox true]
                                  (assoc opts :disable-sandbox true)
 
@@ -23,7 +26,8 @@
     [opts extra]))
 
 (defn native-build [project opts]
-  (binding [ljb/*disable-sandbox* (or ljb/*disable-sandbox* (:disable-sandbox opts))]
+  (binding [ljb/*disable-sandbox* (or ljb/*disable-sandbox* (:disable-sandbox opts))
+            ljb/*verbose-build*   (:verbose-build opts)]
     (let [native-flags (ljb/run-build! (ljb/plan-build project))]
       (update project :jank ljb/merge-native-flags native-flags))))
 

--- a/lein-jank/src/leiningen/jank.clj
+++ b/lein-jank/src/leiningen/jank.clj
@@ -14,9 +14,6 @@
   (let [[args extra] (lmain/parse-options args)
         opts         (reduce (fn [opts arg]
                                (case arg
-                                 [:--verbose-build true]
-                                 (assoc opts :verbose-build true)
-
                                  [:--disable-sandbox true]
                                  (assoc opts :disable-sandbox true)
 
@@ -27,7 +24,7 @@
 
 (defn native-build [project opts]
   (binding [ljb/*disable-sandbox* (or ljb/*disable-sandbox* (:disable-sandbox opts))
-            ljb/*verbose-build*   (:verbose-build opts)]
+            ljb/*verbose-build*   @ljc/verbose?]
     (let [native-flags (ljb/run-build! (ljb/plan-build project))]
       (update project :jank ljb/merge-native-flags native-flags))))
 

--- a/lein-jank/src/leiningen/jank/build.clj
+++ b/lein-jank/src/leiningen/jank/build.clj
@@ -7,19 +7,21 @@
             [leiningen.jank.sandbox.core :as sandbox]
             [leiningen.jank.resolve :as resolve])
   (:import (java.security MessageDigest)
-           (java.util HexFormat)
+           (java.util Base64)
            (java.util.jar JarFile)))
 
 (def ^:dynamic *disable-sandbox* false)
+
+(def ^:dynamic *verbose-build* false)
 
 (def jank-build-file "jank-build.bb")
 (def jank-build-cache-file "jank-build-cache.txt")
 
 (def default-build-opts
   {:target-dir         "target"
-   :optimization-level 2
-   :static-build       true
-   :verbose-build      false})
+   :optimization-level 3
+   ;; TODO: enable when jank can link to .a files via -L and -l flags.
+   :static-build       false})
 
 (defn merge-native-flags
   ([] {})
@@ -46,6 +48,13 @@
   [file out-dir]
   (fs/unzip file out-dir {:replace-existing true}))
 
+(defn base64
+  "Modified base64 encoding which is safe for URLs/file paths."
+  [^bytes bs]
+  (let [enc (-> (Base64/getUrlEncoder)
+                .withoutPadding)]
+    (.encodeToString enc bs)))
+
 (defn fingerprint
   "Compute a fingerprint of the dependency. When the fingerprint changes (due to
   some change in the descendant dependencies or environment) the dependency
@@ -55,20 +64,20 @@
   ;; react to changes in the environment:
   ;;
   ;; https://doc.rust-lang.org/nightly/nightly-rustc/cargo/core/compiler/fingerprint/index.html
-  (let [md     (MessageDigest/getInstance "SHA-256")
+  (let [md     (MessageDigest/getInstance "MD5")
         baos   (java.io.ByteArrayOutputStream.)]
     (with-open [writer (io/writer baos)]
       (binding [*out* writer]
         (pr data)))
     (.update md (.toByteArray baos))
-    (.formatHex (HexFormat/of) (.digest md))))
+    (base64 (.digest md))))
 
-(defn fingerprint-file [f]
-  (let [md     (MessageDigest/getInstance "SHA-256")
-        _      (doto md
-                 (.update (fs/read-all-bytes f)))
-        digest (.digest md)]
-    (.formatHex (HexFormat/of) digest)))
+(defn fingerprint-file
+  "Like `fingerprint` but for the contents of a file."
+  [f]
+  (let [md (MessageDigest/getInstance "MD5")]
+    (.update md (fs/read-all-bytes f))
+    (base64 (.digest md))))
 
 (defn target-subdir
   "Returns a path located in the target directory which is unique based on the
@@ -106,6 +115,23 @@
       (when echo (println (str prefix " " line)))
       (swap! lines-atom conj line))))
 
+(defn build-script-input
+  "Filter the build operation keys which will be forwarded to the jank-build.bb
+  script. This establishes the contract for the data shape which should be
+  expected by a build script. "
+  [build-op]
+  (let [{:keys [src-dir build-dir out-dir inputs build-inputs]} build-op
+        {:keys [optimization-level static-build]}               (:build-opts build-op)]
+    ;; NOTE: spell these out so this can be used as a reference for build script
+    ;; authors. This will be the *input* value in the build script.
+    {:src-dir            src-dir
+     :build-dir          build-dir
+     :out-dir            out-dir
+     :inputs             inputs
+     :build-inputs       build-inputs
+     :optimization-level optimization-level
+     :static-build       static-build}))
+
 (defn build-dep!
   "Run a sandboxed (unless disable-sandbox is set) build on the dependency
   located at `src-dir`, and instruct the build script to place artifacts in the
@@ -120,13 +146,11 @@
 
   The result will be a cached build result file located at
   `out-dir/jank-build-cache.txt` plus the artifacts of the build in `out-dir`."
-  [src-dir out-dir subtree-meta]
+  [{:keys [src-dir out-dir] :as op}]
   (fs/create-dirs out-dir)
-  (let [dep-name     (first (:dep subtree-meta))
+  (let [dep-name     (first (:dep op))
         build-dir    (fs/create-temp-dir {:prefix "jank-build-"})
-        build-meta   (merge subtree-meta {:src-dir   (str src-dir)
-                                          :build-dir (str build-dir)
-                                          :out-dir   (str out-dir)})
+        op           (assoc op :build-dir (str build-dir))
         ;; The sandbox gets standard mounts for a scratch directory and build
         ;; output directory. It also mounts as RO each input and build input.
         sandbox-args (into [[:ro-bind src-dir src-dir]
@@ -135,22 +159,23 @@
                             [:chdir build-dir]
                             [:net false]]
                            (map (fn [dir] [:ro-bind dir dir])
-                                (concat (vals (:inputs subtree-meta))
-                                        (:build-inputs subtree-meta))))
+                                (concat (vals (:inputs op))
+                                        (:build-inputs op))))
         ;; Pass `bb --stream` and provide the EDN-formatted build metadata on
         ;; stdin so that it is available in the build script on `*input*`.
         ;; Include all build input jars into the classpath.
-        bb-classpath (string/join ":" (:build-inputs subtree-meta))
+        bb-classpath (string/join ":" (:build-inputs op))
+        build-input  (build-script-input op)
         proc         (sandbox/process
                       (not *disable-sandbox*)
                       sandbox-args
                       ["bb" "--classpath" bb-classpath "--stream" (fs/path src-dir jank-build-file)]
-                      {:in       (pr-str build-meta)
+                      {:in       (pr-str build-input)
                        :continue true})
         out-lines    (atom [])]
-    (future (wrap-stream (:out proc) out-lines {:echo   (:verbose-build subtree-meta)
+    (future (wrap-stream (:out proc) out-lines {:echo   *verbose-build*
                                                 :prefix (str "  \u001b[0;34m" dep-name ">\u001b[0m")}))
-    (future (wrap-stream (:err proc) out-lines {:echo   (:verbose-build subtree-meta)
+    (future (wrap-stream (:err proc) out-lines {:echo   *verbose-build*
                                                 :prefix (str "  \u001b[0;31m" dep-name ">\u001b[0m")}))
     (if (zero? (:exit @proc))
       ;; Build succeeded. Cache all of the build stdout output. Later we will
@@ -159,7 +184,7 @@
       ;; Build failed. Echo stdout/stderr on build failure, only when it was not
       ;; already live-echoed above. Abort the build.
       (do
-        (when-not (:verbose-build subtree-meta)
+        (when-not *verbose-build*
           (println (string/join "\n" @out-lines))
           (println (string/join "\n" @out-lines)))
         (lmain/abort "failed to run build command")))))
@@ -205,25 +230,25 @@
       subtree-ops
       ;; If this is a native build then we must add its build step and all of
       ;; its descendants' build steps.
-      (let [src-fprint (fingerprint-file src-jar)
+      (let [extract-op {:op  :extract-src
+                        :dep dep
+                        :jar (str src-jar)}
+            src-fprint (fingerprint-file src-jar)
             src-dir    (target-subdir target-dir "src" jar-name src-fprint)
             ;; Output is fingerprinted on the source jar contents and all of the
             ;; build steps which produce its descendant outputs. If any of these
             ;; change then a fresh build is triggered.
-            out-fprint (fingerprint subtree-ops)
+            compile-op {:op           :compile
+                        :dep          dep
+                        :src-dir      (str src-dir)
+                        :build-inputs (collect-build-deps subtree)
+                        :inputs       (collect-out-dirs subtree-ops)
+                        :build-opts   build-opts}
+            out-fprint (fingerprint compile-op)
             out-dir    (target-subdir target-dir "out" jar-name out-fprint)]
         (into subtree-ops
-              [{:op     :extract-src
-                :dep    dep
-                :jar    (str src-jar)
-                :fprint (fingerprint-file src-jar)
-                :dir    (str src-dir)}
-               {:op           :compile
-                :dep          dep
-                :src-dir      (str src-dir)
-                :out-dir      (str out-dir)
-                :build-inputs (collect-build-deps subtree)
-                :inputs       (collect-out-dirs subtree-ops)}])))))
+              [(assoc extract-op :dir (str src-dir))
+               (assoc compile-op :out-dir (str out-dir))])))))
 
 (defn plan-build
   "Compute a build plan, i.e. a linear sequence of operations, which will
@@ -232,30 +257,32 @@
   Returns a map, including the build operations and additional build metadata,
   which can be executed by `run-build!`."
   [project]
-  (let [{:keys [target-dir] :as build-opts} (merge default-build-opts (:jank project))]
+  (let [build-opts (merge default-build-opts (:jank project))
+        target-dir (:target-dir build-opts)]
     (when *disable-sandbox*
       (println "\u001b[1;31mBuilding with sandboxing disabled is potentially dangerous!\u001b[0m"))
 
-    (assoc build-opts :operations
-           (let [tree     (->> (mapv #(resolve/dependency-hierarchy project %) (:dependencies project))
-                               (apply merge))
-                 ;; Plan the build steps just for the child dependencies,
-                 ;; recursively resolving their dependencies and so on.
-                 dep-ops  (vec (mapcat #(plan-subtree-build build-opts target-dir %) tree))
-                 ;; Special handling when the root project has a build script.
-                 ;; 
-                 ;; TODO: For now we always run the root build script, but we
-                 ;; could cache it if we knew its input files. Cargo does this
-                 ;; by outputting rerun-if-changed flags from the build script.
-                 root-ops (when (has-build-file? (:root project))
-                            [{:op           :compile
-                              :dep          [(symbol (:group project) (:name project)) (:version project)]
-                              :src-dir      (str (:root project))
-                              :out-dir      (str (target-subdir target-dir "out" (:name project) "XXX"))
-                              :build-inputs (collect-build-deps tree)
-                              :inputs       (collect-out-dirs dep-ops)
-                              :always-build true}])]
-             (into dep-ops root-ops)))))
+    {:operations
+     (let [tree     (->> (mapv #(resolve/dependency-hierarchy project %) (:dependencies project))
+                         (apply merge))
+           ;; Plan the build steps just for the child dependencies,
+           ;; recursively resolving their dependencies and so on.
+           dep-ops  (vec (mapcat #(plan-subtree-build build-opts target-dir %) tree))
+           ;; Special handling when the root project has a build script.
+           ;; 
+           ;; TODO: For now we always run the root build script, but we
+           ;; could cache it if we knew its input files. Cargo does this
+           ;; by outputting rerun-if-changed flags from the build script.
+           root-ops (when (has-build-file? (:root project))
+                      [{:op           :compile
+                        :dep          [(symbol (:group project) (:name project)) (:version project)]
+                        :src-dir      (str (:root project))
+                        :out-dir      (str (target-subdir target-dir "out" (:name project) "XXX"))
+                        :build-opts   build-opts
+                        :build-inputs (collect-build-deps tree)
+                        :inputs       (collect-out-dirs dep-ops)
+                        :always-build true}])]
+       (into dep-ops root-ops))}))
 
 (defmulti run-build-op! (fn [_ op] (:op op)))
 
@@ -270,11 +297,11 @@
   nil)
 
 (defmethod run-build-op! :compile
-  [plan {:keys [dep src-dir out-dir build-inputs inputs always-build]}]
+  [plan {:keys [dep out-dir always-build] :as op}]
   (let [needs-build? (or always-build (not (is-already-built? out-dir)))]
     (when needs-build?
       (println (str "\u001b[1;32m" (format "%10s" "Compiling") "\u001b[0m") dep)
-      (build-dep! src-dir out-dir (assoc plan :dep dep :inputs inputs :build-inputs build-inputs)))
+      (build-dep! op))
 
     ;; jank flags are extracted from the build cache file
     (process-build-directives (fs/read-all-lines (fs/path out-dir jank-build-cache-file)))))

--- a/lein-jank/src/leiningen/jank/build.clj
+++ b/lein-jank/src/leiningen/jank/build.clj
@@ -147,6 +147,7 @@
   The result will be a cached build result file located at
   `out-dir/jank-build-cache.txt` plus the artifacts of the build in `out-dir`."
   [{:keys [src-dir out-dir] :as op}]
+  (fs/delete-tree out-dir)
   (fs/create-dirs out-dir)
   (let [dep-name     (first (:dep op))
         build-dir    (fs/create-temp-dir {:prefix "jank-build-"})

--- a/lein-jank/src/leiningen/jank/build.clj
+++ b/lein-jank/src/leiningen/jank/build.clj
@@ -24,9 +24,10 @@
    :static-build       false})
 
 (defn merge-native-flags
-  [& maps]
-  (let [valid-keys [:defines :include-dirs :library-dirs :linked-libraries]]
-    (reduce (fn [a b] (merge-with into a (select-keys b valid-keys))) {} maps)))
+  ([] {})
+  ([& maps]
+   (let [valid-keys [:defines :include-dirs :library-dirs :linked-libraries]]
+     (reduce (fn [a b] (merge-with into a (select-keys b valid-keys))) maps))))
 
 (defn has-build-file?
   "Returns true if the given directory or jar file has a `jank-build.bb` file in

--- a/lein-jank/src/leiningen/jank/build.clj
+++ b/lein-jank/src/leiningen/jank/build.clj
@@ -24,10 +24,9 @@
    :static-build       false})
 
 (defn merge-native-flags
-  ([] {})
-  ([& maps]
-   (let [valid-keys [:defines :include-dirs :library-dirs :linked-libraries]]
-     (reduce (fn [a b] (merge-with into a (select-keys b valid-keys))) maps))))
+  [& maps]
+  (let [valid-keys [:defines :include-dirs :library-dirs :linked-libraries]]
+    (reduce (fn [a b] (merge-with into a (select-keys b valid-keys))) {} maps)))
 
 (defn has-build-file?
   "Returns true if the given directory or jar file has a `jank-build.bb` file in
@@ -38,10 +37,10 @@
     (with-open [jar (JarFile. path)]
       (some? (.getEntry jar jank-build-file)))))
 
-(defn is-already-built?
+(defn has-build-cache-file?
   "Returns true if the given directory has a jank build cache file."
-  [out-dir]
-  (fs/regular-file? (fs/path out-dir jank-build-cache-file)))
+  [path]
+  (fs/regular-file? (fs/path path jank-build-cache-file)))
 
 (defn extract-jar!
   "Extract the jar file into `out-dir`, creating it if it does not exist."
@@ -56,9 +55,7 @@
     (.encodeToString enc bs)))
 
 (defn fingerprint
-  "Compute a fingerprint of the dependency. When the fingerprint changes (due to
-  some change in the descendant dependencies or environment) the dependency
-  needs to be recompiled."
+  "Compute a fingerprint of some printable data structure."
   [data]
   ;; TODO: We should implement something like Cargo's fingerprint to better
   ;; react to changes in the environment:
@@ -87,32 +84,26 @@
       (fs/path "_cache" (str dep-name "-" type "-" fprint))
       fs/absolutize))
 
-(defn process-build-directives
-  "Process a sequence of output lines from a build script, parsing those that
-  begin with the jank-build:: prefix and discarding all others."
-  [lines]
-  (->>
-   (for [line  lines
-         :when (and (string/starts-with? line "jank-build::")
-                    (string/includes? line "="))
-         :let  [[k v] (string/split line #"=" 2)]]
-     (case k
-       "jank-build::define"       (let [[a b] (string/split v #"=" 2)]
-                                    {:defines {a b}})
-       "jank-build::include-dir"  {:include-dirs [v]}
-       "jank-build::link-dir"     {:library-dirs [v]}
-       "jank-build::link-library" {:linked-libraries [v]}
-       (do (lmain/warn "invalid jank-build directive:" k)
-           nil)))
-   (remove nil?)))
+(defn process-build-directive
+  "Process an output line from a build script, parsing it if it begins with the
+  jank-build:: prefix. Otherwise returns nil. "
+  [line]
+  (when-let [[_ k v] (re-matches #"jank-build::(.*?)=(.*)" line)]
+    (case k
+      "define"       (let [[a b] (string/split v #"=" 2)] {:defines {a b}})
+      "include-dir"  {:include-dirs [v]}
+      "link-dir"     {:library-dirs [v]}
+      "link-library" {:linked-libraries [v]}
+      (do (lmain/warn "invalid jank-build directive:" line)
+          nil))))
 
 (defn wrap-stream
   "Wrap an IO stream, redirecting the output to stdout with a prefix. Returns a
   vector of the recorded lines (without the prefix)."
-  [stream lines-atom {:keys [prefix echo]}]
+  [stream lines-atom echo? prefix]
   (with-open [rdr (io/reader stream)]
     (doseq [line (line-seq rdr)]
-      (when echo (println (str prefix " " line)))
+      (when echo? (println (str prefix " " line)))
       (swap! lines-atom conj line))))
 
 (defn build-script-input
@@ -174,10 +165,8 @@
                       {:in       (pr-str build-input)
                        :continue true})
         out-lines    (atom [])]
-    (future (wrap-stream (:out proc) out-lines {:echo   *verbose-build*
-                                                :prefix (str "  \u001b[0;34m" dep-name ">\u001b[0m")}))
-    (future (wrap-stream (:err proc) out-lines {:echo   *verbose-build*
-                                                :prefix (str "  \u001b[0;31m" dep-name ">\u001b[0m")}))
+    (future (wrap-stream (:out proc) out-lines *verbose-build* (str "  \u001b[0;34m" dep-name ">\u001b[0m")))
+    (future (wrap-stream (:err proc) out-lines *verbose-build* (str "  \u001b[0;31m" dep-name ">\u001b[0m")))
     (if (zero? (:exit @proc))
       ;; Build succeeded. Cache all of the build stdout output. Later we will
       ;; parse the build directives.
@@ -189,17 +178,6 @@
           (println (string/join "\n" @out-lines))
           (println (string/join "\n" @out-lines)))
         (lmain/abort "failed to run build command")))))
-
-(defn collect-out-dirs
-  "Collect the output directories from all build steps in the given operations
-  list."
-  [plan-ops]
-  (letfn [(simple-dep-name [coord] (-> coord first str))]
-    (->> plan-ops
-         (keep (fn [op] (when (:out-dir op)
-                          [(simple-dep-name (:dep op))
-                           (str (:out-dir op))])))
-         (into {}))))
 
 (defn build-scoped? [coord]
   (let [m (apply hash-map coord)]
@@ -216,6 +194,17 @@
        (filter (fn [[k v]] (build-scoped? k)))
        (into {})
        (resolve/dependency-files)))
+
+(defn collect-out-dirs
+  "Collect the output directories from all build steps in the given operations
+  list."
+  [plan-ops]
+  (letfn [(simple-dep-name [coord] (-> coord first str))]
+    (->> plan-ops
+         (keep (fn [op] (when (:out-dir op)
+                          [(simple-dep-name (:dep op))
+                           (str (:out-dir op))])))
+         (into {}))))
 
 (defn plan-subtree-build [build-opts target-dir [dep subtree]]
   (let [subtree-ops (vec (mapcat #(plan-subtree-build build-opts target-dir %) subtree))
@@ -248,7 +237,7 @@
             out-fprint (fingerprint compile-op)
             out-dir    (target-subdir target-dir "out" jar-name out-fprint)]
         (into subtree-ops
-              [(assoc extract-op :dir (str src-dir))
+              [(assoc extract-op :out-dir (str src-dir))
                (assoc compile-op :out-dir (str out-dir))])))))
 
 (defn plan-build
@@ -263,53 +252,58 @@
     (when *disable-sandbox*
       (println "\u001b[1;31mBuilding with sandboxing disabled is potentially dangerous!\u001b[0m"))
 
-    {:operations
-     (let [tree     (->> (mapv #(resolve/dependency-hierarchy project %) (:dependencies project))
-                         (apply merge))
+    (let [tree     (->> (mapv #(resolve/dependency-hierarchy project %) (:dependencies project))
+                        (apply merge))
            ;; Plan the build steps just for the child dependencies,
            ;; recursively resolving their dependencies and so on.
-           dep-ops  (vec (mapcat #(plan-subtree-build build-opts target-dir %) tree))
+          dep-ops  (vec (mapcat #(plan-subtree-build build-opts target-dir %) tree))
            ;; Special handling when the root project has a build script.
            ;; 
            ;; TODO: For now we always run the root build script, but we
            ;; could cache it if we knew its input files. Cargo does this
            ;; by outputting rerun-if-changed flags from the build script.
-           root-ops (when (has-build-file? (:root project))
-                      [{:op           :compile
-                        :dep          [(symbol (:group project) (:name project)) (:version project)]
-                        :src-dir      (str (:root project))
-                        :out-dir      (str (target-subdir target-dir "out" (:name project) "XXX"))
-                        :build-opts   build-opts
-                        :build-inputs (collect-build-deps tree)
-                        :inputs       (collect-out-dirs dep-ops)
-                        :always-build true}])]
-       (into dep-ops root-ops))}))
+          root-ops (when (has-build-file? (:root project))
+                     [{:op           :compile
+                       :dep          [(symbol (:group project) (:name project)) (:version project)]
+                       :src-dir      (str (:root project))
+                       :out-dir      (str (target-subdir target-dir "out" (:name project) "XXX"))
+                       :build-opts   build-opts
+                       :build-inputs (collect-build-deps tree)
+                       :inputs       (collect-out-dirs dep-ops)
+                       :always-build true}])]
+      (into dep-ops root-ops))))
 
 (defmulti run-build-op! (fn [_ op] (:op op)))
 
 (defmethod run-build-op! :extract-src
-  [plan {:keys [dep jar dir]}]
+  [plan {:keys [dep jar out-dir]}]
   ;; If the output dir already exists then the jar has already been extracted.
-  (when-not (fs/exists? dir)
+  ;; Since the out-dir name includes the jar fingerprint, we know that the
+  ;; contents will be the same and we can skip the step.
+  (when-not (fs/exists? out-dir)
     (println (str "\u001b[1;36m" (format "%10s" "Extracting") "\u001b[0m") dep)
-    (extract-jar! jar dir))
+    (extract-jar! jar out-dir))
 
   ;; does not produce any jank flags
   nil)
 
 (defmethod run-build-op! :compile
   [plan {:keys [dep out-dir always-build] :as op}]
-  (let [needs-build? (or always-build (not (is-already-built? out-dir)))]
-    (when needs-build?
-      (println (str "\u001b[1;32m" (format "%10s" "Compiling") "\u001b[0m") dep)
-      (build-dep! op))
+  ;; Just like the extract-src case, if the build artifacts already exist in the
+  ;; fingerprinted output dir, then we know the inputs have not changed and
+  ;; there is no need to rebuild.
+  (when (or always-build (not (has-build-cache-file? out-dir)))
+    (println (str "\u001b[1;32m" (format "%10s" "Compiling") "\u001b[0m") dep)
+    (build-dep! op))
 
-    ;; jank flags are extracted from the build cache file
-    (process-build-directives (fs/read-all-lines (fs/path out-dir jank-build-cache-file)))))
+  ;; jank flags are extracted from the build cache file
+  (->> (fs/path out-dir jank-build-cache-file)
+       (fs/read-all-lines)
+       (keep process-build-directive)))
 
 (defn run-build!
   "Run the sequence of build steps planned by `plan-build`."
   [plan]
-  (->> (mapv #(run-build-op! plan %) (:operations plan))
+  (->> (mapv #(run-build-op! plan %) plan)
        (flatten)
        (apply merge-native-flags)))

--- a/lein-jank/test/leiningen/jank/integration_test.clj
+++ b/lein-jank/test/leiningen/jank/integration_test.clj
@@ -44,9 +44,8 @@
         ops  (:operations plan)]
     ;; Only test-grandchild has a jank-build file, so it is the only dep which
     ;; will generate build plan steps.
-    (is (match? [{:op     :extract-src
-                  :dep    '[org.jank-lang/test-grandchild "0.1.0"]
-                  :fprint string?}
+    (is (match? [{:op  :extract-src
+                  :dep '[org.jank-lang/test-grandchild "0.1.0"]}
                  {:op           :compile
                   :dep          '[org.jank-lang/test-grandchild "0.1.0"]
                   :build-inputs [(m/regex #".*\.jar")]

--- a/lein-jank/test/leiningen/jank/integration_test.clj
+++ b/lein-jank/test/leiningen/jank/integration_test.clj
@@ -40,8 +40,7 @@
   (is (true? (build/has-build-file? (:root grandchild-project)))))
 
 (deftest plan-build-test
-  (let [plan (build/plan-build parent-project)
-        ops  (:operations plan)]
+  (let [ops (build/plan-build parent-project)]
     ;; Only test-grandchild has a jank-build file, so it is the only dep which
     ;; will generate build plan steps.
     (is (match? [{:op  :extract-src
@@ -57,8 +56,7 @@
                 ops))))
 
 (deftest plan-build-with-root-jank-build-test
-  (let [plan (build/plan-build grandchild-project)
-        ops  (:operations plan)]
+  (let [ops (build/plan-build grandchild-project)]
     (is (match? [;; no extract-src since we are building the root from source
                  {:op           :compile
                   :dep          '[org.jank-lang/test-grandchild "0.1.0"]

--- a/lein-jank/test/leiningen/jank/test_build.clj
+++ b/lein-jank/test/leiningen/jank/test_build.clj
@@ -1,5 +1,5 @@
 (ns leiningen.jank.test-build
-  (:require [clojure.test :refer [deftest testing is]]
+  (:require [clojure.test :refer [deftest is]]
             [babashka.fs :as fs]
             [leiningen.core.project :as proj]
             [leiningen.jank.build :as build]))
@@ -43,3 +43,16 @@
   (is (false? (build/build-scoped? '[org.jank/some-dependency "1.0.0"])))
   (is (false? (build/build-scoped? '[org.jank/some-dependency "1.0.0" :exclusions [foo] :classifier "asdf"])))
   (is (true? (build/build-scoped? '[org.jank/some-dependency "1.0.0" :scope "jank-build"]))))
+
+(deftest fingerprint
+  (is (string? (build/fingerprint [1 2 3])))
+  (is (not= (build/fingerprint [1 2 3])
+            (build/fingerprint [3 2 1])))
+  (let [f       (fs/create-temp-file)
+        fprint0 (do (fs/write-lines f ["Hello" "world"])
+                    (build/fingerprint-file f))
+        fprint1 (do (fs/write-lines f ["world" "Hello"])
+                    (build/fingerprint-file f))]
+    (is (string? fprint0))
+    (is (string? fprint1))
+    (is (not= fprint0 fprint1))))

--- a/lein-jank/test/leiningen/jank/test_build.clj
+++ b/lein-jank/test/leiningen/jank/test_build.clj
@@ -17,27 +17,13 @@
           :library-dirs ["c"]})))
 
 (deftest build-directives
-  (is (empty? (build/process-build-directives [])))
-  
-  (is (empty? (build/process-build-directives
-               ["not a build directive"
-                "also not a build directive"])))
-
-  (is (empty? (build/process-build-directives
-               ["jank-build::an-invalid-directive=123"])))
-  
-  (is (= (build/process-build-directives
-          ["jank-build::define=A=B"
-           "jank-build::include-dir=some-include-path"
-           "jank-build::include-dir=another-include-path"
-           "some text"
-           "jank-build::link-dir=a-link-path"
-           "jank-build::link-library=a-lib"])
-         [{:defines {"A" "B"}}
-          {:include-dirs ["some-include-path"]}
-          {:include-dirs ["another-include-path"]}
-          {:library-dirs ["a-link-path"]}
-          {:linked-libraries ["a-lib"]}])))
+  (is (empty? (build/process-build-directive "")))
+  (is (empty? (build/process-build-directive "not a build directive")))
+  (is (empty? (build/process-build-directive "jank-build::an-invalid-directive=123")))
+  (is (= (build/process-build-directive "jank-build::define=A=B") {:defines {"A" "B"}}))
+  (is (= (build/process-build-directive "jank-build::include-dir=some-include-path") {:include-dirs ["some-include-path"]}))
+  (is (= (build/process-build-directive "jank-build::link-dir=a-link-path") {:library-dirs ["a-link-path"]}))
+  (is (= (build/process-build-directive "jank-build::link-library=a-lib") {:linked-libraries ["a-lib"]})))
 
 (deftest build-scoped
   (is (false? (build/build-scoped? '[org.jank/some-dependency "1.0.0"])))


### PR DESCRIPTION
Fixes various issues culminating in build scripts not rerunning when they should. For example
- A JAR input changing contents, but not changing name
- Build flag changes, such as optimization level

Changes the hash computation and string encoding function to more closely match that of Nix, mostly to avoid very long path names which can cause problems on some systems.

Also establishes a predefined set of inputs which will be passed from the build system into the build script, so build script authors know what to expect.

Cleans up verbose build handling to reuse the existing -v flag. It's not a build input, so we don't want to trigger a rebuild if just that flag changes.