### PR TITLE
Fix `jank::runtime::rest`

### DIFF
--- a/compiler+runtime/include/cpp/jank/runtime/core/seq.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core/seq.hpp
@@ -39,6 +39,7 @@ namespace jank::runtime
   }
 
   object_ref next(object_ref const s);
+  object_ref more(object_ref const s);
 
   template <typename T>
   requires behavior::sequenceable_in_place<T>

--- a/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
@@ -436,6 +436,16 @@ namespace jank::runtime
       s);
   }
 
+  object_ref more(object_ref const s)
+  {
+    if(s.get_type() == object_type::cons)
+    {
+      return expect_object<obj::cons>(s)->tail;
+    }
+
+    return next(s);
+  }
+
   object_ref rest(object_ref const s)
   {
     if(s.is_nil())
@@ -449,7 +459,7 @@ namespace jank::runtime
         {
           return obj::persistent_list::empty();
         }
-        auto ret(next(seq));
+        auto ret(more(seq));
         if(ret.is_nil())
         {
           return obj::persistent_list::empty();

--- a/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
+++ b/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
@@ -221,7 +221,7 @@
     ; clojure.core-test.vector-qmark ; TODO: port array-map, TODO: port object-array
     clojure.core-test.when
     clojure.core-test.when-first
-    ; clojure.core-test.when-let ; FIXME: Failing tests.
+    clojure.core-test.when-let
     clojure.core-test.when-not
     ; clojure.core-test.with-out-str ; TODO: port with-out-str
     ; clojure.core-test.with-precision ; TODO: port with-precision, INFO: SKIP - defprotocol


### PR DESCRIPTION
So I guess [`clojure.core/rest`](https://github.com/clojure/clojure/blob/master/src/clj/clojure/core.clj#L66-L73) uses [`clojure.lang.RT/more`](https://github.com/clojure/clojure/blob/master/src/jvm/clojure/lang/RT.java#L740-L747), which by default is essentially next via [`clojure.lang.ASeq`]( https://github.com/clojure/clojure/blob/1c9fb16f6485d5c908b51158115e132beac9339e/src/jvm/clojure/lang/ASeq.java#L138-L143) except for [`clojure.lang.Cons`](https://github.com/clojure/clojure/blob/master/src/jvm/clojure/lang/Cons.java#L40-L48) which doesn't force the tail. Also, I assume you intentionally didn't include a more method, so this is the minimal change we need to support rest and laziness.

Before
```clojure
% jank repl
nREPL server started on port 44320 on host 127.0.0.1 - nrepl://127.0.0.1:44320
user=> (let [s ((fn s [] (lazy-seq (prn :x) (cons nil (s)))))] (type (rest s)))
:x
:x
"cons" ;; should be lazy seq
user=> (let [s ((fn s [] (lazy-seq (prn :x) (cons nil (s)))))] (type (next s)))
:x
:x
"cons"
user=> (take 5 ((fn s [] (lazy-seq (prn :x) (cons :foo (s))))))
:x
:x
:x
:x
:x
:x ;; head is being realized too soon
(:foo :foo :foo :foo :foo).
```

After
```clojure
% jank repl
nREPL server started on port 45162 on host 127.0.0.1 - nrepl://127.0.0.1:45162
user=> (let [s ((fn s [] (lazy-seq (prn :x) (cons nil (s)))))] (type (rest s)))
:x
"lazy_sequence"
user=> (let [s ((fn s [] (lazy-seq (prn :x) (cons nil (s)))))] (type (next s)))
:x
:x
"cons"
user=> (take 5 ((fn s [] (lazy-seq (prn :x) (cons :foo (s))))))
:x
:x
:x
:x
:x
(:foo :foo :foo :foo :foo)
```

Clojure
```clojure
% clj
Clojure 1.12.2
user=> (let [s ((fn s [] (lazy-seq (prn :x) (cons nil (s)))))] (type (rest s)))
:x
clojure.lang.LazySeq
user=> (let [s ((fn s [] (lazy-seq (prn :x) (cons nil (s)))))] (type (next s)))
:x
:x
clojure.lang.Cons
user=> (take 5 ((fn s [] (lazy-seq (prn :x) (cons :foo (s))))))
(:x
:x
:foo :x
:foo :x
:foo :x
:foo :foo) ;; jumbled print, but only 5 `:x`s total
user=> 
```