### PR TITLE
Enable `clojure.core-test.transient`

### DIFF
--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_array_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_array_map.hpp
@@ -69,6 +69,8 @@ namespace jank::runtime::obj
                                             sizeof...(args));
     }
 
+    static persistent_array_map_ref create_from_seq(object_ref const seq);
+
     /* behavior::get */
     [[gnu::always_inline, gnu::flatten, gnu::hot]]
     object_ref get(object_ref const key) const override

--- a/compiler+runtime/include/cpp/jank/runtime/obj/transient_vector.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/transient_vector.hpp
@@ -32,6 +32,10 @@ namespace jank::runtime::obj
     /* behavior::conjable_in_place */
     transient_vector_ref conj_in_place(object_ref const head);
 
+    /* behavior::indexable */
+    object_ref nth(object_ref const index) const;
+    object_ref nth(object_ref const index, object_ref const fallback) const;
+
     /* behavior::associatively_writable_in_place */
     transient_vector_ref assoc_in_place(object_ref const key, object_ref const val);
     transient_vector_ref dissoc_in_place(object_ref const key);

--- a/compiler+runtime/src/cpp/jank/analyze/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/analyze/processor.cpp
@@ -3405,28 +3405,30 @@ namespace jank::analyze
         return analyze_cpp_call(o, source.data, current_frame, position, fn_ctx, needs_box);
       }
 
-      object_ref expanded{ o };
-      jtl::ptr<error::base> expansion_error{};
-      JANK_TRY
+      if(source->kind != expression_kind::local_reference)
       {
-        expanded = __rt_ctx->macroexpand(o);
-      }
-      JANK_CATCH_THEN(
-        [&](auto const &e) {
-          expansion_error
-            = error::analyze_macro_expansion_exception(e,
-                                                       cpptrace::from_current_exception(),
-                                                       object_source(o),
-                                                       latest_expansion(macro_expansions));
-        },
-        return expansion_error.as_ref())
+        object_ref expanded{ o };
+        jtl::ptr<error::base> expansion_error{};
+        JANK_TRY
+        {
+          expanded = __rt_ctx->macroexpand(o);
+        }
+        JANK_CATCH_THEN(
+          [&](auto const &e) {
+            expansion_error
+              = error::analyze_macro_expansion_exception(e,
+                                                         cpptrace::from_current_exception(),
+                                                         object_source(o),
+                                                         latest_expansion(macro_expansions));
+          },
+          return expansion_error.as_ref())
 
-      if(expanded != o)
-      {
-        return analyze(expanded, current_frame, position, fn_ctx, needs_box);
+        if(expanded != o)
+        {
+          return analyze(expanded, current_frame, position, fn_ctx, needs_box);
+        }
       }
 
