### PR TITLE
Reduce noise on `clojure-test-suite` failures

### DIFF
--- a/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
+++ b/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
@@ -245,10 +245,9 @@
     ;; TODO: Enable once support for exception unwinding across JIT compiled frames is
     ;; added for Windows.
     (println :skip-clojure-test-suite-windows)
-    (do
-      (when (seq namespaces)
-        (apply require namespaces)
-        ;; TODO (t/run-all-tests) => Exception: "TODO: port all-ns"
-        (when-not (t/successful? (apply t/run-tests namespaces))
-          (throw "failed")))))
+    (when (seq namespaces)
+      (apply require namespaces)
+      ;; TODO (t/run-all-tests) => Exception: "TODO: port all-ns"
+      (when-not (t/successful? (apply t/run-tests namespaces))
+        (cpp/exit 1))))
   (println :clojure-test-suite-successful))


### PR DESCRIPTION
I was debugging `clojure.core-test.take-nth` and got confused for a while about the stack trace I was seeing. Turns out it was unrelated and is just how the test runner communicates failure. I think we can simply exist with a non 0 code instead.

Before:
```clojure
% ./pass-test
warning: 'sleep' already referred to #'clojure.core/sleep in namespace 'clojure.core-test.portability' but has been replaced by #'clojure.core-test.portability/sleep

Testing clojure.core-test.take-nth

FAIL in (nil) (:)
Negative cases
expected: (p/thrown? (seq (take-nth nil (range 10))))

Ran 1 tests containing 14 assertions.
1 failures, 0 errors.
Uncaught exception: failed

Stack trace (most recent call first):
#0  at libstdc++.so.6
#4  
#5  in jank::runtime::obj::jit_function::call() const at jit_function.cpp:67
#6  in jank::runtime::oref<jank::runtime::object>::call() const at oref.hpp:524
#7  in jank::runtime::oref<jank::runtime::object> jank::runtime::apply_to(jank::runtime::oref<jank::runtime::object>, jank::runtime::oref<jank::runtime::object>)::$_0::operator()<jank::runtime::oref<jank::runtime::obj::persistent_vector> >(jank::runtime::oref<jank::runtime::obj::persistent_vector>) const at call.cpp:28
#8  in auto jank::runtime::visit_seqable<jank::runtime::apply_to(jank::runtime::oref<jank::runtime::object>, jank::runtime::oref<jank::runtime::object>)::$_0, jank::runtime::visit_seqable<jank::runtime::apply_to(jank::runtime::oref<jank::runtime::object>, jank::runtime::oref<jank::runtime::object>)::$_0>(jank::runtime::apply_to(jank::runtime::oref<jank::runtime::object>, jank::runtime::oref<jank::runtime::object>)::$_0 const&, jank::runtime::oref<jank::runtime::object>)::{lambda()#1}>(jank::runtime::apply_to(jank::runtime::oref<jank::runtime::object>, jank::runtime::oref<jank::runtime::object>)::$_0 const&, jank::runtime::visit_seqable<jank::runtime::apply_to(jank::runtime::oref<jank::runtime::object>, jank::runtime::oref<jank::runtime::object>)::$_0>(jank::runtime::apply_to(jank::runtime::oref<jank::runtime::object>, jank::runtime::oref<jank::runtime::object>)::$_0 const&, jank::runtime::oref<jank::runtime::object>)::{lambda()#1} const&, jank::runtime::oref<jank::runtime::object>) requires (visitable<jank::runtime::apply_to(jank::runtime::oref<jank::runtime::object>, jank::runtime::oref<jank::runtime::object>)::$_0>)&&(!(std::convertible_to<jank::runtime::visit_seqable<jank::runtime::apply_to(jank::runtime::oref<jank::runtime::object>, jank::runtime::oref<jank::runtime::object>)::$_0>(jank::runtime::apply_to(jank::runtime::oref<jank::runtime::object>, jank::runtime::oref<jank::runtime::object>)::$_0 const&, jank::runtime::oref<jank::runtime::object>)::{lambda()#1}, jank::runtime::oref<jank::runtime::object> >)) at visit.hpp:283
#9  in auto jank::runtime::visit_seqable<jank::runtime::apply_to(jank::runtime::oref<jank::runtime::object>, jank::runtime::oref<jank::runtime::object>)::$_0>(jank::runtime::apply_to(jank::runtime::oref<jank::runtime::object>, jank::runtime::oref<jank::runtime::object>)::$_0 const&, jank::runtime::oref<jank::runtime::object>) at visit.hpp:350
#10 in jank::runtime::apply_to(jank::runtime::oref<jank::runtime::object>, jank::runtime::oref<jank::runtime::object>) at call.cpp:15
#11 in jank::run_main() at main.cpp:124
#12 in main::$_0::operator()(int, char const**) const at main.cpp:483
#13 in main::$_0::__invoke(int, char const**) at main.cpp:395
#14 in jank_init_dynamic at c_api_dynamic.cpp:41
#15 in main at main.cpp:389
#16 at libc.so.6
#17 in __libc_start_main at libc.so.6
```

After
```clojure
% ./pass-test
warning: 'sleep' already referred to #'clojure.core/sleep in namespace 'clojure.core-test.portability' but has been replaced by #'clojure.core-test.portability/sleep

Testing clojure.core-test.take-nth

FAIL in (nil) (:)
Negative cases
expected: (p/thrown? (seq (take-nth nil (range 10))))

Ran 1 tests containing 14 assertions.
1 failures, 0 errors.
```