### PR TITLE
Add initial Arch CI jobs

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -40,6 +40,7 @@ misc-definitions-in-headers,\
 -cppcoreguidelines-pro-bounds-constant-array-index,\
 -cppcoreguidelines-missing-std-forward,\
 -cppcoreguidelines-pro-bounds-avoid-unchecked-container-access,\
+-cppcoreguidelines-explicit-constructor,\
 -bugprone-easily-swappable-parameters,\
 -bugprone-reserved-identifier,\
 -bugprone-multi-level-implicit-pointer-conversion,\
@@ -48,6 +49,10 @@ misc-definitions-in-headers,\
 -bugprone-macro-parentheses,\
 -bugprone-throwing-static-initialization,\
 -bugprone-forward-declaration-namespace,\
+-bugprone-std-exception-baseclass,\
+-bugprone-signed-bitwise,\
+-readability-trailing-comma,\
+-readability-redundant-lambda-parameter-list,\
 -readability-redundant-member-init,\
 -readability-redundant-typename,\
 -readability-redundant-casting,\

--- a/.github/workflows/build-compiler+runtime.yml
+++ b/.github/workflows/build-compiler+runtime.yml
@@ -353,7 +353,16 @@ jobs:
             ./bin/configure -GNinja -DCMAKE_BUILD_TYPE=Release -Djank_local_clang=on
             ./bin/compile
             DESTDIR=inst ./bin/install
+            tar czf ~/jank-arch-x86-64.tar.gz inst
           popd
