### PR TITLE
Enable `clojure.core-test.realized-qmark`

### DIFF
--- a/compiler+runtime/include/cpp/jank/runtime/core.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core.hpp
@@ -134,7 +134,7 @@ namespace jank::runtime
   object_ref remove_watch(object_ref const reference, object_ref const key);
 
   obj::future_ref future(object_ref const fn);
-  void cancel_future(obj::future_ref const future);
+  bool cancel_future(obj::future_ref const future);
   bool is_future_cancelled(obj::future_ref const future);
 
   obj::promise_ref promise();

--- a/compiler+runtime/src/cpp/jank/runtime/core.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core.cpp
@@ -971,17 +971,22 @@ namespace jank::runtime
     return ret;
   }
 
-  void cancel_future(obj::future_ref const future)
+  bool cancel_future(obj::future_ref const future)
   {
     /* We need to hold this lock the whole time we're checking, to ensure the thread
      * doesn't finish while we're here checking. */
-    auto const locked_state{ future->state.rlock() };
+    auto const locked_state{ future->state.wlock() };
     if(locked_state->status == obj::future_status::running)
     {
       auto const locked_thread{ future->thread.wlock() };
       auto const thread_handle{ locked_thread->native_handle() };
-      pthread_cancel(reinterpret_cast<pthread_t>(thread_handle));
+      if(pthread_cancel(reinterpret_cast<pthread_t>(thread_handle)) == 0)
+      {
+        locked_state->status = obj::future_status::cancelled;
+        return true;
+      }
     }
+    return false;
   }
 
   bool is_future_cancelled(obj::future_ref const future)

--- a/compiler+runtime/src/cpp/jank/runtime/obj/lazy_sequence.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/lazy_sequence.cpp
@@ -163,7 +163,7 @@ namespace jank::runtime::obj
   bool lazy_sequence::is_realized() const
   {
     std::lock_guard<std::recursive_mutex> const lock{ mutex };
-    return fn.is_some() || sv.is_some();
+    return fn.is_nil() || sv.is_some();
   }
 
   lazy_sequence_ref lazy_sequence::with_meta(object_ref const m) const

--- a/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
+++ b/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
@@ -164,7 +164,7 @@
     ; clojure.core-test.ratio-qmark ; FIXME: Failing test.
     ; clojure.core-test.rational-qmark ; FIXME: Failing test.
     ; clojure.core-test.rationalize ; TODO: port rationalize
-    ; clojure.core-test.realized-qmark ; TODO: port promise
+    clojure.core-test.realized-qmark
     ; clojure.core-test.reduce ; parse/odd-entries-in-map error: Odd number of entries in map. TODO: into-array.
     ; clojure.core-test.rem ; FIXME: Failing tests.
     ; clojure.core-test.remove-watch ; TODO: port sync


### PR DESCRIPTION
I had to update some implementation details to get the tests passing for [`clojure.core-test.realized-qmark`](https://github.com/jank-lang/clojure-test-suite/blob/main/test/clojure/core_test/realized_qmark.cljc):

- Calling `realized?` immediately after `future-cancel` on a `future` needs to return `true` if it was successful
  - the current implementation would eventually return true, but not immediately after.
- `lazy_sequence` had an incorrect implementation of `is_realized`
  - `fn.is_nil()` is `true` after the lazy-seq has been realized
- `future-cancel` should return a `bool` indicating success or failure
  - not strictly needed for the tests to pass, but a detail I observed in getting the tests working

Depends on https://github.com/jank-lang/clojure-test-suite/pull/917 for tests to work/pass.