### PR TITLE
Enable `clojure.core-test.get-in`

### DIFF
--- a/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
@@ -597,7 +597,7 @@ namespace jank::runtime
 
   object_ref get_in(object_ref const m, object_ref const keys, object_ref const fallback)
   {
-    static auto const sentinel(make_box<obj::cons>(jank_nil, jank_nil));
+    static auto const sentinel(make_box<obj::reduced>(jank_true));
 
     if(m.has_behavior(object_behavior::get))
     {

--- a/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
@@ -597,6 +597,8 @@ namespace jank::runtime
 
   object_ref get_in(object_ref const m, object_ref const keys, object_ref const fallback)
   {
+    static auto const sentinel(make_box<obj::cons>(jank_nil, jank_nil));
+
     if(m.has_behavior(object_behavior::get))
     {
       return visit_seqable(
@@ -604,12 +606,11 @@ namespace jank::runtime
           object_ref ret{ m };
           for(auto const &e : make_sequence_range(typed_keys))
           {
-            ret = get(ret, e.erase());
-          }
-
-          if(ret.is_nil())
-          {
-            return fallback;
+            ret = get(ret, e.erase(), sentinel);
+            if(ret == sentinel)
+            {
+              return fallback;
+            }
           }
           return ret;
         },

--- a/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
+++ b/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
@@ -79,7 +79,7 @@
     clojure.core-test.fnil
     ; clojure.core-test.format ; TODO: port format
     ; clojure.core-test.get ; TODO: port to-array
-    ; clojure.core-test.get-in ; FIXME: Failing tests. 
+    clojure.core-test.get-in
     clojure.core-test.gt
     clojure.core-test.gt-eq
     clojure.core-test.hash-map


### PR DESCRIPTION
The fix to get-in mirrors the jvm implementation [here](https://github.com/clojure/clojure/blob/clojure-1.12.5/src/clj/clojure/core.clj#L6218).