+      - name: Import SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.PPA_SSH_KEY }}" > ~/.ssh/jank_id_ed25519
+          chmod 400 ~/.ssh/jank_id_ed25519
+      - name: Publish to cache
+        run: |
+          scp -i ~/.ssh/jank_id_ed25519 -o StrictHostKeyChecking=no ~/*.tar.gz root@cache.jank-lang.org:/var/www/cache.jank-lang.org/html/
 
   #build-nix:
   #  name: "Nix - release"

--- a/.github/workflows/build-compiler+runtime.yml
+++ b/.github/workflows/build-compiler+runtime.yml
@@ -347,8 +347,8 @@ jobs:
       - name: Build and test jank
         id: jank-build-step
         run: |
-          export CC=${GITHUB_WORKSPACE}/build/llvm-install/usr/local/bin/clang;
-          export CXX=${GITHUB_WORKSPACE}/build/llvm-install/usr/local/bin/clang++
+          export CC=${GITHUB_WORKSPACE}/compiler+runtime/build/llvm-install/usr/local/bin/clang
+          export CXX=${GITHUB_WORKSPACE}/compiler+runtime/build/llvm-install/usr/local/bin/clang++
           pushd ${GITHUB_WORKSPACE}/compiler+runtime
             ./bin/configure -GNinja -DCMAKE_BUILD_TYPE=Release -Djank_local_clang=on
             DESTDIR=inst ./bin/install

--- a/.github/workflows/build-compiler+runtime.yml
+++ b/.github/workflows/build-compiler+runtime.yml
@@ -334,7 +334,7 @@ jobs:
       - name: Install packages
         run: |
           pacman -Syu --noconfirm
-          pacman --noconfirm -S gcc git pkg-config cmake ninja make python3 libffi libxml2 libedit boost
+          pacman --noconfirm -S gcc git pkg-config cmake ninja make python3 libffi libxml2 libedit boost scp
       - uses: actions/checkout@v4
         with:
           submodules: true

--- a/.github/workflows/build-compiler+runtime.yml
+++ b/.github/workflows/build-compiler+runtime.yml
@@ -351,6 +351,7 @@ jobs:
           export CXX=${GITHUB_WORKSPACE}/compiler+runtime/build/llvm-install/usr/local/bin/clang++
           pushd ${GITHUB_WORKSPACE}/compiler+runtime
             ./bin/configure -GNinja -DCMAKE_BUILD_TYPE=Release -Djank_local_clang=on
+            ./bin/compile
             DESTDIR=inst ./bin/install
           popd
 

--- a/.github/workflows/build-compiler+runtime.yml
+++ b/.github/workflows/build-compiler+runtime.yml
@@ -349,8 +349,10 @@ jobs:
         run: |
           export CC=${GITHUB_WORKSPACE}/build/llvm-install/usr/local/bin/clang;
           export CXX=${GITHUB_WORKSPACE}/build/llvm-install/usr/local/bin/clang++
-          ./bin/configure -GNinja -DCMAKE_BUILD_TYPE=Release -Djank_local_clang=on
-          DESTDIR=inst ./bin/install
+          pushd ${GITHUB_WORKSPACE}/compiler+runtime
+            ./bin/configure -GNinja -DCMAKE_BUILD_TYPE=Release -Djank_local_clang=on
+            DESTDIR=inst ./bin/install
+          popd
 
   #build-nix:
   #  name: "Nix - release"

--- a/.github/workflows/build-compiler+runtime.yml
+++ b/.github/workflows/build-compiler+runtime.yml
@@ -53,7 +53,9 @@ jobs:
 
   arch-build-clang:
     name: Arch - clang
-    runs-on: archlinux:latest
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:latest
     timeout-minutes: 200
     steps:
       - uses: actions/checkout@v4
@@ -321,7 +323,9 @@ jobs:
   publish-arch-package:
     needs:
       - arch-build-clang
-    runs-on: archlinux:latest
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:latest
     name: Publish Arch package
     timeout-minutes: 60
     steps:

--- a/.github/workflows/build-compiler+runtime.yml
+++ b/.github/workflows/build-compiler+runtime.yml
@@ -112,35 +112,6 @@ jobs:
           fi
           ${{ github.workspace }}/compiler+runtime/build/llvm-install/usr/local/bin/clang++ --version
 
-  macos-intel-build-clang:
-    name: macOS Intel - clang
-    runs-on: macos-26-intel
-    env:
-      HOMEBREW_NO_AUTO_UPDATE: 1
-    timeout-minutes: 200
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-      - name: Install Homebrew deps
-        run: |
-          brew install git pkg-config ninja python cmake gnupg zlib
-      - name: Cache Clang/LLVM
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
-        with:
-          path: |
-            ${{ github.workspace }}/compiler+runtime/build/llvm-install
-          key: clang-${{ runner.os }}-intel-${{ hashFiles('compiler+runtime/bin/build-clang') }}
-      - name: Build Clang/LLVM
-        run: |
-          if [[ ! -e ${{ github.workspace }}/compiler+runtime/build/llvm-install/usr/local/bin/clang++ ]];
-          then
-            pushd ${{ github.workspace }}/compiler+runtime
-              ./bin/build-clang
-            popd
-          fi
-          ${{ github.workspace }}/compiler+runtime/build/llvm-install/usr/local/bin/clang++ --version
-
   build-jank:
     needs:
       - ubuntu-build-clang
@@ -385,46 +356,6 @@ jobs:
             ./bin/compile
             DESTDIR=inst ./bin/install
             tar czf ~/jank-arch-x86-64.tar.gz inst
-          popd
-      - name: Import SSH key
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.PPA_SSH_KEY }}" > ~/.ssh/jank_id_ed25519
-          chmod 400 ~/.ssh/jank_id_ed25519
-      - name: Publish to cache
-        run: |
-          rsync -avz -e "ssh -i $HOME/.ssh/jank_id_ed25519 -o StrictHostKeyChecking=no" --progress ~/*.tar.gz root@cache.jank-lang.org:/var/www/cache.jank-lang.org/html/arch
-
-  publish-macos-intel-package:
-    #if: github.ref == 'refs/heads/main'
-    needs:
-      - macos-intel-build-clang
-    runs-on: macos-15-intel
-    name: Publish macOS Intel package
-    timeout-minutes: 60
-    steps:
-      - name: Install packages
-        run: |
-          brew install cmake ninja double-conversion pkg-config llvm ccache boost openssl zlib boost clojure/tools/clojure
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-      - name: Cache Clang/LLVM
-        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684
-        with:
-          path: |
-            compiler+runtime/build/llvm-install
-          key: clang-${{ runner.os }}-intel-${{ hashFiles('compiler+runtime/bin/build-clang') }}
-      - name: Build and test jank
-        id: jank-build-step
-        run: |
-          export CC=${GITHUB_WORKSPACE}/compiler+runtime/build/llvm-install/usr/local/bin/clang
-          export CXX=${GITHUB_WORKSPACE}/compiler+runtime/build/llvm-install/usr/local/bin/clang++
-          pushd ${GITHUB_WORKSPACE}/compiler+runtime
-            ./bin/configure -GNinja -DCMAKE_BUILD_TYPE=Release -Djank_local_clang=on
-            ./bin/compile
-            DESTDIR=inst ./bin/install
-            tar czf ~/jank-macos-x86-64.tar.gz inst
           popd
       - name: Import SSH key
         run: |

--- a/.github/workflows/build-compiler+runtime.yml
+++ b/.github/workflows/build-compiler+runtime.yml
@@ -51,6 +51,33 @@ jobs:
           fi
           ${{ github.workspace }}/compiler+runtime/build/llvm-install/usr/local/bin/clang++ --version
 
+  arch-build-clang:
+    name: Arch - clang
+    runs-on: archlinux/latest
+    timeout-minutes: 200
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install packages
+        run: |
+          pacman -S gcc git git-lfs pkg-config cmake ninja make python3 libffi entr libxml2 libedit boost
+      - name: Cache Clang/LLVM
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            ${{ github.workspace }}/compiler+runtime/build/llvm-install
+          key: clang-${{ runner.os }}-${{ hashFiles('compiler+runtime/bin/build-clang') }}
+      - name: Build Clang/LLVM
+        run: |
+          if [[ ! -e ${{ github.workspace }}/compiler+runtime/build/llvm-install/usr/local/bin/clang++ ]];
+          then
+            pushd ${{ github.workspace }}/compiler+runtime
+              ./bin/build-clang
+            popd
+          fi
+          ${{ github.workspace }}/compiler+runtime/build/llvm-install/usr/local/bin/clang++ --version
+
   macos-build-clang:
     name: macOS - clang
     runs-on: macos-26
@@ -80,122 +107,228 @@ jobs:
           fi
           ${{ github.workspace }}/compiler+runtime/build/llvm-install/usr/local/bin/clang++ --version
 
-  build-jank:
-    needs:
-      - ubuntu-build-clang
-      - macos-build-clang
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # Ubuntu
-          ## Lint all sources
-          - name: Ubuntu - lint
-            os: ubuntu-24.04
-            lint: true
-          ## Debug + clang-tidy + coverage
-          - name: Ubuntu - debug, analysis, coverage
-            os: ubuntu-24.04
-            build_type: Debug
-            sanitize: none
-            coverage: on
-            analyze: on
+  #build-jank:
+  #  needs:
+  #    - ubuntu-build-clang
+  #    - macos-build-clang
+  #  strategy:
+  #    fail-fast: false
+  #    matrix:
+  #      include:
+  #        # Ubuntu
+  #        ## Lint all sources
+  #        - name: Ubuntu - lint
+  #          os: ubuntu-24.04
+  #          lint: true
+  #        ## Debug + clang-tidy + coverage
+  #        - name: Ubuntu - debug, analysis, coverage
+  #          os: ubuntu-24.04
+  #          build_type: Debug
+  #          sanitize: none
+  #          coverage: on
+  #          analyze: on
 
-          ## Debug + sanitization
-          # TODO: Fix this. GC issue: https://github.com/bdwgc/bdwgc/issues/772
-          #- name: Ubuntu - address sanitizer
-          #  os: ubuntu-24.04
-          #  build_type: Debug
-          #  sanitize: address
+  #        ## Debug + sanitization
+  #        # TODO: Fix this. GC issue: https://github.com/bdwgc/bdwgc/issues/772
+  #        #- name: Ubuntu - address sanitizer
+  #        #  os: ubuntu-24.04
+  #        #  build_type: Debug
+  #        #  sanitize: address
 
-          - name: Ubuntu - undefined behavior sanitizer
-            os: ubuntu-24.04
-            build_type: Debug
-            sanitize: undefined
+  #        - name: Ubuntu - undefined behavior sanitizer
+  #          os: ubuntu-24.04
+  #          build_type: Debug
+  #          sanitize: undefined
 
-          ## TODO: Fix this. Causes linker issues.
-          # https://github.com/jank-lang/jank/actions/runs/16657688537/job/47146758720
-          #- name: Ubuntu - thread sanitizer
-          #  os: ubuntu-24.04
-          #  build_type: Debug
-          #  sanitize: thread
+  #        ## TODO: Fix this. Causes linker issues.
+  #        # https://github.com/jank-lang/jank/actions/runs/16657688537/job/47146758720
+  #        #- name: Ubuntu - thread sanitizer
+  #        #  os: ubuntu-24.04
+  #        #  build_type: Debug
+  #        #  sanitize: thread
 
-          ## Release
-          - name: Ubuntu - release
-            os: ubuntu-24.04
-            build_type: Release
-            sanitize: none
-            package: on
+  #        ## Release
+  #        - name: Ubuntu - release
+  #          os: ubuntu-24.04
+  #          build_type: Release
+  #          sanitize: none
+  #          package: on
 
-          # macOS
-          ## Debug + clang-tidy
-          - name: macOS - debug, analysis
-            os: macos-26
-            build_type: Debug
-            sanitize: none
-            analyze: on
+  #        # macOS
+  #        ## Debug + clang-tidy
+  #        - name: macOS - debug, analysis
+  #          os: macos-26
+  #          build_type: Debug
+  #          sanitize: none
+  #          analyze: on
 
-          ## Debug + sanitization
-          ## TODO: Fails, but looks like a false positive.
-          # https://github.com/jank-lang/jank/actions/runs/21684803696/job/62528872227?pr=677
-          #- name: macOS - address sanitizer
-          #  os: macos-26
-          #  build_type: Debug
-          #  sanitize: address
+  #        ## Debug + sanitization
+  #        ## TODO: Fails, but looks like a false positive.
+  #        # https://github.com/jank-lang/jank/actions/runs/21684803696/job/62528872227?pr=677
+  #        #- name: macOS - address sanitizer
+  #        #  os: macos-26
+  #        #  build_type: Debug
+  #        #  sanitize: address
 
-          - name: macOS - undefined behavior sanitizer
-            os: macos-26
-            build_type: Debug
-            sanitize: undefined
+  #        - name: macOS - undefined behavior sanitizer
+  #          os: macos-26
+  #          build_type: Debug
+  #          sanitize: undefined
 
-          # TODO: Fix this. It hangs in CI.
-          #- name: macOS - thread sanitizer
-          #  os: macos-26
-          #  build_type: Debug
-          #  sanitize: thread
+  #        # TODO: Fix this. It hangs in CI.
+  #        #- name: macOS - thread sanitizer
+  #        #  os: macos-26
+  #        #  build_type: Debug
+  #        #  sanitize: thread
 
-          ## Release
-          - name: macOS - release
-            os: macos-26
-            build_type: Release
-            sanitize: none
-            package: on
-    runs-on: ${{ matrix.os }}
-    name: ${{ matrix.name }}
-    env:
-      JANK_MATRIX_ID: ${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.sanitize }}
-      JANK_BUILD_TYPE: ${{ matrix.build_type }}
-      JANK_LINT: ${{ matrix.lint }}
-      JANK_COVERAGE: ${{ matrix.coverage }}
-      JANK_ANALYZE: ${{ matrix.analyze }}
-      JANK_SANITIZE: ${{ matrix.sanitize }}
-      JANK_PACKAGE: ${{ matrix.package }}
-      ASAN_OPTIONS: detect_leaks=0
-      TERM: xterm
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      HOMEBREW_NO_AUTO_UPDATE: 1
+  #        ## Release
+  #        - name: macOS - release
+  #          os: macos-26
+  #          build_type: Release
+  #          sanitize: none
+  #          package: on
+  #  runs-on: ${{ matrix.os }}
+  #  name: ${{ matrix.name }}
+  #  env:
+  #    JANK_MATRIX_ID: ${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.sanitize }}
+  #    JANK_BUILD_TYPE: ${{ matrix.build_type }}
+  #    JANK_LINT: ${{ matrix.lint }}
+  #    JANK_COVERAGE: ${{ matrix.coverage }}
+  #    JANK_ANALYZE: ${{ matrix.analyze }}
+  #    JANK_SANITIZE: ${{ matrix.sanitize }}
+  #    JANK_PACKAGE: ${{ matrix.package }}
+  #    ASAN_OPTIONS: detect_leaks=0
+  #    TERM: xterm
+  #    CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  #    HOMEBREW_NO_AUTO_UPDATE: 1
+  #  timeout-minutes: 60
+  #  steps:
+  #    - uses: actions/checkout@v4
+  #      with:
+  #        submodules: true
+  #    - name: Install apt packages
+  #      if: runner.os == 'Linux'
+  #      uses: awalsh128/cache-apt-pkgs-action@5902b33ae29014e6ca012c5d8025d4346556bd40
+  #      with:
+  #        packages: default-jdk software-properties-common lsb-release npm lcov leiningen ccache curl git git-lfs build-essential entr libssl-dev libdouble-conversion-dev pkg-config ninja-build cmake zlib1g-dev libffi-dev gcc g++ libgc-dev libboost-all-dev
+  #        # Increment this when the package list changes.
+  #        version: 13
+  #    # Boost doesn't get cached properly with the above action.
+  #    # https://github.com/awalsh128/cache-apt-pkgs-action/issues/151
+  #    - name: Install boost
+  #      if: runner.os == 'Linux'
+  #      run: |
+  #        sudo apt install -y libboost-all-dev
+  #    - name: Install Homebrew packages
+  #      if: runner.os == 'macOS'
+  #      run: |
+  #        brew install cmake ninja double-conversion pkg-config llvm ccache boost openssl zlib boost clojure/tools/clojure
+  #    - name: Cache Clang/LLVM
+  #      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684
+  #      with:
+  #        path: |
+  #          ${{ github.workspace }}/compiler+runtime/build/llvm-install
+  #        key: clang-${{ runner.os }}-${{ hashFiles('${{ github.workspace }}/compiler+runtime/bin/build-clang') }}
+  #    - name: Cache ccache object files
+  #      if: matrix.analyze == 'off'
+  #      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+  #      with:
+  #        path: |
+  #          ${{ github.workspace }}/compiler+runtime/.ctcache
+  #        key: ccache-${{ env.JANK_MATRIX_ID }}-${{ github.ref_name }}
+  #    - name: Cache ctcache object files
+  #      if: matrix.analyze == 'on'
+  #      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+  #      with:
+  #        path: |
+  #          ${{ github.workspace }}/compiler+runtime/.ctcache
+  #        key: ctcache-${{ env.JANK_MATRIX_ID }}-${{ github.ref_name }}
+  #    - uses: thejerrybao/setup-swap-space@466d59798fb9263b9c2331c83cf71f9b7bfd0c78
+  #      if: runner.os == 'Linux'
+  #      with:
+  #        swap-space-path: /swapfile
+  #        swap-size-gb: 8
+  #        remove-existing-swap-files: true
+  #    - name: Build and test jank
+  #      id: jank-build-step
+  #      run: |
+  #        curl -sL -o install-bb https://raw.githubusercontent.com/babashka/babashka/master/install
+  #        chmod +x install-bb
+  #        sudo ./install-bb
+  #        if [[ "${RUNNER_OS}" == "macOS" ]];
+  #        then
+  #          export SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
+  #        fi
+  #        if [[ "${JANK_SANITIZE}" != "none" || "${JANK_COVERAGE}" == "on" ]];
+  #        then
+  #          export JANK_SKIP_AOT_CHECK=1
+  #        fi
+  #        JANK_INSTALL_DEPS=true ./bin/jank/check_everything.clj
+  #    - name: Upload .deb for publishing
+  #      if: github.ref == 'refs/heads/main' && steps.jank-build-step.outputs.deb
+  #      uses: actions/upload-artifact@v4
+  #      with:
+  #        name: jank-deb
+  #        path: ${{ steps.jank-build-step.outputs.deb }}
+  #    - name: Upload Homebrew tarball for publishing
+  #      if: github.ref == 'refs/heads/main' && steps.jank-build-step.outputs.homebrew-tarball
+  #      uses: actions/upload-artifact@v4
+  #      with:
+  #        name: jank-homebrew-tarball
+  #        path: ${{ steps.jank-build-step.outputs.homebrew-tarball }}
+
+  #publish-deb:
+  #  if: github.ref == 'refs/heads/main'
+  #  needs: build-jank
+  #  name: Publish .deb
+  #  runs-on: ubuntu-24.04
+  #  timeout-minutes: 5
+  #  steps:
+  #    - uses: actions/download-artifact@v5
+  #      with:
+  #        name: jank-deb
+  #        path: ~/
+  #    - name: Import SSH key
+  #      run: |
+  #        mkdir -p ~/.ssh
+  #        echo "${{ secrets.PPA_SSH_KEY }}" > ~/.ssh/jank_id_ed25519
+  #        chmod 400 ~/.ssh/jank_id_ed25519
+  #    - name: Publish to PPA
+  #      run: |
+  #        scp -i ~/.ssh/jank_id_ed25519 -o StrictHostKeyChecking=no ~/*.deb root@ppa.jank-lang.org:/var/www/ppa.jank-lang.org/html/
+  #        ssh -i ~/.ssh/jank_id_ed25519 -o StrictHostKeyChecking=no root@ppa.jank-lang.org "~/update+sign"
+
+  #publish-homebrew-tarball:
+  #  if: github.ref == 'refs/heads/main'
+  #  needs: build-jank
+  #  name: Publish Homebrew package
+  #  runs-on: macos-26
+  #  timeout-minutes: 5
+  #  steps:
+  #    - uses: actions/download-artifact@v5
+  #      with:
+  #        name: jank-homebrew-tarball
+  #        path: ~/
+  #    - name: Import SSH key
+  #      run: |
+  #        mkdir -p ~/.ssh
+  #        echo "${{ secrets.PPA_SSH_KEY }}" > ~/.ssh/jank_id_ed25519
+  #        chmod 400 ~/.ssh/jank_id_ed25519
+  #    - name: Publish to cache
+  #      run: |
+  #        scp -i ~/.ssh/jank_id_ed25519 -o StrictHostKeyChecking=no ~/*.tar.gz root@cache.jank-lang.org:/var/www/cache.jank-lang.org/html/
+
+  publish-arch-package:
+    runs-on: archlinux/latest
+    name: Publish Arch package
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Install apt packages
-        if: runner.os == 'Linux'
-        uses: awalsh128/cache-apt-pkgs-action@5902b33ae29014e6ca012c5d8025d4346556bd40
-        with:
-          packages: default-jdk software-properties-common lsb-release npm lcov leiningen ccache curl git git-lfs build-essential entr libssl-dev libdouble-conversion-dev pkg-config ninja-build cmake zlib1g-dev libffi-dev gcc g++ libgc-dev libboost-all-dev
-          # Increment this when the package list changes.
-          version: 13
-      # Boost doesn't get cached properly with the above action.
-      # https://github.com/awalsh128/cache-apt-pkgs-action/issues/151
-      - name: Install boost
-        if: runner.os == 'Linux'
+      - name: Install packages
         run: |
-          sudo apt install -y libboost-all-dev
-      - name: Install Homebrew packages
-        if: runner.os == 'macOS'
-        run: |
-          brew install cmake ninja double-conversion pkg-config llvm ccache boost openssl zlib boost clojure/tools/clojure
+          pacman -S gcc git git-lfs pkg-config cmake ninja make python3 libffi entr libxml2 libedit boost
       - name: Cache Clang/LLVM
         uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684
         with:
@@ -203,21 +336,12 @@ jobs:
             ${{ github.workspace }}/compiler+runtime/build/llvm-install
           key: clang-${{ runner.os }}-${{ hashFiles('${{ github.workspace }}/compiler+runtime/bin/build-clang') }}
       - name: Cache ccache object files
-        if: matrix.analyze == 'off'
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: |
             ${{ github.workspace }}/compiler+runtime/.ctcache
           key: ccache-${{ env.JANK_MATRIX_ID }}-${{ github.ref_name }}
-      - name: Cache ctcache object files
-        if: matrix.analyze == 'on'
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
-        with:
-          path: |
-            ${{ github.workspace }}/compiler+runtime/.ctcache
-          key: ctcache-${{ env.JANK_MATRIX_ID }}-${{ github.ref_name }}
       - uses: thejerrybao/setup-swap-space@466d59798fb9263b9c2331c83cf71f9b7bfd0c78
-        if: runner.os == 'Linux'
         with:
           swap-space-path: /swapfile
           swap-size-gb: 8
@@ -225,98 +349,37 @@ jobs:
       - name: Build and test jank
         id: jank-build-step
         run: |
-          curl -sL -o install-bb https://raw.githubusercontent.com/babashka/babashka/master/install
-          chmod +x install-bb
-          sudo ./install-bb
-          if [[ "${RUNNER_OS}" == "macOS" ]];
-          then
-            export SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
-          fi
-          if [[ "${JANK_SANITIZE}" != "none" || "${JANK_COVERAGE}" == "on" ]];
-          then
-            export JANK_SKIP_AOT_CHECK=1
-          fi
-          JANK_INSTALL_DEPS=true ./bin/jank/check_everything.clj
-      - name: Upload .deb for publishing
-        if: github.ref == 'refs/heads/main' && steps.jank-build-step.outputs.deb
-        uses: actions/upload-artifact@v4
-        with:
-          name: jank-deb
-          path: ${{ steps.jank-build-step.outputs.deb }}
-      - name: Upload Homebrew tarball for publishing
-        if: github.ref == 'refs/heads/main' && steps.jank-build-step.outputs.homebrew-tarball
-        uses: actions/upload-artifact@v4
-        with:
-          name: jank-homebrew-tarball
-          path: ${{ steps.jank-build-step.outputs.homebrew-tarball }}
+          export CC=$PWD/build/llvm-install/usr/local/bin/clang;
+          export CXX=$PWD/build/llvm-install/usr/local/bin/clang++
+          ./bin/configure -GNinja -DCMAKE_BUILD_TYPE=Release -Djank_local_clang=on
+          DESTDIR=inst ./bin/install
 
-  publish-deb:
-    if: github.ref == 'refs/heads/main'
-    needs: build-jank
-    name: Publish .deb
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    steps:
-      - uses: actions/download-artifact@v5
-        with:
-          name: jank-deb
-          path: ~/
-      - name: Import SSH key
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.PPA_SSH_KEY }}" > ~/.ssh/jank_id_ed25519
-          chmod 400 ~/.ssh/jank_id_ed25519
-      - name: Publish to PPA
-        run: |
-          scp -i ~/.ssh/jank_id_ed25519 -o StrictHostKeyChecking=no ~/*.deb root@ppa.jank-lang.org:/var/www/ppa.jank-lang.org/html/
-          ssh -i ~/.ssh/jank_id_ed25519 -o StrictHostKeyChecking=no root@ppa.jank-lang.org "~/update+sign"
-
-  publish-homebrew-tarball:
-    if: github.ref == 'refs/heads/main'
-    needs: build-jank
-    name: Publish Homebrew package
-    runs-on: macos-26
-    timeout-minutes: 5
-    steps:
-      - uses: actions/download-artifact@v5
-        with:
-          name: jank-homebrew-tarball
-          path: ~/
-      - name: Import SSH key
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.PPA_SSH_KEY }}" > ~/.ssh/jank_id_ed25519
-          chmod 400 ~/.ssh/jank_id_ed25519
-      - name: Publish to cache
-        run: |
-          scp -i ~/.ssh/jank_id_ed25519 -o StrictHostKeyChecking=no ~/*.tar.gz root@cache.jank-lang.org:/var/www/cache.jank-lang.org/html/
-
-  build-nix:
-    name: "Nix - release"
-    runs-on: ubuntu-latest
-    steps:
-    - name: "Set up nix"
-      uses: cachix/install-nix-action@v31
-      with:
-        nix_path: nixpkgs=channel:nixos-unstable
-    - name: "Set up cachix"
-      uses: cachix/cachix-action@v16
-      with:
-        name: jank-lang
-        # If you chose API tokens for write access OR if you have a private cache
-        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-        # Only push to cache on main branch, not PRs
-        skipPush: "${{ github.ref != 'refs/heads/main' }}"
-    - uses: actions/checkout@v4
-      with:
-        submodules: 'recursive'
-    - uses: thejerrybao/setup-swap-space@466d59798fb9263b9c2331c83cf71f9b7bfd0c78
-      if: runner.os == 'Linux'
-      with:
-        swap-space-path: /swapfile
-        swap-size-gb: 8
-        remove-existing-swap-files: true
-    - name: "Build jank"
-      run: nix build .?submodules=1 -L
-    - name: "Check health"
-      run: nix run .?submodules=1 check-health
+  #build-nix:
+  #  name: "Nix - release"
+  #  runs-on: ubuntu-latest
+  #  steps:
+  #  - name: "Set up nix"
+  #    uses: cachix/install-nix-action@v31
+  #    with:
+  #      nix_path: nixpkgs=channel:nixos-unstable
+  #  - name: "Set up cachix"
+  #    uses: cachix/cachix-action@v16
+  #    with:
+  #      name: jank-lang
+  #      # If you chose API tokens for write access OR if you have a private cache
+  #      authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+  #      # Only push to cache on main branch, not PRs
+  #      skipPush: "${{ github.ref != 'refs/heads/main' }}"
+  #  - uses: actions/checkout@v4
+  #    with:
+  #      submodules: 'recursive'
+  #  - uses: thejerrybao/setup-swap-space@466d59798fb9263b9c2331c83cf71f9b7bfd0c78
+  #    if: runner.os == 'Linux'
+  #    with:
+  #      swap-space-path: /swapfile
+  #      swap-size-gb: 8
+  #      remove-existing-swap-files: true
+  #  - name: "Build jank"
+  #    run: nix build .?submodules=1 -L
+  #  - name: "Check health"
+  #    run: nix run .?submodules=1 check-health

--- a/.github/workflows/build-compiler+runtime.yml
+++ b/.github/workflows/build-compiler+runtime.yml
@@ -112,6 +112,35 @@ jobs:
           fi
           ${{ github.workspace }}/compiler+runtime/build/llvm-install/usr/local/bin/clang++ --version
 
+  macos-intel-build-clang:
+    name: macOS Intel - clang
+    runs-on: macos-26-intel
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    timeout-minutes: 200
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install Homebrew deps
+        run: |
+          brew install git pkg-config ninja python cmake gnupg zlib
+      - name: Cache Clang/LLVM
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            ${{ github.workspace }}/compiler+runtime/build/llvm-install
+          key: clang-${{ runner.os }}-intel-${{ hashFiles('compiler+runtime/bin/build-clang') }}
+      - name: Build Clang/LLVM
+        run: |
+          if [[ ! -e ${{ github.workspace }}/compiler+runtime/build/llvm-install/usr/local/bin/clang++ ]];
+          then
+            pushd ${{ github.workspace }}/compiler+runtime
+              ./bin/build-clang
+            popd
+          fi
+          ${{ github.workspace }}/compiler+runtime/build/llvm-install/usr/local/bin/clang++ --version
+
   build-jank:
     needs:
       - ubuntu-build-clang
@@ -356,6 +385,46 @@ jobs:
             ./bin/compile
             DESTDIR=inst ./bin/install
             tar czf ~/jank-arch-x86-64.tar.gz inst
+          popd
+      - name: Import SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.PPA_SSH_KEY }}" > ~/.ssh/jank_id_ed25519
+          chmod 400 ~/.ssh/jank_id_ed25519
+      - name: Publish to cache
+        run: |
+          rsync -avz -e "ssh -i $HOME/.ssh/jank_id_ed25519 -o StrictHostKeyChecking=no" --progress ~/*.tar.gz root@cache.jank-lang.org:/var/www/cache.jank-lang.org/html/arch
+
+  publish-macos-intel-package:
+    #if: github.ref == 'refs/heads/main'
+    needs:
+      - macos-intel-build-clang
+    runs-on: macos-15-intel
+    name: Publish macOS Intel package
+    timeout-minutes: 60
+    steps:
+      - name: Install packages
+        run: |
+          brew install cmake ninja double-conversion pkg-config llvm ccache boost openssl zlib boost clojure/tools/clojure
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Cache Clang/LLVM
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            compiler+runtime/build/llvm-install
+          key: clang-${{ runner.os }}-intel-${{ hashFiles('compiler+runtime/bin/build-clang') }}
+      - name: Build and test jank
+        id: jank-build-step
+        run: |
+          export CC=${GITHUB_WORKSPACE}/compiler+runtime/build/llvm-install/usr/local/bin/clang
+          export CXX=${GITHUB_WORKSPACE}/compiler+runtime/build/llvm-install/usr/local/bin/clang++
+          pushd ${GITHUB_WORKSPACE}/compiler+runtime
+            ./bin/configure -GNinja -DCMAKE_BUILD_TYPE=Release -Djank_local_clang=on
+            ./bin/compile
+            DESTDIR=inst ./bin/install
+            tar czf ~/jank-macos-x86-64.tar.gz inst
           popd
       - name: Import SSH key
         run: |

--- a/.github/workflows/build-compiler+runtime.yml
+++ b/.github/workflows/build-compiler+runtime.yml
@@ -268,6 +268,7 @@ jobs:
           then
             export JANK_SKIP_AOT_CHECK=1
           fi
+          ${CXX} --version
           JANK_INSTALL_DEPS=true ./bin/jank/check_everything.clj
       - name: Upload .deb for publishing
         if: github.ref == 'refs/heads/main' && steps.jank-build-step.outputs.deb

--- a/.github/workflows/build-compiler+runtime.yml
+++ b/.github/workflows/build-compiler+runtime.yml
@@ -111,218 +111,219 @@ jobs:
           fi
           ${{ github.workspace }}/compiler+runtime/build/llvm-install/usr/local/bin/clang++ --version
 
-  #build-jank:
-  #  needs:
-  #    - ubuntu-build-clang
-  #    - macos-build-clang
-  #  strategy:
-  #    fail-fast: false
-  #    matrix:
-  #      include:
-  #        # Ubuntu
-  #        ## Lint all sources
-  #        - name: Ubuntu - lint
-  #          os: ubuntu-24.04
-  #          lint: true
-  #        ## Debug + clang-tidy + coverage
-  #        - name: Ubuntu - debug, analysis, coverage
-  #          os: ubuntu-24.04
-  #          build_type: Debug
-  #          sanitize: none
-  #          coverage: on
-  #          analyze: on
+  build-jank:
+    needs:
+      - ubuntu-build-clang
+      - macos-build-clang
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Ubuntu
+          ## Lint all sources
+          - name: Ubuntu - lint
+            os: ubuntu-24.04
+            lint: true
+          ## Debug + clang-tidy + coverage
+          - name: Ubuntu - debug, analysis, coverage
+            os: ubuntu-24.04
+            build_type: Debug
+            sanitize: none
+            coverage: on
+            analyze: on
 
-  #        ## Debug + sanitization
-  #        # TODO: Fix this. GC issue: https://github.com/bdwgc/bdwgc/issues/772
-  #        #- name: Ubuntu - address sanitizer
-  #        #  os: ubuntu-24.04
-  #        #  build_type: Debug
-  #        #  sanitize: address
+          ## Debug + sanitization
+          # TODO: Fix this. GC issue: https://github.com/bdwgc/bdwgc/issues/772
+          #- name: Ubuntu - address sanitizer
+          #  os: ubuntu-24.04
+          #  build_type: Debug
+          #  sanitize: address
 
-  #        - name: Ubuntu - undefined behavior sanitizer
-  #          os: ubuntu-24.04
-  #          build_type: Debug
-  #          sanitize: undefined
+          - name: Ubuntu - undefined behavior sanitizer
+            os: ubuntu-24.04
+            build_type: Debug
+            sanitize: undefined
 
-  #        ## TODO: Fix this. Causes linker issues.
-  #        # https://github.com/jank-lang/jank/actions/runs/16657688537/job/47146758720
-  #        #- name: Ubuntu - thread sanitizer
-  #        #  os: ubuntu-24.04
-  #        #  build_type: Debug
-  #        #  sanitize: thread
+          ## TODO: Fix this. Causes linker issues.
+          # https://github.com/jank-lang/jank/actions/runs/16657688537/job/47146758720
+          #- name: Ubuntu - thread sanitizer
+          #  os: ubuntu-24.04
+          #  build_type: Debug
+          #  sanitize: thread
 
-  #        ## Release
-  #        - name: Ubuntu - release
-  #          os: ubuntu-24.04
-  #          build_type: Release
-  #          sanitize: none
-  #          package: on
+          ## Release
+          - name: Ubuntu - release
+            os: ubuntu-24.04
+            build_type: Release
+            sanitize: none
+            package: on
 
-  #        # macOS
-  #        ## Debug + clang-tidy
-  #        - name: macOS - debug, analysis
-  #          os: macos-26
-  #          build_type: Debug
-  #          sanitize: none
-  #          analyze: on
+          # macOS
+          ## Debug + clang-tidy
+          - name: macOS - debug, analysis
+            os: macos-26
+            build_type: Debug
+            sanitize: none
+            analyze: on
 
-  #        ## Debug + sanitization
-  #        ## TODO: Fails, but looks like a false positive.
-  #        # https://github.com/jank-lang/jank/actions/runs/21684803696/job/62528872227?pr=677
-  #        #- name: macOS - address sanitizer
-  #        #  os: macos-26
-  #        #  build_type: Debug
-  #        #  sanitize: address
+          ## Debug + sanitization
+          ## TODO: Fails, but looks like a false positive.
+          # https://github.com/jank-lang/jank/actions/runs/21684803696/job/62528872227?pr=677
+          #- name: macOS - address sanitizer
+          #  os: macos-26
+          #  build_type: Debug
+          #  sanitize: address
 
-  #        - name: macOS - undefined behavior sanitizer
-  #          os: macos-26
-  #          build_type: Debug
-  #          sanitize: undefined
+          - name: macOS - undefined behavior sanitizer
+            os: macos-26
+            build_type: Debug
+            sanitize: undefined
 
-  #        # TODO: Fix this. It hangs in CI.
-  #        #- name: macOS - thread sanitizer
-  #        #  os: macos-26
-  #        #  build_type: Debug
-  #        #  sanitize: thread
+          # TODO: Fix this. It hangs in CI.
+          #- name: macOS - thread sanitizer
+          #  os: macos-26
+          #  build_type: Debug
+          #  sanitize: thread
 
-  #        ## Release
-  #        - name: macOS - release
-  #          os: macos-26
-  #          build_type: Release
-  #          sanitize: none
-  #          package: on
-  #  runs-on: ${{ matrix.os }}
-  #  name: ${{ matrix.name }}
-  #  env:
-  #    JANK_MATRIX_ID: ${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.sanitize }}
-  #    JANK_BUILD_TYPE: ${{ matrix.build_type }}
-  #    JANK_LINT: ${{ matrix.lint }}
-  #    JANK_COVERAGE: ${{ matrix.coverage }}
-  #    JANK_ANALYZE: ${{ matrix.analyze }}
-  #    JANK_SANITIZE: ${{ matrix.sanitize }}
-  #    JANK_PACKAGE: ${{ matrix.package }}
-  #    ASAN_OPTIONS: detect_leaks=0
-  #    TERM: xterm
-  #    CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-  #    HOMEBREW_NO_AUTO_UPDATE: 1
-  #  timeout-minutes: 60
-  #  steps:
-  #    - uses: actions/checkout@v4
-  #      with:
-  #        submodules: true
-  #    - name: Install apt packages
-  #      if: runner.os == 'Linux'
-  #      uses: awalsh128/cache-apt-pkgs-action@5902b33ae29014e6ca012c5d8025d4346556bd40
-  #      with:
-  #        packages: default-jdk software-properties-common lsb-release npm lcov leiningen ccache curl git build-essential libssl-dev libdouble-conversion-dev pkg-config ninja-build cmake zlib1g-dev libffi-dev gcc g++ libgc-dev libboost-all-dev
-  #        # Increment this when the package list changes.
-  #        version: 14
-  #    # Boost doesn't get cached properly with the above action.
-  #    # https://github.com/awalsh128/cache-apt-pkgs-action/issues/151
-  #    - name: Install boost
-  #      if: runner.os == 'Linux'
-  #      run: |
-  #        sudo apt install -y libboost-all-dev
-  #    - name: Install Homebrew packages
-  #      if: runner.os == 'macOS'
-  #      run: |
-  #        brew install cmake ninja double-conversion pkg-config llvm ccache boost openssl zlib boost clojure/tools/clojure
-  #    - name: Cache Clang/LLVM
-  #      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684
-  #      with:
-  #        path: |
-  #          ${{ github.workspace }}/compiler+runtime/build/llvm-install
-  #        key: clang-${{ runner.os }}-${{ hashFiles('${{ github.workspace }}/compiler+runtime/bin/build-clang') }}
-  #    - name: Cache ccache object files
-  #      if: matrix.analyze == 'off'
-  #      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
-  #      with:
-  #        path: |
-  #          ${{ github.workspace }}/compiler+runtime/.ctcache
-  #        key: ccache-${{ env.JANK_MATRIX_ID }}-${{ github.ref_name }}
-  #    - name: Cache ctcache object files
-  #      if: matrix.analyze == 'on'
-  #      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
-  #      with:
-  #        path: |
-  #          ${{ github.workspace }}/compiler+runtime/.ctcache
-  #        key: ctcache-${{ env.JANK_MATRIX_ID }}-${{ github.ref_name }}
-  #    - uses: thejerrybao/setup-swap-space@466d59798fb9263b9c2331c83cf71f9b7bfd0c78
-  #      if: runner.os == 'Linux'
-  #      with:
-  #        swap-space-path: /swapfile
-  #        swap-size-gb: 8
-  #        remove-existing-swap-files: true
-  #    - name: Build and test jank
-  #      id: jank-build-step
-  #      run: |
-  #        curl -sL -o install-bb https://raw.githubusercontent.com/babashka/babashka/master/install
-  #        chmod +x install-bb
-  #        sudo ./install-bb
-  #        if [[ "${RUNNER_OS}" == "macOS" ]];
-  #        then
-  #          export SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
-  #        fi
-  #        if [[ "${JANK_SANITIZE}" != "none" || "${JANK_COVERAGE}" == "on" ]];
-  #        then
-  #          export JANK_SKIP_AOT_CHECK=1
-  #        fi
-  #        JANK_INSTALL_DEPS=true ./bin/jank/check_everything.clj
-  #    - name: Upload .deb for publishing
-  #      if: github.ref == 'refs/heads/main' && steps.jank-build-step.outputs.deb
-  #      uses: actions/upload-artifact@v4
-  #      with:
-  #        name: jank-deb
-  #        path: ${{ steps.jank-build-step.outputs.deb }}
-  #    - name: Upload Homebrew tarball for publishing
-  #      if: github.ref == 'refs/heads/main' && steps.jank-build-step.outputs.homebrew-tarball
-  #      uses: actions/upload-artifact@v4
-  #      with:
-  #        name: jank-homebrew-tarball
-  #        path: ${{ steps.jank-build-step.outputs.homebrew-tarball }}
+          ## Release
+          - name: macOS - release
+            os: macos-26
+            build_type: Release
+            sanitize: none
+            package: on
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.name }}
+    env:
+      JANK_MATRIX_ID: ${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.sanitize }}
+      JANK_BUILD_TYPE: ${{ matrix.build_type }}
+      JANK_LINT: ${{ matrix.lint }}
+      JANK_COVERAGE: ${{ matrix.coverage }}
+      JANK_ANALYZE: ${{ matrix.analyze }}
+      JANK_SANITIZE: ${{ matrix.sanitize }}
+      JANK_PACKAGE: ${{ matrix.package }}
+      ASAN_OPTIONS: detect_leaks=0
+      TERM: xterm
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install apt packages
+        if: runner.os == 'Linux'
+        uses: awalsh128/cache-apt-pkgs-action@5902b33ae29014e6ca012c5d8025d4346556bd40
+        with:
+          packages: default-jdk software-properties-common lsb-release npm lcov leiningen ccache curl git build-essential libssl-dev libdouble-conversion-dev pkg-config ninja-build cmake zlib1g-dev libffi-dev gcc g++ libgc-dev libboost-all-dev
+          # Increment this when the package list changes.
+          version: 14
+      # Boost doesn't get cached properly with the above action.
+      # https://github.com/awalsh128/cache-apt-pkgs-action/issues/151
+      - name: Install boost
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt install -y libboost-all-dev
+      - name: Install Homebrew packages
+        if: runner.os == 'macOS'
+        run: |
+          brew install cmake ninja double-conversion pkg-config llvm ccache boost openssl zlib boost clojure/tools/clojure
+      - name: Cache Clang/LLVM
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            ${{ github.workspace }}/compiler+runtime/build/llvm-install
+          key: clang-${{ runner.os }}-${{ hashFiles('${{ github.workspace }}/compiler+runtime/bin/build-clang') }}
+      - name: Cache ccache object files
+        if: matrix.analyze == 'off'
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            ${{ github.workspace }}/compiler+runtime/.ctcache
+          key: ccache-${{ env.JANK_MATRIX_ID }}-${{ github.ref_name }}
+      - name: Cache ctcache object files
+        if: matrix.analyze == 'on'
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            ${{ github.workspace }}/compiler+runtime/.ctcache
+          key: ctcache-${{ env.JANK_MATRIX_ID }}-${{ github.ref_name }}
+      - uses: thejerrybao/setup-swap-space@466d59798fb9263b9c2331c83cf71f9b7bfd0c78
+        if: runner.os == 'Linux'
+        with:
+          swap-space-path: /swapfile
+          swap-size-gb: 8
+          remove-existing-swap-files: true
+      - name: Build and test jank
+        id: jank-build-step
+        run: |
+          curl -sL -o install-bb https://raw.githubusercontent.com/babashka/babashka/master/install
+          chmod +x install-bb
+          sudo ./install-bb
+          if [[ "${RUNNER_OS}" == "macOS" ]];
+          then
+            export SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
+          fi
+          if [[ "${JANK_SANITIZE}" != "none" || "${JANK_COVERAGE}" == "on" ]];
+          then
+            export JANK_SKIP_AOT_CHECK=1
+          fi
+          JANK_INSTALL_DEPS=true ./bin/jank/check_everything.clj
+      - name: Upload .deb for publishing
+        if: github.ref == 'refs/heads/main' && steps.jank-build-step.outputs.deb
+        uses: actions/upload-artifact@v4
+        with:
+          name: jank-deb
+          path: ${{ steps.jank-build-step.outputs.deb }}
+      - name: Upload Homebrew tarball for publishing
+        if: github.ref == 'refs/heads/main' && steps.jank-build-step.outputs.homebrew-tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: jank-homebrew-tarball
+          path: ${{ steps.jank-build-step.outputs.homebrew-tarball }}
 
-  #publish-deb:
-  #  if: github.ref == 'refs/heads/main'
-  #  needs: build-jank
-  #  name: Publish .deb
-  #  runs-on: ubuntu-24.04
-  #  timeout-minutes: 5
-  #  steps:
-  #    - uses: actions/download-artifact@v5
-  #      with:
-  #        name: jank-deb
-  #        path: ~/
-  #    - name: Import SSH key
-  #      run: |
-  #        mkdir -p ~/.ssh
-  #        echo "${{ secrets.PPA_SSH_KEY }}" > ~/.ssh/jank_id_ed25519
-  #        chmod 400 ~/.ssh/jank_id_ed25519
-  #    - name: Publish to PPA
-  #      run: |
-  #        scp -i ~/.ssh/jank_id_ed25519 -o StrictHostKeyChecking=no ~/*.deb root@ppa.jank-lang.org:/var/www/ppa.jank-lang.org/html/
-  #        ssh -i ~/.ssh/jank_id_ed25519 -o StrictHostKeyChecking=no root@ppa.jank-lang.org "~/update+sign"
+  publish-deb:
+    if: github.ref == 'refs/heads/main'
+    needs: build-jank
+    name: Publish .deb
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/download-artifact@v5
+        with:
+          name: jank-deb
+          path: ~/
+      - name: Import SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.PPA_SSH_KEY }}" > ~/.ssh/jank_id_ed25519
+          chmod 400 ~/.ssh/jank_id_ed25519
+      - name: Publish to PPA
+        run: |
+          scp -i ~/.ssh/jank_id_ed25519 -o StrictHostKeyChecking=no ~/*.deb root@ppa.jank-lang.org:/var/www/ppa.jank-lang.org/html/
+          ssh -i ~/.ssh/jank_id_ed25519 -o StrictHostKeyChecking=no root@ppa.jank-lang.org "~/update+sign"
 
-  #publish-homebrew-tarball:
-  #  if: github.ref == 'refs/heads/main'
-  #  needs: build-jank
-  #  name: Publish Homebrew package
-  #  runs-on: macos-26
-  #  timeout-minutes: 5
-  #  steps:
-  #    - uses: actions/download-artifact@v5
-  #      with:
-  #        name: jank-homebrew-tarball
-  #        path: ~/
-  #    - name: Import SSH key
-  #      run: |
-  #        mkdir -p ~/.ssh
-  #        echo "${{ secrets.PPA_SSH_KEY }}" > ~/.ssh/jank_id_ed25519
-  #        chmod 400 ~/.ssh/jank_id_ed25519
-  #    - name: Publish to cache
-  #      run: |
-  #        scp -i ~/.ssh/jank_id_ed25519 -o StrictHostKeyChecking=no ~/*.tar.gz root@cache.jank-lang.org:/var/www/cache.jank-lang.org/html/
+  publish-homebrew-tarball:
+    if: github.ref == 'refs/heads/main'
+    needs: build-jank
+    name: Publish Homebrew package
+    runs-on: macos-26
+    timeout-minutes: 5
+    steps:
+      - uses: actions/download-artifact@v5
+        with:
+          name: jank-homebrew-tarball
+          path: ~/
+      - name: Import SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.PPA_SSH_KEY }}" > ~/.ssh/jank_id_ed25519
+          chmod 400 ~/.ssh/jank_id_ed25519
+      - name: Publish to cache
+        run: |
+          scp -i ~/.ssh/jank_id_ed25519 -o StrictHostKeyChecking=no ~/*.tar.gz root@cache.jank-lang.org:/var/www/cache.jank-lang.org/html/
 
   publish-arch-package:
+    if: github.ref == 'refs/heads/main'
     needs:
       - arch-build-clang
     runs-on: ubuntu-latest
@@ -364,32 +365,32 @@ jobs:
         run: |
           rsync -avz -e "ssh -i $HOME/.ssh/jank_id_ed25519 -o StrictHostKeyChecking=no" --progress ~/*.tar.gz root@cache.jank-lang.org:/var/www/cache.jank-lang.org/html/arch
 
-  #build-nix:
-  #  name: "Nix - release"
-  #  runs-on: ubuntu-latest
-  #  steps:
-  #  - name: "Set up nix"
-  #    uses: cachix/install-nix-action@v31
-  #    with:
-  #      nix_path: nixpkgs=channel:nixos-unstable
-  #  - name: "Set up cachix"
-  #    uses: cachix/cachix-action@v16
-  #    with:
-  #      name: jank-lang
-  #      # If you chose API tokens for write access OR if you have a private cache
-  #      authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-  #      # Only push to cache on main branch, not PRs
-  #      skipPush: "${{ github.ref != 'refs/heads/main' }}"
-  #  - uses: actions/checkout@v4
-  #    with:
-  #      submodules: 'recursive'
-  #  - uses: thejerrybao/setup-swap-space@466d59798fb9263b9c2331c83cf71f9b7bfd0c78
-  #    if: runner.os == 'Linux'
-  #    with:
-  #      swap-space-path: /swapfile
-  #      swap-size-gb: 8
-  #      remove-existing-swap-files: true
-  #  - name: "Build jank"
-  #    run: nix build .?submodules=1 -L
-  #  - name: "Check health"
-  #    run: nix run .?submodules=1 check-health
+  build-nix:
+    name: "Nix - release"
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Set up nix"
+      uses: cachix/install-nix-action@v31
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - name: "Set up cachix"
+      uses: cachix/cachix-action@v16
+      with:
+        name: jank-lang
+        # If you chose API tokens for write access OR if you have a private cache
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+        # Only push to cache on main branch, not PRs
+        skipPush: "${{ github.ref != 'refs/heads/main' }}"
+    - uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+    - uses: thejerrybao/setup-swap-space@466d59798fb9263b9c2331c83cf71f9b7bfd0c78
+      if: runner.os == 'Linux'
+      with:
+        swap-space-path: /swapfile
+        swap-size-gb: 8
+        remove-existing-swap-files: true
+    - name: "Build jank"
+      run: nix build .?submodules=1 -L
+    - name: "Check health"
+      run: nix run .?submodules=1 check-health

--- a/.github/workflows/build-compiler+runtime.yml
+++ b/.github/workflows/build-compiler+runtime.yml
@@ -268,7 +268,7 @@ jobs:
           then
             export JANK_SKIP_AOT_CHECK=1
           fi
-          ${CXX} --version
+          ${{ github.workspace }}/compiler+runtime/build/llvm-install/usr/local/bin/clang++ --version
           JANK_INSTALL_DEPS=true ./bin/jank/check_everything.clj
       - name: Upload .deb for publishing
         if: github.ref == 'refs/heads/main' && steps.jank-build-step.outputs.deb

--- a/.github/workflows/build-compiler+runtime.yml
+++ b/.github/workflows/build-compiler+runtime.yml
@@ -61,25 +61,26 @@ jobs:
       - name: Install packages
         run: |
           pacman -Syu --noconfirm
-          pacman --noconfirm -S gcc git git-lfs pkg-config cmake ninja make python3 libffi entr libxml2 libedit boost
+          pacman --noconfirm -S gcc git pkg-config cmake ninja make python3 libffi libxml2 libedit
+
       - uses: actions/checkout@v4
-        with:
-          submodules: true
+
       - name: Cache Clang/LLVM
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: |
-            ${{ github.workspace }}/compiler+runtime/build/llvm-install
-          key: clang-${{ runner.os }}-${{ hashFiles('compiler+runtime/bin/build-clang') }}
+            ${{ env.GITHUB_WORKSPACE }}/compiler+runtime/build/llvm-install
+          key: clang-Arch-${{ hashFiles('compiler+runtime/bin/build-clang') }}
+
       - name: Build Clang/LLVM
         run: |
-          if [[ ! -e ${{ github.workspace }}/compiler+runtime/build/llvm-install/usr/local/bin/clang++ ]];
+          if [[ ! -e ${GITHUB_WORKSPACE}/compiler+runtime/build/llvm-install/usr/local/bin/clang++ ]];
           then
-            pushd ${{ github.workspace }}/compiler+runtime
+            pushd ${GITHUB_WORKSPACE}/compiler+runtime
               ./bin/build-clang
             popd
           fi
-          ${{ github.workspace }}/compiler+runtime/build/llvm-install/usr/local/bin/clang++ --version
+          ${GITHUB_WORKSPACE}/compiler+runtime/build/llvm-install/usr/local/bin/clang++ --version
 
   macos-build-clang:
     name: macOS - clang
@@ -93,7 +94,7 @@ jobs:
           submodules: true
       - name: Install Homebrew deps
         run: |
-          brew install git git-lfs pkg-config ninja python cmake gnupg zlib
+          brew install git pkg-config ninja python cmake gnupg zlib
       - name: Cache Clang/LLVM
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
         with:
@@ -213,9 +214,9 @@ jobs:
   #      if: runner.os == 'Linux'
   #      uses: awalsh128/cache-apt-pkgs-action@5902b33ae29014e6ca012c5d8025d4346556bd40
   #      with:
-  #        packages: default-jdk software-properties-common lsb-release npm lcov leiningen ccache curl git git-lfs build-essential entr libssl-dev libdouble-conversion-dev pkg-config ninja-build cmake zlib1g-dev libffi-dev gcc g++ libgc-dev libboost-all-dev
+  #        packages: default-jdk software-properties-common lsb-release npm lcov leiningen ccache curl git build-essential libssl-dev libdouble-conversion-dev pkg-config ninja-build cmake zlib1g-dev libffi-dev gcc g++ libgc-dev libboost-all-dev
   #        # Increment this when the package list changes.
-  #        version: 13
+  #        version: 14
   #    # Boost doesn't get cached properly with the above action.
   #    # https://github.com/awalsh128/cache-apt-pkgs-action/issues/151
   #    - name: Install boost
@@ -333,7 +334,7 @@ jobs:
       - name: Install packages
         run: |
           pacman -Syu --noconfirm
-          pacman --noconfirm -S gcc git git-lfs pkg-config cmake ninja make python3 libffi entr libxml2 libedit boost
+          pacman --noconfirm -S gcc git pkg-config cmake ninja make python3 libffi libxml2 libedit boost
       - uses: actions/checkout@v4
         with:
           submodules: true
@@ -341,14 +342,8 @@ jobs:
         uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: |
-            ${{ github.workspace }}/compiler+runtime/build/llvm-install
-          key: clang-${{ runner.os }}-${{ hashFiles('${{ github.workspace }}/compiler+runtime/bin/build-clang') }}
-      - name: Cache ccache object files
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
-        with:
-          path: |
-            ${{ github.workspace }}/compiler+runtime/.ctcache
-          key: ccache-${{ env.JANK_MATRIX_ID }}-${{ github.ref_name }}
+            ${{ env.GITHUB_WORKSPACE }}/compiler+runtime/build/llvm-install
+          key: clang-Arch-${{ hashFiles('${{ github.workspace }}/compiler+runtime/bin/build-clang') }}
       - uses: thejerrybao/setup-swap-space@466d59798fb9263b9c2331c83cf71f9b7bfd0c78
         with:
           swap-space-path: /swapfile
@@ -357,8 +352,8 @@ jobs:
       - name: Build and test jank
         id: jank-build-step
         run: |
-          export CC=$PWD/build/llvm-install/usr/local/bin/clang;
-          export CXX=$PWD/build/llvm-install/usr/local/bin/clang++
+          export CC=${GITHUB_WORKSPACE}/build/llvm-install/usr/local/bin/clang;
+          export CXX=${GITHUB_WORKSPACE}/build/llvm-install/usr/local/bin/clang++
           ./bin/configure -GNinja -DCMAKE_BUILD_TYPE=Release -Djank_local_clang=on
           DESTDIR=inst ./bin/install
 

--- a/.github/workflows/build-compiler+runtime.yml
+++ b/.github/workflows/build-compiler+runtime.yml
@@ -343,7 +343,7 @@ jobs:
         with:
           path: |
             ${{ env.GITHUB_WORKSPACE }}/compiler+runtime/build/llvm-install
-          key: clang-Arch-${{ hashFiles('${{ github.workspace }}/compiler+runtime/bin/build-clang') }}
+          key: clang-Arch-${{ hashFiles('compiler+runtime/bin/build-clang') }}
       - name: Build and test jank
         id: jank-build-step
         run: |

--- a/.github/workflows/build-compiler+runtime.yml
+++ b/.github/workflows/build-compiler+runtime.yml
@@ -334,7 +334,7 @@ jobs:
       - name: Install packages
         run: |
           pacman -Syu --noconfirm
-          pacman --noconfirm -S gcc git pkg-config cmake ninja make python3 libffi libxml2 libedit boost scp
+          pacman --noconfirm -S gcc git pkg-config cmake ninja make python3 libffi libxml2 libedit boost openssh rsync
       - uses: actions/checkout@v4
         with:
           submodules: true
@@ -362,7 +362,7 @@ jobs:
           chmod 400 ~/.ssh/jank_id_ed25519
       - name: Publish to cache
         run: |
-          scp -i ~/.ssh/jank_id_ed25519 -o StrictHostKeyChecking=no ~/*.tar.gz root@cache.jank-lang.org:/var/www/cache.jank-lang.org/html/
+          rsync -avz -e "ssh -i ~/.ssh/jank_id_ed25519 -o StrictHostKeyChecking=no" --progress ~/*.tar.gz root@cache.jank-lang.org:/var/www/cache.jank-lang.org/html/
 
   #build-nix:
   #  name: "Nix - release"

--- a/.github/workflows/build-compiler+runtime.yml
+++ b/.github/workflows/build-compiler+runtime.yml
@@ -362,7 +362,7 @@ jobs:
           chmod 400 ~/.ssh/jank_id_ed25519
       - name: Publish to cache
         run: |
-          rsync -avz -e "ssh -i $HOME/.ssh/jank_id_ed25519 -o StrictHostKeyChecking=no" --progress ~/*.tar.gz root@cache.jank-lang.org:/var/www/cache.jank-lang.org/html/
+          rsync -avz -e "ssh -i $HOME/.ssh/jank_id_ed25519 -o StrictHostKeyChecking=no" --progress ~/*.tar.gz root@cache.jank-lang.org:/var/www/cache.jank-lang.org/html/arch
 
   #build-nix:
   #  name: "Nix - release"

--- a/.github/workflows/build-compiler+runtime.yml
+++ b/.github/workflows/build-compiler+runtime.yml
@@ -329,12 +329,13 @@ jobs:
     name: Publish Arch package
     timeout-minutes: 60
     steps:
+      - name: Install packages
+        run: |
+          pacman -Syu
+          pacman -S gcc git git-lfs pkg-config cmake ninja make python3 libffi entr libxml2 libedit boost
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Install packages
-        run: |
-          pacman -S gcc git git-lfs pkg-config cmake ninja make python3 libffi entr libxml2 libedit boost
       - name: Cache Clang/LLVM
         uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684
         with:

--- a/.github/workflows/build-compiler+runtime.yml
+++ b/.github/workflows/build-compiler+runtime.yml
@@ -344,11 +344,6 @@ jobs:
           path: |
             ${{ env.GITHUB_WORKSPACE }}/compiler+runtime/build/llvm-install
           key: clang-Arch-${{ hashFiles('${{ github.workspace }}/compiler+runtime/bin/build-clang') }}
-      - uses: thejerrybao/setup-swap-space@466d59798fb9263b9c2331c83cf71f9b7bfd0c78
-        with:
-          swap-space-path: /swapfile
-          swap-size-gb: 8
-          remove-existing-swap-files: true
       - name: Build and test jank
         id: jank-build-step
         run: |

--- a/.github/workflows/build-compiler+runtime.yml
+++ b/.github/workflows/build-compiler+runtime.yml
@@ -69,7 +69,7 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: |
-            ${{ env.GITHUB_WORKSPACE }}/compiler+runtime/build/llvm-install
+            compiler+runtime/build/llvm-install
           key: clang-Arch-${{ hashFiles('compiler+runtime/bin/build-clang') }}
 
       - name: Build Clang/LLVM
@@ -342,7 +342,7 @@ jobs:
         uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: |
-            ${{ env.GITHUB_WORKSPACE }}/compiler+runtime/build/llvm-install
+            compiler+runtime/build/llvm-install
           key: clang-Arch-${{ hashFiles('compiler+runtime/bin/build-clang') }}
       - name: Build and test jank
         id: jank-build-step

--- a/.github/workflows/build-compiler+runtime.yml
+++ b/.github/workflows/build-compiler+runtime.yml
@@ -58,12 +58,13 @@ jobs:
       image: archlinux:latest
     timeout-minutes: 200
     steps:
+      - name: Install packages
+        run: |
+          pacman -Syu
+          pacman -S gcc git git-lfs pkg-config cmake ninja make python3 libffi entr libxml2 libedit boost
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Install packages
-        run: |
-          pacman -S gcc git git-lfs pkg-config cmake ninja make python3 libffi entr libxml2 libedit boost
       - name: Cache Clang/LLVM
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
         with:

--- a/.github/workflows/build-compiler+runtime.yml
+++ b/.github/workflows/build-compiler+runtime.yml
@@ -53,6 +53,7 @@ jobs:
 
   arch-build-clang:
     name: Arch - clang
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     container:
       image: archlinux:latest

--- a/.github/workflows/build-compiler+runtime.yml
+++ b/.github/workflows/build-compiler+runtime.yml
@@ -60,8 +60,8 @@ jobs:
     steps:
       - name: Install packages
         run: |
-          pacman -Syu
-          pacman -S gcc git git-lfs pkg-config cmake ninja make python3 libffi entr libxml2 libedit boost
+          pacman -Syu --noconfirm
+          pacman --noconfirm -S gcc git git-lfs pkg-config cmake ninja make python3 libffi entr libxml2 libedit boost
       - uses: actions/checkout@v4
         with:
           submodules: true
@@ -332,8 +332,8 @@ jobs:
     steps:
       - name: Install packages
         run: |
-          pacman -Syu
-          pacman -S gcc git git-lfs pkg-config cmake ninja make python3 libffi entr libxml2 libedit boost
+          pacman -Syu --noconfirm
+          pacman --noconfirm -S gcc git git-lfs pkg-config cmake ninja make python3 libffi entr libxml2 libedit boost
       - uses: actions/checkout@v4
         with:
           submodules: true

--- a/.github/workflows/build-compiler+runtime.yml
+++ b/.github/workflows/build-compiler+runtime.yml
@@ -362,7 +362,7 @@ jobs:
           chmod 400 ~/.ssh/jank_id_ed25519
       - name: Publish to cache
         run: |
-          rsync -avz -e "ssh -i ~/.ssh/jank_id_ed25519 -o StrictHostKeyChecking=no" --progress ~/*.tar.gz root@cache.jank-lang.org:/var/www/cache.jank-lang.org/html/
+          rsync -avz -e "ssh -i $HOME/.ssh/jank_id_ed25519 -o StrictHostKeyChecking=no" --progress ~/*.tar.gz root@cache.jank-lang.org:/var/www/cache.jank-lang.org/html/
 
   #build-nix:
   #  name: "Nix - release"

--- a/.github/workflows/build-compiler+runtime.yml
+++ b/.github/workflows/build-compiler+runtime.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install packages
         run: |
           pacman -Syu --noconfirm
-          pacman --noconfirm -S gcc git pkg-config cmake ninja make python3 libffi libxml2 libedit
+          pacman --noconfirm -S gcc git clang pkg-config cmake ninja make python3 libffi libxml2 libedit
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build-compiler+runtime.yml
+++ b/.github/workflows/build-compiler+runtime.yml
@@ -53,7 +53,7 @@ jobs:
 
   arch-build-clang:
     name: Arch - clang
-    runs-on: archlinux/latest
+    runs-on: archlinux:latest
     timeout-minutes: 200
     steps:
       - uses: actions/checkout@v4
@@ -319,7 +319,7 @@ jobs:
   #        scp -i ~/.ssh/jank_id_ed25519 -o StrictHostKeyChecking=no ~/*.tar.gz root@cache.jank-lang.org:/var/www/cache.jank-lang.org/html/
 
   publish-arch-package:
-    runs-on: archlinux/latest
+    runs-on: archlinux:latest
     name: Publish Arch package
     timeout-minutes: 60
     steps:

--- a/.github/workflows/build-compiler+runtime.yml
+++ b/.github/workflows/build-compiler+runtime.yml
@@ -319,6 +319,8 @@ jobs:
   #        scp -i ~/.ssh/jank_id_ed25519 -o StrictHostKeyChecking=no ~/*.tar.gz root@cache.jank-lang.org:/var/www/cache.jank-lang.org/html/
 
   publish-arch-package:
+    needs:
+      - arch-build-clang
     runs-on: archlinux:latest
     name: Publish Arch package
     timeout-minutes: 60

--- a/.github/workflows/build-win-compiler+runtime.yml
+++ b/.github/workflows/build-win-compiler+runtime.yml
@@ -19,142 +19,142 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-jobs:
-  # Rather than having every job in the matrix try to build its own Clang, we built it once
-  # before running the matrix. Then we can just restore it from the cache in each job.
-  windows-build-clang:
-    name: Windows MSYS2 - clang
-    runs-on: windows-2022
-    timeout-minutes: 200
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-      - name: Cache Clang/LLVM
-        id: clang-cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
-        with:
-          path: |
-            ${{ github.workspace }}/compiler+runtime/build/llvm-install
-          key: clang-${{ runner.os }}-${{ hashFiles('compiler+runtime/bin/build-clang') }}
-
-      - uses: msys2/setup-msys2@v2
-        if: steps.clang-cache.outputs.cache-hit != 'true'
-        with:
-          msystem: CLANG64
-          install: base-devel git mingw-w64-clang-x86_64-clang mingw-w64-clang-x86_64-cmake mingw-w64-clang-x86_64-ninja mingw-w64-clang-x86_64-pkgconf mingw-w64-clang-x86_64-libunwind mingw-w64-clang-x86_64-libffi mingw-w64-clang-x86_64-z3 mingw-w64-clang-x86_64-python mingw-w64-clang-x86_64-compiler-rt mingw-w64-clang-x86_64-libc++
-          update: true
-
-      - name: Build Clang/LLVM
-        if: steps.clang-cache.outputs.cache-hit != 'true'
-        shell: msys2 {0}
-        env:
-          MSYSTEM: CLANG64
-        run: |
-          pushd compiler+runtime
-            ./bin/build-clang
-          popd
-          ls -al compiler+runtime/build/llvm-install
-
-  build-jank:
-    needs:
-      - windows-build-clang
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          ## Release
-          - name: Windows - release
-            os: windows-2022
-            build_type: Debug
-            sanitize: none
-            analyze: on
-    runs-on: ${{ matrix.os }}
-    name: ${{ matrix.name }}
-    env:
-      JANK_MATRIX_ID: ${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.sanitize }}
-      JANK_BUILD_TYPE: ${{ matrix.build_type }}
-      JANK_LINT: ${{ matrix.lint }}
-      JANK_COVERAGE: ${{ matrix.coverage }}
-      JANK_ANALYZE: ${{ matrix.analyze }}
-      JANK_SANITIZE: ${{ matrix.sanitize }}
-      JANK_PACKAGE: ${{ matrix.package }}
-      ASAN_OPTIONS: detect_leaks=0
-      TERM: xterm
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      HOMEBREW_NO_AUTO_UPDATE: 1
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-      - name: Install Homebrew packages
-        if: runner.os == 'macOS'
-        run: |
-          brew install cmake ninja double-conversion pkg-config llvm ccache boost openssl zlib doctest boost clojure/tools/clojure
-      - uses: msys2/setup-msys2@v2
-        if: runner.os == 'Windows'
-        with:
-          MSYSTEM: CLANG64
-          install: unzip mingw-w64-clang-x86_64-ccache base-devel curl zip mingw-w64-clang-x86_64-git-lfs mingw-w64-clang-x86_64-cmake mingw-w64-clang-x86_64-libffi mingw-w64-clang-x86_64-doctest mingw-w64-clang-x86_64-libzip mingw-w64-clang-x86_64-gc mingw-w64-clang-x86_64-boost
-          update: true
-      - name: Prepare java
-        if: runner.os == 'Windows'
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'zulu'
-          java-version: '25'
-      - name: Locate java (MS-Windows)
-        if: runner.os == 'Windows'
-        id: find
-        shell: pwsh
-        run: |
-          $java = (Get-Command java).Path
-          $dir = Split-Path $java
-          "java_dir=$dir" >> $env:GITHUB_OUTPUT
-
-      - name: Cache Clang/LLVM
-        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684
-        with:
-          path: |
-            ${{ github.workspace }}/compiler+runtime/build/llvm-install
-          key: clang-${{ runner.os }}-${{ hashFiles('compiler+runtime/bin/build-clang') }}
-      - name: Cache ccache object files
-        if: matrix.analyze == 'off'
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
-        with:
-          path: |
-            ${{ github.workspace }}/compiler+runtime/.ctcache
-          key: ccache-${{ env.JANK_MATRIX_ID }}-${{ github.ref_name }}
-      - name: Cache ctcache object files
-        if: matrix.analyze == 'on'
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
-        with:
-          path: |
-            ${{ github.workspace }}/compiler+runtime/.ctcache
-          key: ctcache-${{ env.JANK_MATRIX_ID }}-${{ github.ref_name }}
-      - name: Build and test jank (MS-Windows)
-        if: runner.os == 'Windows'
-        shell: msys2 {0}
-        env:
-          msystem: CLANG64
-        id: jank-build-step-win
-        run: |
-          curl -sL -o install-bb https://raw.githubusercontent.com/babashka/babashka/master/install
-          ./install-bb
-
-          curl -sL https://raw.githubusercontent.com/borkdude/deps.clj/master/install > install_clojure
-          ./install_clojure --as-clj
-
-          JAVA_DIR=$(cygpath -u "${{ steps.find.outputs.java_dir }}")
-
-          pushd compiler+runtime
-            ./bin/build-clang -i
-            clang++ --version
-          popd
-
-          if [[ "${JANK_SANITIZE}" != "none" || "${JANK_COVERAGE}" == "on" ]];
-          then
-            export JANK_SKIP_AOT_CHECK=1
-          fi
-          PATH="$PATH:$JAVA_DIR" JANK_INSTALL_DEPS=true ./bin/jank/check_everything.clj
+#jobs:
+#  # Rather than having every job in the matrix try to build its own Clang, we built it once
+#  # before running the matrix. Then we can just restore it from the cache in each job.
+#  windows-build-clang:
+#    name: Windows MSYS2 - clang
+#    runs-on: windows-2022
+#    timeout-minutes: 200
+#    steps:
+#      - uses: actions/checkout@v4
+#        with:
+#          submodules: true
+#      - name: Cache Clang/LLVM
+#        id: clang-cache
+#        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+#        with:
+#          path: |
+#            ${{ github.workspace }}/compiler+runtime/build/llvm-install
+#          key: clang-${{ runner.os }}-${{ hashFiles('compiler+runtime/bin/build-clang') }}
+#
+#      - uses: msys2/setup-msys2@v2
+#        if: steps.clang-cache.outputs.cache-hit != 'true'
+#        with:
+#          msystem: CLANG64
+#          install: base-devel git mingw-w64-clang-x86_64-clang mingw-w64-clang-x86_64-cmake mingw-w64-clang-x86_64-ninja mingw-w64-clang-x86_64-pkgconf mingw-w64-clang-x86_64-libunwind mingw-w64-clang-x86_64-libffi mingw-w64-clang-x86_64-z3 mingw-w64-clang-x86_64-python mingw-w64-clang-x86_64-compiler-rt mingw-w64-clang-x86_64-libc++
+#          update: true
+#
+#      - name: Build Clang/LLVM
+#        if: steps.clang-cache.outputs.cache-hit != 'true'
+#        shell: msys2 {0}
+#        env:
+#          MSYSTEM: CLANG64
+#        run: |
+#          pushd compiler+runtime
+#            ./bin/build-clang
+#          popd
+#          ls -al compiler+runtime/build/llvm-install
+#
+#  build-jank:
+#    needs:
+#      - windows-build-clang
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        include:
+#          ## Release
+#          - name: Windows - release
+#            os: windows-2022
+#            build_type: Debug
+#            sanitize: none
+#            analyze: on
+#    runs-on: ${{ matrix.os }}
+#    name: ${{ matrix.name }}
+#    env:
+#      JANK_MATRIX_ID: ${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.sanitize }}
+#      JANK_BUILD_TYPE: ${{ matrix.build_type }}
+#      JANK_LINT: ${{ matrix.lint }}
+#      JANK_COVERAGE: ${{ matrix.coverage }}
+#      JANK_ANALYZE: ${{ matrix.analyze }}
+#      JANK_SANITIZE: ${{ matrix.sanitize }}
+#      JANK_PACKAGE: ${{ matrix.package }}
+#      ASAN_OPTIONS: detect_leaks=0
+#      TERM: xterm
+#      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+#      HOMEBREW_NO_AUTO_UPDATE: 1
+#    timeout-minutes: 60
+#    steps:
+#      - uses: actions/checkout@v4
+#        with:
+#          submodules: true
+#      - name: Install Homebrew packages
+#        if: runner.os == 'macOS'
+#        run: |
+#          brew install cmake ninja double-conversion pkg-config llvm ccache boost openssl zlib doctest boost clojure/tools/clojure
+#      - uses: msys2/setup-msys2@v2
+#        if: runner.os == 'Windows'
+#        with:
+#          MSYSTEM: CLANG64
+#          install: unzip mingw-w64-clang-x86_64-ccache base-devel curl zip mingw-w64-clang-x86_64-git-lfs mingw-w64-clang-x86_64-cmake mingw-w64-clang-x86_64-libffi mingw-w64-clang-x86_64-doctest mingw-w64-clang-x86_64-libzip mingw-w64-clang-x86_64-gc mingw-w64-clang-x86_64-boost
+#          update: true
+#      - name: Prepare java
+#        if: runner.os == 'Windows'
+#        uses: actions/setup-java@v5
+#        with:
+#          distribution: 'zulu'
+#          java-version: '25'
+#      - name: Locate java (MS-Windows)
+#        if: runner.os == 'Windows'
+#        id: find
+#        shell: pwsh
+#        run: |
+#          $java = (Get-Command java).Path
+#          $dir = Split-Path $java
+#          "java_dir=$dir" >> $env:GITHUB_OUTPUT
+#
+#      - name: Cache Clang/LLVM
+#        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684
+#        with:
+#          path: |
+#            ${{ github.workspace }}/compiler+runtime/build/llvm-install
+#          key: clang-${{ runner.os }}-${{ hashFiles('compiler+runtime/bin/build-clang') }}
+#      - name: Cache ccache object files
+#        if: matrix.analyze == 'off'
+#        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+#        with:
+#          path: |
+#            ${{ github.workspace }}/compiler+runtime/.ctcache
+#          key: ccache-${{ env.JANK_MATRIX_ID }}-${{ github.ref_name }}
+#      - name: Cache ctcache object files
+#        if: matrix.analyze == 'on'
+#        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+#        with:
+#          path: |
+#            ${{ github.workspace }}/compiler+runtime/.ctcache
+#          key: ctcache-${{ env.JANK_MATRIX_ID }}-${{ github.ref_name }}
+#      - name: Build and test jank (MS-Windows)
+#        if: runner.os == 'Windows'
+#        shell: msys2 {0}
+#        env:
+#          msystem: CLANG64
+#        id: jank-build-step-win
+#        run: |
+#          curl -sL -o install-bb https://raw.githubusercontent.com/babashka/babashka/master/install
+#          ./install-bb
+#
+#          curl -sL https://raw.githubusercontent.com/borkdude/deps.clj/master/install > install_clojure
+#          ./install_clojure --as-clj
+#
+#          JAVA_DIR=$(cygpath -u "${{ steps.find.outputs.java_dir }}")
+#
+#          pushd compiler+runtime
+#            ./bin/build-clang -i
+#            clang++ --version
+#          popd
+#
+#          if [[ "${JANK_SANITIZE}" != "none" || "${JANK_COVERAGE}" == "on" ]];
+#          then
+#            export JANK_SKIP_AOT_CHECK=1
+#          fi
+#          PATH="$PATH:$JAVA_DIR" JANK_INSTALL_DEPS=true ./bin/jank/check_everything.clj

--- a/.github/workflows/build-win-compiler+runtime.yml
+++ b/.github/workflows/build-win-compiler+runtime.yml
@@ -19,142 +19,142 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-#jobs:
-#  # Rather than having every job in the matrix try to build its own Clang, we built it once
-#  # before running the matrix. Then we can just restore it from the cache in each job.
-#  windows-build-clang:
-#    name: Windows MSYS2 - clang
-#    runs-on: windows-2022
-#    timeout-minutes: 200
-#    steps:
-#      - uses: actions/checkout@v4
-#        with:
-#          submodules: true
-#      - name: Cache Clang/LLVM
-#        id: clang-cache
-#        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
-#        with:
-#          path: |
-#            ${{ github.workspace }}/compiler+runtime/build/llvm-install
-#          key: clang-${{ runner.os }}-${{ hashFiles('compiler+runtime/bin/build-clang') }}
-#
-#      - uses: msys2/setup-msys2@v2
-#        if: steps.clang-cache.outputs.cache-hit != 'true'
-#        with:
-#          msystem: CLANG64
-#          install: base-devel git mingw-w64-clang-x86_64-clang mingw-w64-clang-x86_64-cmake mingw-w64-clang-x86_64-ninja mingw-w64-clang-x86_64-pkgconf mingw-w64-clang-x86_64-libunwind mingw-w64-clang-x86_64-libffi mingw-w64-clang-x86_64-z3 mingw-w64-clang-x86_64-python mingw-w64-clang-x86_64-compiler-rt mingw-w64-clang-x86_64-libc++
-#          update: true
-#
-#      - name: Build Clang/LLVM
-#        if: steps.clang-cache.outputs.cache-hit != 'true'
-#        shell: msys2 {0}
-#        env:
-#          MSYSTEM: CLANG64
-#        run: |
-#          pushd compiler+runtime
-#            ./bin/build-clang
-#          popd
-#          ls -al compiler+runtime/build/llvm-install
-#
-#  build-jank:
-#    needs:
-#      - windows-build-clang
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        include:
-#          ## Release
-#          - name: Windows - release
-#            os: windows-2022
-#            build_type: Debug
-#            sanitize: none
-#            analyze: on
-#    runs-on: ${{ matrix.os }}
-#    name: ${{ matrix.name }}
-#    env:
-#      JANK_MATRIX_ID: ${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.sanitize }}
-#      JANK_BUILD_TYPE: ${{ matrix.build_type }}
-#      JANK_LINT: ${{ matrix.lint }}
-#      JANK_COVERAGE: ${{ matrix.coverage }}
-#      JANK_ANALYZE: ${{ matrix.analyze }}
-#      JANK_SANITIZE: ${{ matrix.sanitize }}
-#      JANK_PACKAGE: ${{ matrix.package }}
-#      ASAN_OPTIONS: detect_leaks=0
-#      TERM: xterm
-#      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-#      HOMEBREW_NO_AUTO_UPDATE: 1
-#    timeout-minutes: 60
-#    steps:
-#      - uses: actions/checkout@v4
-#        with:
-#          submodules: true
-#      - name: Install Homebrew packages
-#        if: runner.os == 'macOS'
-#        run: |
-#          brew install cmake ninja double-conversion pkg-config llvm ccache boost openssl zlib doctest boost clojure/tools/clojure
-#      - uses: msys2/setup-msys2@v2
-#        if: runner.os == 'Windows'
-#        with:
-#          MSYSTEM: CLANG64
-#          install: unzip mingw-w64-clang-x86_64-ccache base-devel curl zip mingw-w64-clang-x86_64-git-lfs mingw-w64-clang-x86_64-cmake mingw-w64-clang-x86_64-libffi mingw-w64-clang-x86_64-doctest mingw-w64-clang-x86_64-libzip mingw-w64-clang-x86_64-gc mingw-w64-clang-x86_64-boost
-#          update: true
-#      - name: Prepare java
-#        if: runner.os == 'Windows'
-#        uses: actions/setup-java@v5
-#        with:
-#          distribution: 'zulu'
-#          java-version: '25'
-#      - name: Locate java (MS-Windows)
-#        if: runner.os == 'Windows'
-#        id: find
-#        shell: pwsh
-#        run: |
-#          $java = (Get-Command java).Path
-#          $dir = Split-Path $java
-#          "java_dir=$dir" >> $env:GITHUB_OUTPUT
-#
-#      - name: Cache Clang/LLVM
-#        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684
-#        with:
-#          path: |
-#            ${{ github.workspace }}/compiler+runtime/build/llvm-install
-#          key: clang-${{ runner.os }}-${{ hashFiles('compiler+runtime/bin/build-clang') }}
-#      - name: Cache ccache object files
-#        if: matrix.analyze == 'off'
-#        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
-#        with:
-#          path: |
-#            ${{ github.workspace }}/compiler+runtime/.ctcache
-#          key: ccache-${{ env.JANK_MATRIX_ID }}-${{ github.ref_name }}
-#      - name: Cache ctcache object files
-#        if: matrix.analyze == 'on'
-#        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
-#        with:
-#          path: |
-#            ${{ github.workspace }}/compiler+runtime/.ctcache
-#          key: ctcache-${{ env.JANK_MATRIX_ID }}-${{ github.ref_name }}
-#      - name: Build and test jank (MS-Windows)
-#        if: runner.os == 'Windows'
-#        shell: msys2 {0}
-#        env:
-#          msystem: CLANG64
-#        id: jank-build-step-win
-#        run: |
-#          curl -sL -o install-bb https://raw.githubusercontent.com/babashka/babashka/master/install
-#          ./install-bb
-#
-#          curl -sL https://raw.githubusercontent.com/borkdude/deps.clj/master/install > install_clojure
-#          ./install_clojure --as-clj
-#
-#          JAVA_DIR=$(cygpath -u "${{ steps.find.outputs.java_dir }}")
-#
-#          pushd compiler+runtime
-#            ./bin/build-clang -i
-#            clang++ --version
-#          popd
-#
-#          if [[ "${JANK_SANITIZE}" != "none" || "${JANK_COVERAGE}" == "on" ]];
-#          then
-#            export JANK_SKIP_AOT_CHECK=1
-#          fi
-#          PATH="$PATH:$JAVA_DIR" JANK_INSTALL_DEPS=true ./bin/jank/check_everything.clj
+jobs:
+  # Rather than having every job in the matrix try to build its own Clang, we built it once
+  # before running the matrix. Then we can just restore it from the cache in each job.
+  windows-build-clang:
+    name: Windows MSYS2 - clang
+    runs-on: windows-2022
+    timeout-minutes: 200
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Cache Clang/LLVM
+        id: clang-cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            ${{ github.workspace }}/compiler+runtime/build/llvm-install
+          key: clang-${{ runner.os }}-${{ hashFiles('compiler+runtime/bin/build-clang') }}
+
+      - uses: msys2/setup-msys2@v2
+        if: steps.clang-cache.outputs.cache-hit != 'true'
+        with:
+          msystem: CLANG64
+          install: base-devel git mingw-w64-clang-x86_64-clang mingw-w64-clang-x86_64-cmake mingw-w64-clang-x86_64-ninja mingw-w64-clang-x86_64-pkgconf mingw-w64-clang-x86_64-libunwind mingw-w64-clang-x86_64-libffi mingw-w64-clang-x86_64-z3 mingw-w64-clang-x86_64-python mingw-w64-clang-x86_64-compiler-rt mingw-w64-clang-x86_64-libc++
+          update: true
+
+      - name: Build Clang/LLVM
+        if: steps.clang-cache.outputs.cache-hit != 'true'
+        shell: msys2 {0}
+        env:
+          MSYSTEM: CLANG64
+        run: |
+          pushd compiler+runtime
+            ./bin/build-clang
+          popd
+          ls -al compiler+runtime/build/llvm-install
+
+  build-jank:
+    needs:
+      - windows-build-clang
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          ## Release
+          - name: Windows - release
+            os: windows-2022
+            build_type: Debug
+            sanitize: none
+            analyze: on
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.name }}
+    env:
+      JANK_MATRIX_ID: ${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.sanitize }}
+      JANK_BUILD_TYPE: ${{ matrix.build_type }}
+      JANK_LINT: ${{ matrix.lint }}
+      JANK_COVERAGE: ${{ matrix.coverage }}
+      JANK_ANALYZE: ${{ matrix.analyze }}
+      JANK_SANITIZE: ${{ matrix.sanitize }}
+      JANK_PACKAGE: ${{ matrix.package }}
+      ASAN_OPTIONS: detect_leaks=0
+      TERM: xterm
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install Homebrew packages
+        if: runner.os == 'macOS'
+        run: |
+          brew install cmake ninja double-conversion pkg-config llvm ccache boost openssl zlib doctest boost clojure/tools/clojure
+      - uses: msys2/setup-msys2@v2
+        if: runner.os == 'Windows'
+        with:
+          MSYSTEM: CLANG64
+          install: unzip mingw-w64-clang-x86_64-ccache base-devel curl zip mingw-w64-clang-x86_64-git-lfs mingw-w64-clang-x86_64-cmake mingw-w64-clang-x86_64-libffi mingw-w64-clang-x86_64-doctest mingw-w64-clang-x86_64-libzip mingw-w64-clang-x86_64-gc mingw-w64-clang-x86_64-boost
+          update: true
+      - name: Prepare java
+        if: runner.os == 'Windows'
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: '25'
+      - name: Locate java (MS-Windows)
+        if: runner.os == 'Windows'
+        id: find
+        shell: pwsh
+        run: |
+          $java = (Get-Command java).Path
+          $dir = Split-Path $java
+          "java_dir=$dir" >> $env:GITHUB_OUTPUT
+
+      - name: Cache Clang/LLVM
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            ${{ github.workspace }}/compiler+runtime/build/llvm-install
+          key: clang-${{ runner.os }}-${{ hashFiles('compiler+runtime/bin/build-clang') }}
+      - name: Cache ccache object files
+        if: matrix.analyze == 'off'
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            ${{ github.workspace }}/compiler+runtime/.ctcache
+          key: ccache-${{ env.JANK_MATRIX_ID }}-${{ github.ref_name }}
+      - name: Cache ctcache object files
+        if: matrix.analyze == 'on'
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            ${{ github.workspace }}/compiler+runtime/.ctcache
+          key: ctcache-${{ env.JANK_MATRIX_ID }}-${{ github.ref_name }}
+      - name: Build and test jank (MS-Windows)
+        if: runner.os == 'Windows'
+        shell: msys2 {0}
+        env:
+          msystem: CLANG64
+        id: jank-build-step-win
+        run: |
+          curl -sL -o install-bb https://raw.githubusercontent.com/babashka/babashka/master/install
+          ./install-bb
+
+          curl -sL https://raw.githubusercontent.com/borkdude/deps.clj/master/install > install_clojure
+          ./install_clojure --as-clj
+
+          JAVA_DIR=$(cygpath -u "${{ steps.find.outputs.java_dir }}")
+
+          pushd compiler+runtime
+            ./bin/build-clang -i
+            clang++ --version
+          popd
+
+          if [[ "${JANK_SANITIZE}" != "none" || "${JANK_COVERAGE}" == "on" ]];
+          then
+            export JANK_SKIP_AOT_CHECK=1
+          fi
+          PATH="$PATH:$JAVA_DIR" JANK_INSTALL_DEPS=true ./bin/jank/check_everything.clj

--- a/README.md
+++ b/README.md
@@ -69,13 +69,6 @@ If you'd like your name, company, or logo here, you can
   </a>
 </p>
 
-<!-- mkarp -->
-<p align="center">
-  <a href="https://pitch.com/">
-    Misha Karpenko
-  </a>
-</p>
-
 <!-- stijlist -->
 <p align="center">
   <a href="http://www.somethingdoneright.net/about">

--- a/bin/jank/util.clj
+++ b/bin/jank/util.clj
@@ -7,7 +7,7 @@
 (def compiler+runtime-dir (str (b.f/canonicalize (str (b.f/parent *file*) "/../../compiler+runtime"))))
 (def llvm-bin-dir (str compiler+runtime-dir "/build/llvm-install/usr/local/bin"))
 
-(def llvm-version 22)
+(def llvm-version 23)
 
 (defn get-env
   ([s]

--- a/bin/jank/util.clj
+++ b/bin/jank/util.clj
@@ -7,7 +7,9 @@
 (def compiler+runtime-dir (str (b.f/canonicalize (str (b.f/parent *file*) "/../../compiler+runtime"))))
 (def llvm-bin-dir (str compiler+runtime-dir "/build/llvm-install/usr/local/bin"))
 
-(def llvm-version 23)
+(def llvm-version (if (b.f/windows?)
+                    22
+                    23))
 
 (defn get-env
   ([s]

--- a/compiler+runtime/bin/build-clang
+++ b/compiler+runtime/bin/build-clang
@@ -60,7 +60,14 @@ llvm_commit="106644f6c835f9d2137aeb9cbfe1b9a60d03d17f"
 llvm_branch="jank"
 llvm_dest_dir="${srcdir}/llvm-install"
 llvm_build_dir="${srcdir}/llvm-build"
+
 if [[ -n "${MSYSTEM:-}" ]]; then
+
+    # Keeping Windows on 22 for now, since the mingw package relies on Github releases and 23
+    # is still unreleased.
+    llvm_version=22
+    llvm_commit="8164f1a0c17b192e133817436bdb07598b7402a3"
+
     # Building LLVM on MSYS2 requires a pacman package definition.  a
     # patched version of MINGW-packages/mingw-w64-llvm is used, which
     # is maintain separately.

--- a/compiler+runtime/bin/build-clang
+++ b/compiler+runtime/bin/build-clang
@@ -54,10 +54,9 @@ echo "Using ${make_j} cores to build"
 srcdir="${PWD}"
 
 llvm_url="https://github.com/jank-lang/llvm-project.git"
-llvm_version=22
+llvm_version=23
 llvm_branch="jank-snapshot/llvm${llvm_version}"
-# 8164f1a0c17b192e133817436bdb07598b7402a3
-llvm_commit="8164f1a0c17b192e133817436bdb07598b7402a3"
+llvm_commit="106644f6c835f9d2137aeb9cbfe1b9a60d03d17f"
 llvm_branch="jank"
 llvm_dest_dir="${srcdir}/llvm-install"
 llvm_build_dir="${srcdir}/llvm-build"

--- a/compiler+runtime/doc/build.md
+++ b/compiler+runtime/doc/build.md
@@ -125,5 +125,5 @@ JIT compilation.
 ```bash
 cd compiler+runtime
 ./bin/configure -GNinja -DCMAKE_BUILD_TYPE=Release
-./bin/install
+DESTDIR=inst ./bin/install
 ```

--- a/compiler+runtime/include/cpp/jank/c_api.h
+++ b/compiler+runtime/include/cpp/jank/c_api.h
@@ -345,7 +345,7 @@ extern "C"
                         jank_usize pch_size,
                         int (*fn)(int const, char const ** const));
 
-  jank_object_ref jank_parse_command_line_args(int const argc, char const **argv);
+  jank_object_ref jank_parse_command_line_args(int const argc, char const * const * const argv);
 
 #ifdef __cplusplus
 }

--- a/compiler+runtime/include/cpp/jank/gc.hpp
+++ b/compiler+runtime/include/cpp/jank/gc.hpp
@@ -6,6 +6,9 @@
 /* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) */
 #define GC_NAME_CONFLICT 1
 