-      source = sym_result.expect_ok();
       auto const var_deref(llvm::dyn_cast<expr::var_deref>(source.data));
 
       /* Some vars have meta which defines how calls to it can be inlined. This works similarly

--- a/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
@@ -167,7 +167,7 @@ namespace jank::runtime
         else
         {
           throw std::runtime_error{ util::format("not transientable: {}",
-                                                 typed_o.to_code_string()) };
+                                                 object_type_str(typed_o.get_type())) };
         }
       },
       o);

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_array_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_array_map.cpp
@@ -7,6 +7,7 @@
 #include <jank/runtime/core/seq.hpp>
 #include <jank/runtime/core/to_string.hpp>
 #include <jank/runtime/rtti.hpp>
+#include <jank/runtime/sequence_range.hpp>
 #include <jank/util/fmt.hpp>
 
 namespace jank::runtime::obj
@@ -31,6 +32,32 @@ namespace jank::runtime::obj
     : parent_type{ meta }
     , data{ std::move(d) }
   {
+  }
+
+  persistent_array_map_ref persistent_array_map::create_from_seq(object_ref const seq)
+  {
+    return visit_seqable(
+      [](auto const typed_seq) -> persistent_array_map_ref {
+        transient_array_map transient{};
+        auto const r{ make_sequence_range(typed_seq) };
+        for(auto it(r.begin()); it != r.end(); ++it)
+        {
+          auto const key(*it);
+          ++it;
+          if(it == r.end())
+          {
+            throw std::runtime_error{ util::format("Odd number of elements: {}",
+                                                   typed_seq->to_string()) };
+          }
+          auto const val(*it);
+          transient.assoc_in_place(key, val);
+        }
+        return transient.to_persistent();
+      },
+      [=]() -> persistent_array_map_ref {
+        throw std::runtime_error{ util::format("Not seqable: {}", runtime::to_string(seq)) };
+      },
+      seq);
   }
 
   object_ref persistent_array_map::find(object_ref const key) const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/transient_vector.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/transient_vector.cpp
@@ -50,6 +50,31 @@ namespace jank::runtime::obj
     return this;
   }
 
+  object_ref transient_vector::nth(object_ref const index) const
+  {
+    if(is_integral(index))
+    {
+      auto const i(to_i64(index));
+      if(i < 0 || data.size() <= static_cast<size_t>(i))
+      {
+        throw std::runtime_error{
+          util::format("out of bounds index {}; vector has a size of {}", i, data.size())
+        };
+      }
+      return data[i];
+    }
+    else
+    {
+      throw std::runtime_error{ util::format("nth on a vector must be an integer; found {}",
+                                             runtime::to_string(index)) };
+    }
+  }
+
+  object_ref transient_vector::nth(object_ref const index, object_ref const fallback) const
+  {
+    return get(index, fallback);
+  }
+
   transient_vector_ref transient_vector::assoc_in_place(object_ref const key, object_ref const val)
   {
     assert_active();

--- a/compiler+runtime/src/jank/clojure/core.jank
+++ b/compiler+runtime/src/jank/clojure/core.jank
@@ -6252,14 +6252,9 @@
   "Constructs an array-map. If any keys are equal, they are handled as
   if by repeated uses of assoc."
   ([]
-  ;;  (. clojure.lang.PersistentArrayMap EMPTY)
-   (throw "TODO: port array-map"))
+   (cpp/jank.runtime.obj.persistent_array_map.empty))
   ([& keyvals]
-    ;;  (let [ary (to-array keyvals)]
-    ;;    (if (odd? (alength ary))
-    ;;      (throw (IllegalArgumentException. (str "No value supplied for key: " (last keyvals))))
-    ;;      (clojure.lang.PersistentArrayMap/createAsIfByAssoc ary)))
-   (throw "TODO: port array-map")))
+   (cpp/jank.runtime.obj.persistent_array_map.create_from_seq keyvals)))
 
 (defn seq-to-map-for-destructuring
   "Builds a map from a seq as described in

--- a/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
+++ b/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
@@ -207,7 +207,7 @@
     clojure.core-test.take-nth
     clojure.core-test.take-while
     clojure.core-test.taps
-    ; clojure.core-test.transient ; analyze/macro-expansion-exception error: invalid call to #object [unknown jit_function 0x104434c80] with 3 args provided
+    clojure.core-test.transient
     clojure.core-test.true-qmark
     clojure.core-test.underive
     clojure.core-test.unsigned-bit-shift-right

--- a/compiler+runtime/test/jank/call/pass-prevent-macro-shadow.jank
+++ b/compiler+runtime/test/jank/call/pass-prevent-macro-shadow.jank
@@ -1,1 +1,1 @@
-(let* [amap {:x :success}] (amap :x))
+(let* [amap (fn* [] :success)] (amap))

--- a/compiler+runtime/test/jank/call/pass-prevent-macro-shadow.jank
+++ b/compiler+runtime/test/jank/call/pass-prevent-macro-shadow.jank
@@ -1,0 +1,1 @@
+(let* [amap {:x :success}] (amap :x))


### PR DESCRIPTION
This closes https://github.com/jank-lang/jank/issues/861.

~Depends on https://github.com/jank-lang/clojure-test-suite/pull/920 and resolving the following issue~: Done

```cpp
% jank repl
user=> ((transient [0]) 0)
─ analyze/invalid-cpp-operator-call ────────────────────────────────────────────────────────────────
error: Unable to find '()' operator support for 'jank::runtime::object_ref'.   
```

I think the issue might be related to this condition in `processor.cpp:715`, but I'm not certain:

```cpp
      else if(arg_types.size() == 2 && !cpp_util::is_any_object(arg_types[1].m_Type)
              && cpp_util::is_trait_convertible(arg_types[1].m_Type)
              && cpp_util::is_any_object(Cpp::GetNonReferenceType(obj_type)))
```