### PR TITLE
Enable `clojure.core-test.compare`

### DIFF
--- a/compiler+runtime/include/cpp/jank/runtime/obj/character.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/character.hpp
@@ -26,6 +26,12 @@ namespace jank::runtime::obj
     jtl::immutable_string to_code_string() const override;
     uhash to_hash() const override;
 
+    /* behavior::comparable */
+    i64 compare(object const &) const override;
+
+    /* behavior::comparable extended */
+    i64 compare(character const &) const;
+
     /* Character does not fully support `behavior::number_like`, but can be converted to an integer. */
     i64 to_integer() const override;
 

--- a/compiler+runtime/include/cpp/jank/runtime/oref.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/oref.hpp
@@ -823,15 +823,15 @@ namespace jank::runtime
       {
         if(detail::is_tagged_small_int(o.raw()))
         {
-          i32 const l{ detail::as_integer(data) };
-          i32 const r{ detail::as_integer(o.raw()) };
+          auto const l{ detail::as_integer(data) };
+          auto const r{ detail::as_integer(o.raw()) };
           return (r < l) - (l < r);
         }
 
         if(detail::is_tagged_small_real(o.raw()))
         {
-          i32 const l{ detail::as_integer(data) };
-          f64 const r{ detail::as_real(o.raw()) };
+          auto const l{ detail::as_integer(data) };
+          auto const r{ detail::as_real(o.raw()) };
           return (r < l) - (l < r);
         }
 
@@ -843,15 +843,15 @@ namespace jank::runtime
       {
         if(detail::is_tagged_small_real(o.raw()))
         {
-          f64 const l{ detail::as_real(data) };
-          f64 const r{ detail::as_real(o.raw()) };
+          auto const l{ detail::as_real(data) };
+          auto const r{ detail::as_real(o.raw()) };
           return (r < l) - (l < r);
         }
 
         if(detail::is_tagged_small_int(o.raw()))
         {
-          f64 const l{ detail::as_real(data) };
-          i32 const r{ detail::as_integer(o.raw()) };
+          auto const l{ detail::as_real(data) };
+          auto const r{ detail::as_integer(o.raw()) };
           return (r < l) - (l < r);
         }
 
@@ -866,8 +866,8 @@ namespace jank::runtime
       }
       else if(detail::is_tagged_small_real(o.raw()))
       {
-        obj::small_real const i{ detail::as_real(o.raw()) };
-        return ptr()->compare(i);
+        obj::small_real const r{ detail::as_real(o.raw()) };
+        return ptr()->compare(r);
       }
 
       return ptr()->compare(*o.ptr());

--- a/compiler+runtime/include/cpp/jank/runtime/oref.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/oref.hpp
@@ -823,31 +823,46 @@ namespace jank::runtime
       {
         if(detail::is_tagged_small_int(o.raw()))
         {
-          auto const l{ detail::as_integer(data) };
-          auto const r{ detail::as_integer(o.raw()) };
+          i32 const l{ detail::as_integer(data) };
+          i32 const r{ detail::as_integer(o.raw()) };
           return (r < l) - (l < r);
         }
 
-        obj::small_integer const i{ detail::as_integer(data) };
-        return o.compare(detail::untagged(&i));
-      }
-      else if(detail::is_tagged_small_int(o.raw()))
-      {
-        obj::small_integer const i{ detail::as_integer(o.raw()) };
-        return ptr()->compare(i);
+        if(detail::is_tagged_small_real(o.raw()))
+        {
+          i32 const l{ detail::as_integer(data) };
+          f64 const r{ detail::as_real(o.raw()) };
+          return (r < l) - (l < r);
+        }
+
+        obj::small_integer const l{ detail::as_integer(data) };
+        return l.compare(*o.ptr());
       }
 
       if(detail::is_tagged_small_real(data))
       {
         if(detail::is_tagged_small_real(o.raw()))
         {
-          auto const l{ detail::as_real(data) };
-          auto const r{ detail::as_real(o.raw()) };
+          f64 const l{ detail::as_real(data) };
+          f64 const r{ detail::as_real(o.raw()) };
           return (r < l) - (l < r);
         }
 
-        obj::small_real const i{ detail::as_real(data) };
-        return o.compare(detail::untagged(&i));
+        if(detail::is_tagged_small_int(o.raw()))
+        {
+          f64 const l{ detail::as_real(data) };
+          i32 const r{ detail::as_integer(o.raw()) };
+          return (r < l) - (l < r);
+        }
+
+        obj::small_real const l{ detail::as_real(data) };
+        return l.compare(*o.ptr());
+      }
+
+      if(detail::is_tagged_small_int(o.raw()))
+      {
+        obj::small_integer const i{ detail::as_integer(o.raw()) };
+        return ptr()->compare(i);
       }
       else if(detail::is_tagged_small_real(o.raw()))
       {

--- a/compiler+runtime/include/cpp/jank/runtime/visit.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/visit.hpp
@@ -262,9 +262,9 @@ namespace jank::runtime
     }
     else
     {
-      jtl::panic("invalid object type: {}, raw value {}",
-                 object_type_str(erased.get_type()),
-                 static_cast<int>(erased.get_type()));
+      throw std::runtime_error{ util::format("invalid object type: {}, raw value {}",
+                                             object_type_str(erased.get_type()),
+                                             static_cast<int>(erased.get_type())) };
     }
   }
 