+/* libc++ needs this. */
+#include <cstddef>
+
 #include <gc/gc_cpp.h>
 #include <gc/gc_allocator.h>
 #include <gc/gc_typed.h>

--- a/compiler+runtime/include/cpp/jank/ir/rewrite.hpp
+++ b/compiler+runtime/include/cpp/jank/ir/rewrite.hpp
@@ -7,5 +7,5 @@ namespace jank::ir
   struct function;
   using identifier = jtl::immutable_string;
 
-  void rewrite_uses(function &fn, identifier const &old_name, identifier const &new_name);
+  void rewrite_uses(function const &fn, identifier const &old_name, identifier const &new_name);
 }

--- a/compiler+runtime/include/cpp/jank/runtime/detail/type.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/detail/type.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+/* libc++ needs this. */
+#include <exception>
+
 #include <immer/vector.hpp>
 #include <immer/vector_transient.hpp>
 #include <immer/map.hpp>

--- a/compiler+runtime/include/cpp/jank/runtime/obj/nil.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/nil.hpp
@@ -57,8 +57,8 @@ namespace jank::runtime::obj
 
 namespace jank::runtime
 {
-  bool operator==(object *, obj::nil_ref);
-  bool operator!=(object *, obj::nil_ref);
+  bool operator==(object const *, obj::nil_ref);
+  bool operator!=(object const *, obj::nil_ref);
 
   extern obj::nil const _jank_nil;
   extern obj::nil_ref const jank_nil;

--- a/compiler+runtime/include/cpp/jank/util/cli.hpp
+++ b/compiler+runtime/include/cpp/jank/util/cli.hpp
@@ -160,8 +160,9 @@ namespace jank::util::cli
   extern options opts;
 
   /* Affects the global opts. */
-  jtl::result<void, int> parse_opts(int const argc, char const **argv);
+  jtl::result<void, int> parse_opts(int const argc, char const * const * const argv);
 
   /* Takes the CLI args and puts 'em in a vector. */
-  native_vector<jtl::immutable_string> parse_into_vector(int const argc, char const **argv);
+  native_vector<jtl::immutable_string>
+  parse_into_vector(int const argc, char const * const * const argv);
 }

