### PR TITLE
Add thread local destructor test for CI confirmation

### DIFF
--- a/compiler+runtime/test/jank/cpp/thread-local/pass-thread-local-destructor.jank
+++ b/compiler+runtime/test/jank/cpp/thread-local/pass-thread-local-destructor.jank
@@ -1,9 +1,8 @@
-(cpp/raw "
-#include <string.h>
-namespace jank::cpp::thread_local::destructor
+(cpp/raw "#include <string.h>
+namespace jank::cpp::thread_local_::destructor
 {
   void hello () { thread_local std::string _{ \"hello\" }; }
 } 
 ")
 
-(let [_ (cpp/jank.cpp.thread_local.destructor.hello)])
+(let [_ (cpp/jank.cpp.thread_local_.destructor.hello)])

--- a/compiler+runtime/test/jank/cpp/thread-local/pass-thread-local-destructor.jank
+++ b/compiler+runtime/test/jank/cpp/thread-local/pass-thread-local-destructor.jank
@@ -1,0 +1,9 @@
+(cpp/raw "
+#include <string.h>
+namespace jank::cpp::thread_local::destructor
+{
+  void hello () { thread_local std::string _{ \"hello\" }; }
+} 
+")
+
+(let [_ (cpp/jank.cpp.thread_local.destructor.hello)])

--- a/compiler+runtime/test/jank/cpp/thread-local/pass-thread-local-destructor.jank
+++ b/compiler+runtime/test/jank/cpp/thread-local/pass-thread-local-destructor.jank
@@ -5,4 +5,5 @@ namespace jank::cpp::thread_local_::destructor
 } 
 ")
 
-(let [_ (cpp/jank.cpp.thread_local_.destructor.hello)])
+(let [_ (cpp/jank.cpp.thread_local_.destructor.hello)]
+  :success)


### PR DESCRIPTION
Related to https://github.com/jank-lang/jank/issues/854

I'm trying to determine if this issue is isolated to some misconfiguration on my machine, or is a valid issue.

Locally:

```
% jank run test/jank/cpp/thread-local/pass-thread-local-destructor.jank 
zsh: segmentation fault (core dumped)  jank run test/jank/cpp/thread-local/pass-thread-local-destructor.jank
```

CI:

```
testing file test/jank/cpp/thread-local/pass-thread-local-destructor.jank => success
...
./bin/test: line 10: 11654 Segmentation fault      (core dumped) "${here}/../build/jank-test" "$@"
```