--- a/compiler+runtime/src/cpp/jank/runtime/core/equal.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/equal.cpp
@@ -32,11 +32,6 @@ namespace jank::runtime
 
   i64 compare(object_ref const l, object_ref const r)
   {
-    if(l == r)
-    {
-      return 0;
-    }
-
     if(l.is_some())
     {
       if(r.is_nil())

--- a/compiler+runtime/src/cpp/jank/runtime/obj/character.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/character.cpp
@@ -115,6 +115,16 @@ namespace jank::runtime::obj
     return data.to_hash();
   }
 
+  i64 character::compare(object const &o) const
+  {
+    return compare(*try_object<character>(runtime::detail::untagged(&o)));
+  }
+
+  i64 character::compare(character const &s) const
+  {
+    return data.compare(s.data);
+  }
+
   i64 character::to_integer() const
   {
     std::mbstate_t state{};

--- a/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
+++ b/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
@@ -39,7 +39,7 @@
     clojure.core-test.char-qmark
     ; clojure.core-test.coll-qmark ; TODO: port array-map, TODO: port object-array
     clojure.core-test.comment
-    ; clojure.core-test.compare ; libc++abi: terminating due to uncaught exception of type std::runtime_error: not comparable: a
+    clojure.core-test.compare
     clojure.core-test.conj
     clojure.core-test.conj-bang
     clojure.core-test.cons


### PR DESCRIPTION
I had to re-work compare a little to handle `small_` numbers as follows:

| Left                | Right                | Operation                       |
|----------------|-----------------|--------------------------- |
|`small_integer` | `small_integer`| `(r < l) - (l < r)`                |
|`small_integer` | `small_real`      | `(r < l) - (l < r)`                |
|`small_integer` | `object_ref`      | `l.compare(*o.ptr())`        |
|`small_real`      | `small_integer` | `(r < l) - (l < r)`                |
|`small_real`      | `small_real`      | `(r < l) - (l < r)`                 |
|`small_real`      | `object_ref`      | `l.compare(*o.ptr())`         |
|`object_ref`      | `small_integer`| `ptr()->compare(i)`           |
|`object_ref`      | `small_real`     | `ptr()->compare(r)`           |
|`object_ref`      | `object_ref`     | `ptr()->compare(*o.ptr())` |

It's mostly the same as the existing code, just slightly reordered to handle the following issues:

Before:
```clojure
% jank repl
user=> (compare 0 -100N) ;; we were swapping L and R here
-1
user=> (compare 1.0 0) ;; we weren't handling this case
Assertion failed! is_tagged_pointer(val)
Stack trace (most recent call first):
```

After
```clojure
% jank repl               
user=> (compare 0 -100N)
1
user=> (compare 1.0 0)
1
```