--- a/compiler+runtime/include/cpp/jank/util/scope_exit.hpp
+++ b/compiler+runtime/include/cpp/jank/util/scope_exit.hpp
@@ -10,7 +10,7 @@ namespace jank::util
 
     scope_exit(function_type &&f);
     scope_exit(function_type &&f, bool should_propagate_exceptions);
-    ~scope_exit() noexcept(false);
+    ~scope_exit();
 
     void release()
     {

--- a/compiler+runtime/src/cpp/jank/analyze/cpp_util.cpp
+++ b/compiler+runtime/src/cpp/jank/analyze/cpp_util.cpp
@@ -1050,13 +1050,10 @@ namespace jank::analyze::cpp_util
       for(size_t i{ 0 }; i < arg_types.size() - member; ++i)
       {
         auto const scope{ arg_scopes[i + member] };
-        if(scope)
+        if(scope && Cpp::IsTemplate(scope))
         {
-          if(Cpp::IsTemplate(scope))
-          {
-            auto const new_type{ Cpp::GetFunctionArgType(match, i) };
-            arg_types[i + member].m_Type = new_type;
-          }
+          auto const new_type{ Cpp::GetFunctionArgType(match, i) };
+          arg_types[i + member].m_Type = new_type;
         }
       }
 
@@ -1289,8 +1286,8 @@ namespace jank::analyze::cpp_util
     }
 
     if(/* Up cast. */
-       (Cpp::IsTypeDerivedFrom(Cpp::GetUnderlyingType(expr_type),
-                               Cpp::GetUnderlyingType(expected_type)))
+       Cpp::IsTypeDerivedFrom(Cpp::GetUnderlyingType(expr_type),
+                              Cpp::GetUnderlyingType(expected_type))
        /* Same type or adding reference. */
        || (Cpp::GetCanonicalType(expr_type)
              == Cpp::GetCanonicalType(Cpp::GetNonReferenceType(expected_type))

--- a/compiler+runtime/src/cpp/jank/analyze/cpp_util.cpp
+++ b/compiler+runtime/src/cpp/jank/analyze/cpp_util.cpp
@@ -146,7 +146,7 @@ namespace jank::analyze::cpp_util
                 util::format("Unable to find '{}' within namespace '{}'.", subs, old_scope_name));
             }
           }
