### PR TITLE
Explicitly fail `rem` when div is 0

### DIFF
--- a/compiler+runtime/src/cpp/jank/runtime/core/math.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/math.cpp
@@ -177,8 +177,15 @@ namespace jank::runtime
             }
             else
             {
-              auto const l_real{ to_real(typed_l_data) };
               auto const r_real{ to_real(typed_r->data) };
+
+              if(r_real == 0)
+              {
+                throw std::runtime_error{ "Illegal divide by zero in 'rem'" };
+              }
+
+              auto const l_real{ to_real(typed_l_data) };
+
               return make_box(std::fmod(l_real, r_real)).erase();
             }
           },

--- a/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
+++ b/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
@@ -202,7 +202,7 @@
     ; clojure.core-test.subvec ; libc++abi: terminating due to uncaught exception of type std::runtime_error: invalid object type (expected integer found real).
     ; clojure.core-test.symbol ; lex/invalid-ratio error: A ratio denominator must be an integer.
     clojure.core-test.symbol-qmark
-    ; clojure.core-test.take ; Assertion failed! val.is_some()., https://github.com/jank-lang/jank/issues/245 , https://github.com/jank-lang/jank/issues/243
+    clojure.core-test.take
     clojure.core-test.take-last
     ; clojure.core-test.take-nth ; FIXME: Failing tests.
     clojure.core-test.take-while


### PR DESCRIPTION
Before:
```clojure
% jank repl        
nREPL server started on port 44830 on host 127.0.0.1 - nrepl://127.0.0.1:44830
user=> (rem 1 0)
Assertion failed! is_tagged_pointer(val)
Stack trace (most recent call first):
...
zsh: abort      jank repl
```

After:

```clojure
% jank repl
nREPL server started on port 43504 on host 127.0.0.1 - nrepl://127.0.0.1:43504
user=> (rem 1 0)
Uncaught exception: Illegal divide by zero in 'rem'

Stack trace (most recent call first):
...

user=> ;; jank process is fine
```