-          if(auto const res = instantiate_if_needed(fns[0]); res.is_err())
+          if(auto const res{ instantiate_if_needed(fns[0]) }; res.is_err())
           {
             return res.expect_err();
           }

--- a/compiler+runtime/src/cpp/jank/analyze/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/analyze/processor.cpp
@@ -217,15 +217,13 @@ namespace jank::analyze
                                          expr::cpp_value_ref const val,
                                          native_vector<runtime::object_ref> const &macro_expansions)
   {
-    if(args.size() == 2)
+    if(args.size() == 2
+       && ((Cpp::IsPointerType(Cpp::GetNonReferenceType(args[0].m_Type))
+            && !Cpp::IsIntegral(Cpp::GetNonReferenceType(args[1].m_Type)))
+           || (Cpp::IsPointerType(Cpp::GetNonReferenceType(args[1].m_Type))
+               && !Cpp::IsIntegral(Cpp::GetNonReferenceType(args[0].m_Type)))))
     {
-      if((Cpp::IsPointerType(Cpp::GetNonReferenceType(args[0].m_Type))
-          && !Cpp::IsIntegral(Cpp::GetNonReferenceType(args[1].m_Type)))
-         || (Cpp::IsPointerType(Cpp::GetNonReferenceType(args[1].m_Type))
-             && !Cpp::IsIntegral(Cpp::GetNonReferenceType(args[0].m_Type))))
-      {
-        return invalid_binary(args, op_name, val, macro_expansions);
-      }
+      return invalid_binary(args, op_name, val, macro_expansions);
     }
 
     return ok();
@@ -236,14 +234,11 @@ namespace jank::analyze
                                        expr::cpp_value_ref const val,
                                        native_vector<runtime::object_ref> const &macro_expansions)
   {
-    if(args.size() == 2)
+    if(args.size() == 2 && Cpp::IsIntegral(Cpp::GetNonReferenceType(args[0].m_Type))
+       && Cpp::IsPointerType(Cpp::GetNonReferenceType(args[1].m_Type)))
     {
-      if(Cpp::IsIntegral(Cpp::GetNonReferenceType(args[0].m_Type))
-         && Cpp::IsPointerType(Cpp::GetNonReferenceType(args[1].m_Type)))
-      {
-        /* TODO: Add a note to swap the arguments. */
-        return invalid_binary(args, op_name, val, macro_expansions);
-      }
+      /* TODO: Add a note to swap the arguments. */
+      return invalid_binary(args, op_name, val, macro_expansions);
     }
 
     return ok();
@@ -848,14 +843,12 @@ namespace jank::analyze
        * Nothing else could have an unresolved template up until now. */
       for(size_t i{}; i < arg_types.size(); ++i)
       {
-        if(auto const value = llvm::dyn_cast<expr::cpp_value>(arg_exprs[i].data))
+        /* Just adding a reference to the same type is not worthy of change.
+         * For some situations, this would fuck up codegen. For example, with enum constants. */
+        if(auto const value{ llvm::dyn_cast<expr::cpp_value>(arg_exprs[i].data) };
+           value && value->type.data != Cpp::GetNonReferenceType(arg_types[i].m_Type))
         {
-          /* Just adding a reference to the same type is not worthy of change.
-           * For some situations, this would fuck up codegen. For example, with enum constants. */
-          if(value->type.data != Cpp::GetNonReferenceType(arg_types[i].m_Type))
-          {
-            value->type = arg_types[i].m_Type;
-          }
+          value->type = arg_types[i].m_Type;
         }
       }
 

--- a/compiler+runtime/src/cpp/jank/c_api.cpp
+++ b/compiler+runtime/src/cpp/jank/c_api.cpp
@@ -1070,7 +1070,7 @@ extern "C"
     return 0;
   }
 
-  jank_object_ref jank_parse_command_line_args(int const argc, char const **argv)
+  jank_object_ref jank_parse_command_line_args(int const argc, char const * const * const argv)
   {
     obj::transient_vector trans;
     auto const args{ util::cli::parse_into_vector(argc, argv) };

--- a/compiler+runtime/src/cpp/jank/codegen/cpp_processor.cpp
+++ b/compiler+runtime/src/cpp/jank/codegen/cpp_processor.cpp
@@ -1245,7 +1245,14 @@ namespace jank::codegen
         util::format_to(b.body_buffer, "auto &&{}(", inst->name);
       }
 
-      util::format_to(b.body_buffer, "{}(", Cpp::GetQualifiedCompleteName(source->scope));
+      if(Cpp::IsInlineFriendFunction(source->scope))
+      {
+        util::format_to(b.body_buffer, "{}(", Cpp::GetName(source->scope));
+      }
+      else
+      {
+        util::format_to(b.body_buffer, "{}(", Cpp::GetQualifiedCompleteName(source->scope));
+      }
 
       bool need_comma{};
       for(usize arg_idx{}; arg_idx < inst->expr->arg_exprs.size(); ++arg_idx)

--- a/compiler+runtime/src/cpp/jank/codegen/cpp_processor.cpp
+++ b/compiler+runtime/src/cpp/jank/codegen/cpp_processor.cpp
@@ -120,7 +120,7 @@ namespace jank::codegen
     native_set<ir::identifier> seen_blocks;
   };
 
-  using identifier = ir::identifier;
+  using ir::identifier;
 
 
   static folly::Synchronized<
@@ -131,7 +131,7 @@ namespace jank::codegen
     /* NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables) */
     global_vars;
 
-  static identifier lift_constant(identifier const &name, object_ref const o, builder &b)
+  static identifier lift_constant(identifier const &name, object_ref const o, builder const &b)
   {
     if(b.module->target == compilation_target::eval)
     {
@@ -187,7 +187,8 @@ namespace jank::codegen
     return name;
   }
 
-  static jtl::immutable_string lift_var(jtl::immutable_string const &qualified_var, builder &b)
+  static jtl::immutable_string
+  lift_var(jtl::immutable_string const &qualified_var, builder const &b)
   {
     if(b.module->target == compilation_target::eval)
     {

--- a/compiler+runtime/src/cpp/jank/ir/rewrite.cpp
+++ b/compiler+runtime/src/cpp/jank/ir/rewrite.cpp
@@ -311,7 +311,7 @@ namespace jank::ir
 
   /* Rewrite all uses of `old_name` in the function to use `new_name` instead.
    * This covers all instruction operands in every block. */
-  void rewrite_uses(function &fn, identifier const &old_name, identifier const &new_name)
+  void rewrite_uses(function const &fn, identifier const &old_name, identifier const &new_name)
   {
     for(auto const &block : fn.blocks)
     {

--- a/compiler+runtime/src/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/src/cpp/jank/read/lex.cpp
@@ -1441,15 +1441,14 @@ namespace jank::read::lex
           auto const result(peek());
           auto const [character, len](result.unwrap_or(codepoint{ ' ', 1 }));
           pos += len;
-          switch(character)
+          if(character == '@')
           {
-            case '@':
-              {
-                ++pos;
-                return ok(token{ token_start, pos, token_kind::unquote_splice });
-              }
-            default:
-              return ok(token{ token_start, pos, token_kind::unquote });
+            ++pos;
+            return ok(token{ token_start, pos, token_kind::unquote_splice });
+          }
+          else
+          {
+            return ok(token{ token_start, pos, token_kind::unquote });
           }
         }
         /* Deref macro. */

--- a/compiler+runtime/src/cpp/jank/runtime/core.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core.cpp
@@ -3,6 +3,7 @@
 #include <deque>
 #include <pthread.h>
 #include <cxxabi.h>
+#include <charconv>
 
 #include <jank/gc.hpp>
 #include <jank/runtime/core.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/core.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core.cpp
@@ -920,13 +920,6 @@ namespace jank::runtime
     auto const ret{ make_box<obj::future>() };
     /* NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): False positive. */
     ret->thread = std::thread{ [=]() {
-      /* GC threads should be explicitly registered so that the GC is prepared to perform
-       * allocations from this thread. Unregistering is equally important. */
-      GC_stack_base sb{};
-      GC_get_stack_base(&sb);
-      GC_register_my_thread(&sb);
-      util::scope_exit const unregister{ []() { GC_unregister_my_thread(); } };
-
       __rt_ctx->push_thread_bindings(bindings).expect_ok();
 
       try

--- a/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
@@ -34,13 +34,13 @@ namespace jank::runtime
         {
           return true;
         }
-        else if constexpr(behavior::seqable<T>)
-        {
-          return typed_o->seq().is_nil();
-        }
         else if constexpr(behavior::countable<T>)
         {
           return typed_o->count() == 0;
+        }
+        else if constexpr(behavior::seqable<T>)
+        {
+          return typed_o->seq().is_nil();
         }
         else
         {

--- a/compiler+runtime/src/cpp/jank/runtime/ns.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/ns.cpp
@@ -175,19 +175,17 @@ namespace jank::runtime
   jtl::result<void, jtl::immutable_string> ns::refer(obj::symbol_ref const sym, var_ref const var)
   {
     auto locked_vars(vars.wlock());
-    if(auto const found = (*locked_vars)->data.find(sym))
+    if(auto const found{ (*locked_vars)->data.find(sym) };
+       found && found->get_type() == object_type::var)
     {
-      if(found->get_type() == object_type::var)
+      auto const found_var(expect_object<runtime::var>(*found));
+      auto const clojure_core(__rt_ctx->find_ns(make_box<obj::symbol>("clojure.core")));
+      if(var->n != found_var->n && (found_var->n != clojure_core))
       {
-        auto const found_var(expect_object<runtime::var>(*found));
-        auto const clojure_core(__rt_ctx->find_ns(make_box<obj::symbol>("clojure.core")));
-        if(var->n != found_var->n && (found_var->n != clojure_core))
-        {
-          return err(util::format("{} already refers to {} in ns {}",
-                                  sym->to_string(),
-                                  expect_object<runtime::var>(*found)->to_string(),
-                                  to_string()));
-        }
+        return err(util::format("{} already refers to {} in ns {}",
+                                sym->to_string(),
+                                expect_object<runtime::var>(*found)->to_string(),
+                                to_string()));
       }
     }
     *locked_vars = make_box<obj::persistent_hash_map>((*locked_vars)->data.set(sym, var));

--- a/compiler+runtime/src/cpp/jank/runtime/obj/nil.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/nil.cpp
@@ -99,12 +99,12 @@ namespace jank::runtime::obj
 
 namespace jank::runtime
 {
-  bool operator==(object * const lhs, obj::nil_ref)
+  bool operator==(object const * const lhs, obj::nil_ref)
   {
     return lhs->type == object_type::nil;
   }
 
-  bool operator!=(object * const lhs, obj::nil_ref)
+  bool operator!=(object const * const lhs, obj::nil_ref)
   {
     return lhs->type != object_type::nil;
   }

--- a/compiler+runtime/src/cpp/jank/util/cli.cpp
+++ b/compiler+runtime/src/cpp/jank/util/cli.cpp
@@ -210,7 +210,7 @@ OPTIONS
     }
   }
 
-  jtl::result<void, int> parse_opts(int const argc, char const **argv)
+  jtl::result<void, int> parse_opts(int const argc, char const * const * const argv)
   {
     auto const flags{ parse_into_vector(argc, argv) };
 
@@ -260,13 +260,13 @@ OPTIONS
         {
           if(check_flag(it, end, value, util::format("-O{}", pass.first), false))
           {
-            scratch.*(pass.second) = true;
+            scratch.*pass.second = true;
             handled = true;
             break;
           }
           else if(check_flag(it, end, value, util::format("-Ono-{}", pass.first), false))
           {
-            scratch.*(pass.second) = false;
+            scratch.*pass.second = false;
             handled = true;
             break;
           }
@@ -517,7 +517,8 @@ OPTIONS
     return ok();
   }
 
-  native_vector<jtl::immutable_string> parse_into_vector(int const argc, char const **argv)
+  native_vector<jtl::immutable_string>
+  parse_into_vector(int const argc, char const * const * const argv)
   {
     native_vector<jtl::immutable_string> ret;
     ret.reserve(argc - 1);

--- a/compiler+runtime/src/cpp/jank/util/scope_exit.cpp
+++ b/compiler+runtime/src/cpp/jank/util/scope_exit.cpp
@@ -16,7 +16,7 @@ namespace jank::util
   {
   }
 
-  scope_exit::~scope_exit() noexcept(false)
+  scope_exit::~scope_exit()
   {
     if(!active)
     {

--- a/compiler+runtime/src/cpp/jank/util/scope_exit.cpp
+++ b/compiler+runtime/src/cpp/jank/util/scope_exit.cpp
@@ -16,6 +16,7 @@ namespace jank::util
   {
   }
 
+  /* NOLINTNEXTLINE(bugprone-exception-escape): This is allowed, in some cases. */
   scope_exit::~scope_exit()
   {
     if(!active)

--- a/compiler+runtime/src/cpp/main.cpp
+++ b/compiler+runtime/src/cpp/main.cpp
@@ -263,7 +263,7 @@ namespace jank
         continue;
       }
 
-      if(line.ends_with("\\"))
+      if(line.ends_with('\\'))
       {
         input.append(line.substr(0, line.size() - 1));
         input.append("\n");
@@ -331,7 +331,7 @@ namespace jank
         continue;
       }
 
-      if(line.ends_with("\\"))
+      if(line.ends_with('\\'))
       {
         input.append(line.substr(0, line.size() - 1));
         le.setPrompt("native>... ");

--- a/compiler+runtime/test/bash/ahead-of-time/pass-test
+++ b/compiler+runtime/test/bash/ahead-of-time/pass-test
@@ -114,7 +114,10 @@
       (is (string= expected-output (-> default-output-file-path proc/sh :out))))))
 
 (defn -main []
-  (when (empty? (System/getenv "JANK_SKIP_AOT_CHECK"))
+  (when (or (empty? (System/getenv "JANK_SKIP_AOT_CHECK"))
+            ; Windows is sometimes failing in CI, presumably due to a race condition.
+            ; An example failure is here: https://github.com/jank-lang/jank/actions/runs/28888267509/job/85694092257?pr=846
+            (fs/windows?))
     (proc/sh {:out *out* :err *out*} "jank check-health")
     (System/exit
      (if (t/successful? (t/run-tests this-nsym))

--- a/compiler+runtime/test/cpp/jank/jit/processor.cpp
+++ b/compiler+runtime/test/cpp/jank/jit/processor.cpp
@@ -76,7 +76,7 @@ namespace jank::jit
 
         auto const filename(dir_entry.path().filename().string());
 
-        if(filename.starts_with("."))
+        if(filename.starts_with('.'))
         {
           continue;
         }

--- a/compiler+runtime/test/jank/cpp/call/friend/pass-inline-adl.jank
+++ b/compiler+runtime/test/jank/cpp/call/friend/pass-inline-adl.jank
@@ -8,5 +8,5 @@
           }")
 
 (let [f (cpp/jank.cpp.call.friend_.pass_inline_adl.foo)]
-  (if (= 6 (cpp/bar f))
+  (if (= 6 (cpp/jank.cpp.call.friend_.pass_inline_adl.bar f))
     :success))

--- a/flake.nix
+++ b/flake.nix
@@ -181,6 +181,8 @@
             clangbuildanalyzer
             openjdk
             leiningen
+            expect
+            nodejs
 
             # Examples.
             pkg-config

--- a/lein-jank/src/leiningen/jank/build.clj
+++ b/lein-jank/src/leiningen/jank/build.clj
@@ -271,8 +271,9 @@
                        :build-opts   build-opts
                        :build-inputs (collect-build-deps tree)
                        :inputs       (collect-out-dirs dep-ops)
-                       :always-build true}])]
-      (into dep-ops root-ops))))
+                       :always-build true}])
+          plan (into dep-ops root-ops)]
+      plan)))
 
 (defmulti run-build-op! (fn [_ op] (:op op)))
 


### PR DESCRIPTION
As part of this PR, we:

* Add an Arch CI job, which runs on main, to publish tarballs for Arch packaging
* Add (unreleased) LLVM 23 support and bump CI to use LLVM 23 by default (except on Windows)
* Add support for ADL calls for inline friend fns, which became necessary with recent libc++ changes
* Fix double registration of GC threads (this closes #708 and #722)