### PR TITLE
Stop cleaning build dir; use binary version

### DIFF
--- a/compiler+runtime/CMakeLists.txt
+++ b/compiler+runtime/CMakeLists.txt
@@ -180,34 +180,34 @@ set(
   "${CMAKE_SOURCE_DIR}/src/jank/jank/nrepl/server/handler/lookup.jank"
 )
 
-set(jank_clojure_core_output "${CMAKE_BINARY_DIR}/core-libs/_cache/clojure/core.o")
+set(jank_clojure_core_output "${CMAKE_BINARY_DIR}/core-libs/_cache/0/clojure/core.o")
 set(jank_clojure_core_binary_output "${jank_clojure_core_output}")
 set(
   jank_nrepl_server_outputs
-  "${CMAKE_BINARY_DIR}/core-libs/_cache/clojure/string.o"
-  "${CMAKE_BINARY_DIR}/core-libs/_cache/clojure/walk.o"
+  "${CMAKE_BINARY_DIR}/core-libs/_cache/0/clojure/string.o"
+  "${CMAKE_BINARY_DIR}/core-libs/_cache/0/clojure/walk.o"
 
-  "${CMAKE_BINARY_DIR}/core-libs/_cache/jank/nrepl/server/inspect.o"
-  "${CMAKE_BINARY_DIR}/core-libs/_cache/jank/nrepl/server/core.o"
-  "${CMAKE_BINARY_DIR}/core-libs/_cache/jank/nrepl/server/handler.o"
-  "${CMAKE_BINARY_DIR}/core-libs/_cache/jank/nrepl/server/bencode.o"
-  "${CMAKE_BINARY_DIR}/core-libs/_cache/jank/nrepl/server/capture.o"
-  "${CMAKE_BINARY_DIR}/core-libs/_cache/jank/nrepl/server/util.o"
-  "${CMAKE_BINARY_DIR}/core-libs/_cache/jank/nrepl/server/eval.o"
-  "${CMAKE_BINARY_DIR}/core-libs/_cache/jank/nrepl/server/parsec.o"
-  "${CMAKE_BINARY_DIR}/core-libs/_cache/jank/nrepl/server/handler/close.o"
-  "${CMAKE_BINARY_DIR}/core-libs/_cache/jank/nrepl/server/handler/clone.o"
-  "${CMAKE_BINARY_DIR}/core-libs/_cache/jank/nrepl/server/handler/describe.o"
-  "${CMAKE_BINARY_DIR}/core-libs/_cache/jank/nrepl/server/handler/completions.o"
-  "${CMAKE_BINARY_DIR}/core-libs/_cache/jank/nrepl/server/handler/eval.o"
-  "${CMAKE_BINARY_DIR}/core-libs/_cache/jank/nrepl/server/handler/lookup.o"
+  "${CMAKE_BINARY_DIR}/core-libs/_cache/0/jank/nrepl/server/inspect.o"
+  "${CMAKE_BINARY_DIR}/core-libs/_cache/0/jank/nrepl/server/core.o"
+  "${CMAKE_BINARY_DIR}/core-libs/_cache/0/jank/nrepl/server/handler.o"
+  "${CMAKE_BINARY_DIR}/core-libs/_cache/0/jank/nrepl/server/bencode.o"
+  "${CMAKE_BINARY_DIR}/core-libs/_cache/0/jank/nrepl/server/capture.o"
+  "${CMAKE_BINARY_DIR}/core-libs/_cache/0/jank/nrepl/server/util.o"
+  "${CMAKE_BINARY_DIR}/core-libs/_cache/0/jank/nrepl/server/eval.o"
+  "${CMAKE_BINARY_DIR}/core-libs/_cache/0/jank/nrepl/server/parsec.o"
+  "${CMAKE_BINARY_DIR}/core-libs/_cache/0/jank/nrepl/server/handler/close.o"
+  "${CMAKE_BINARY_DIR}/core-libs/_cache/0/jank/nrepl/server/handler/clone.o"
+  "${CMAKE_BINARY_DIR}/core-libs/_cache/0/jank/nrepl/server/handler/describe.o"
+  "${CMAKE_BINARY_DIR}/core-libs/_cache/0/jank/nrepl/server/handler/completions.o"
+  "${CMAKE_BINARY_DIR}/core-libs/_cache/0/jank/nrepl/server/handler/eval.o"
+  "${CMAKE_BINARY_DIR}/core-libs/_cache/0/jank/nrepl/server/handler/lookup.o"
 )
 
 list(JOIN jank_nrepl_server_outputs " " jank_nrepl_server_outputs_str)
 if(jank_enable_phase_2)
   set(jank_core_lib_output_target --output-target cpp)
-  set(jank_clojure_core_output "${CMAKE_BINARY_DIR}/core-libs/_cache/clojure/core.cpp")
-  set(jank_clojure_core_binary_output "${CMAKE_BINARY_DIR}/CMakeFiles/jank_exe_phase_2.dir/core-libs/_cache/clojure/core.cpp${CMAKE_CXX_OUTPUT_EXTENSION}")
+  set(jank_clojure_core_output "${CMAKE_BINARY_DIR}/core-libs/_cache/0/clojure/core.cpp")
+  set(jank_clojure_core_binary_output "${CMAKE_BINARY_DIR}/CMakeFiles/jank_exe_phase_2.dir/core-libs/_cache/0/clojure/core.cpp${CMAKE_CXX_OUTPUT_EXTENSION}")
 
   list(
     TRANSFORM jank_nrepl_server_outputs
@@ -1081,9 +1081,9 @@ add_custom_command(
   DEPENDS ${CMAKE_BINARY_DIR}/jank-phase-1${CMAKE_EXECUTABLE_SUFFIX} ${jank_clojure_core_sources} ${jank_other_core_sources} ${jank_incremental_pch_flag}
   OUTPUT ${jank_core_libraries_flag}
   BYPRODUCTS ${jank_clojure_core_output} ${jank_nrepl_server_outputs}
-  COMMAND ${CMAKE_BINARY_DIR}/jank-phase-1${CMAKE_EXECUTABLE_SUFFIX} -O3 compile-module --target-dir ${CMAKE_BINARY_DIR}/core-libs --output-target object clojure.core
-  COMMAND ${CMAKE_BINARY_DIR}/jank-phase-1${CMAKE_EXECUTABLE_SUFFIX} -O3 compile-module --target-dir ${CMAKE_BINARY_DIR}/core-libs ${jank_core_lib_output_target} clojure.core
-  COMMAND ${CMAKE_BINARY_DIR}/jank-phase-1${CMAKE_EXECUTABLE_SUFFIX} -O3 compile-module --target-dir ${CMAKE_BINARY_DIR}/core-libs ${jank_core_lib_output_target} jank.nrepl.server.core
+  COMMAND ${CMAKE_BINARY_DIR}/jank-phase-1${CMAKE_EXECUTABLE_SUFFIX} -O3 --force-binary-version 0 compile-module --target-dir ${CMAKE_BINARY_DIR}/core-libs --output-target object clojure.core
+  COMMAND ${CMAKE_BINARY_DIR}/jank-phase-1${CMAKE_EXECUTABLE_SUFFIX} -O3 --force-binary-version 0 compile-module --target-dir ${CMAKE_BINARY_DIR}/core-libs ${jank_core_lib_output_target} clojure.core
+  COMMAND ${CMAKE_BINARY_DIR}/jank-phase-1${CMAKE_EXECUTABLE_SUFFIX} -O3 --force-binary-version 0 compile-module --target-dir ${CMAKE_BINARY_DIR}/core-libs ${jank_core_lib_output_target} jank.nrepl.server.core
   COMMAND touch ${jank_core_libraries_flag}
 )
 add_custom_target(

--- a/compiler+runtime/include/cpp/jank/util/cli.hpp
+++ b/compiler+runtime/include/cpp/jank/util/cli.hpp
@@ -12,7 +12,8 @@ namespace jank::util::cli
     repl,
     cpp_repl,
     run_main,
-    check_health
+    check_health,
+    print_binary_version,
   };
 
   enum class compilation_target : u8

--- a/compiler+runtime/include/cpp/jank/util/cli.hpp
+++ b/compiler+runtime/include/cpp/jank/util/cli.hpp
@@ -146,6 +146,7 @@ namespace jank::util::cli
     jtl::immutable_string output_filename{ "a.out" };
     jtl::immutable_string target_dir{ "target" };
     jtl::immutable_string build_dir;
+    jtl::immutable_string forced_binary_version;
 
     /* Compile-module command. */
     jtl::immutable_string output_module_filename;

--- a/compiler+runtime/include/cpp/jank/util/environment.hpp
+++ b/compiler+runtime/include/cpp/jank/util/environment.hpp
@@ -9,6 +9,7 @@ namespace jank::util
   jtl::immutable_string const &user_config_dir();
 
   jtl::immutable_string const &binary_version();
+  jtl::immutable_string build_dir();
 
   jtl::immutable_string process_path();
   jtl::immutable_string process_dir();

--- a/compiler+runtime/src/cpp/jank/aot/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/aot/processor.cpp
@@ -24,7 +24,7 @@ namespace jank::aot
 
   static jtl::immutable_string relative_to_build_dir(jtl::immutable_string const &file_path)
   {
-    return util::format("{}/{}", util::cli::opts.build_dir, file_path);
+    return util::format("{}/{}", util::build_dir(), file_path);
   }
 
   // TODO: Generate an object file instead of a cpp
@@ -432,8 +432,7 @@ int main(int argc, const char** argv)
     /* TODO: Use runtime::context::get_output_module_name. */
     std::filesystem::path const module_path{
       util::cli::opts.output_module_filename.empty()
-        ? util::format("{}/{}.o", util::cli::opts.build_dir, module::module_to_path(module_name))
-            .c_str()
+        ? util::format("{}/{}.o", util::build_dir(), module::module_to_path(module_name)).c_str()
         : jtl::immutable_string{ util::cli::opts.output_module_filename }.c_str()
     };
     std::filesystem::create_directories(module_path.parent_path());

--- a/compiler+runtime/src/cpp/jank/runtime/context_dynamic.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/context_dynamic.cpp
@@ -244,7 +244,7 @@ namespace jank::runtime
   {
     return util::cli::opts.output_module_filename.empty()
       ? util::format("{}/{}.{}",
-                     util::cli::opts.build_dir,
+                     util::build_dir(),
                      module::module_to_path(module_name),
                      util::cli::compilation_target_extension(util::cli::opts.output_target))
       : jtl::immutable_string{ util::cli::opts.output_module_filename };

--- a/compiler+runtime/src/cpp/jank/runtime/module/loader_dynamic.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/module/loader_dynamic.cpp
@@ -120,82 +120,6 @@ namespace jank::runtime::module
     return ret;
   }
 
-  static jtl::immutable_string binary_version_path()
-  {
-    auto const path{ util::format("{}/.jank-binary-version", util::cli::opts.build_dir) };
-    return path;
-  }
-
-  enum class binary_version_status : u8
-  {
-    /* A binary version file exists and holds a matching value. */
-    good,
-    /* No binary version file was found. */
-    needs_write,
-    /* A binary version file exists, but the value within it doesn't match. */
-    needs_clean
-  };
-
-  static binary_version_status check_binary_version_status()
-  {
-    if(!std::filesystem::exists(util::cli::opts.build_dir.c_str()))
-    {
-      return binary_version_status::needs_write;
-    }
-
-    auto const &path{ binary_version_path() };
-    if(!std::filesystem::exists(path.c_str()))
-    {
-      return binary_version_status::needs_write;
-    }
-
-    std::ifstream ifs{ path.c_str() };
-    std::string file_binary_version;
-    std::getline(ifs, file_binary_version);
-
-    auto const &binary_version{ util::binary_version() };
-    if(file_binary_version != binary_version)
-    {
-      return binary_version_status::needs_clean;
-    }
-
-    return binary_version_status::good;
-  }
-
-  static void write_binary_version()
-  {
-    std::filesystem::create_directories(util::cli::opts.build_dir.c_str());
-
-    auto const &binary_version{ util::binary_version() };
-    auto const &path{ binary_version_path() };
-    std::ofstream ofs{ path.c_str() };
-    ofs << binary_version.c_str();
-  }
-
-  static void clean_build_directory()
-  {
-    std::filesystem::remove_all(util::cli::opts.build_dir.c_str());
-    write_binary_version();
-  }
-
-  void verify_binary_version()
-  {
-    auto const status{ check_binary_version_status() };
-    switch(status)
-    {
-      case binary_version_status::good:
-        break;
-      case binary_version_status::needs_write:
-        write_binary_version();
-        break;
-      case binary_version_status::needs_clean:
-        error::warn(
-          "Cleaning build directory before compiling, since the configuration has changed.");
-        clean_build_directory();
-        break;
-    }
-  }
-
   static zip_entry_ptr open_zip_entry(zip_t * const zip, jtl::immutable_string const &path)
   {
     zip_entry_open(zip, path.c_str());
@@ -469,7 +393,7 @@ namespace jank::runtime::module
     std::filesystem::path const jank_path{ jank::util::process_dir().c_str() };
     std::filesystem::path const resource_dir{ jank::util::resource_dir().c_str() };
     std::filesystem::path const target_dir{ util::cli::opts.target_dir.c_str() };
-    std::filesystem::path const build_dir{ util::cli::opts.build_dir.c_str() };
+    std::filesystem::path const build_dir{ jank::util::build_dir().c_str() };
     native_transient_string paths{ util::cli::opts.module_path };
 
     /* These paths are used by an installed jank. */

--- a/compiler+runtime/src/cpp/jank/util/cli.cpp
+++ b/compiler+runtime/src/cpp/jank/util/cli.cpp
@@ -112,6 +112,7 @@ COMMANDS
   compile                     Ahead of time compile project with entrypoint module containing
                               -main.
   check-health                Provide a status report on the jank installation.
+  print-binary-version        Print the current binary version to stdout and exit.
 
 OPTIONS
   -h,     --help              Print this help message and exit.
@@ -215,13 +216,14 @@ OPTIONS
     auto const flags{ parse_into_vector(argc, argv) };
 
     static native_unordered_map<jtl::immutable_string, command> valid_commands{
-      {            "run",            command::run },
-      {       "run-main",       command::run_main },
-      {           "repl",           command::repl },
-      {       "cpp-repl",       command::cpp_repl },
-      {        "compile",        command::compile },
-      { "compile-module", command::compile_module },
-      {   "check-health",   command::check_health }
+      {                  "run",                  command::run },
+      {             "run-main",             command::run_main },
+      {                 "repl",                 command::repl },
+      {             "cpp-repl",             command::cpp_repl },
+      {              "compile",              command::compile },
+      {       "compile-module",       command::compile_module },
+      {         "check-health",         command::check_health },
+      { "print-binary-version", command::print_binary_version },
     };
 
     options_scratchpad scratch;

--- a/compiler+runtime/src/cpp/jank/util/cli.cpp
+++ b/compiler+runtime/src/cpp/jank/util/cli.cpp
@@ -138,6 +138,8 @@ OPTIONS
                               The directory to use for storing final artifacts.
           --build-dir <path> [default: <target dir>/_cache]
                               The prefix to use for intermediate build files.
+          --force-binary-version <version>
+                              Override jank's binary version hashing to provide your own.
           --name <name> [default: a.out]
                               The name of the output file, in the target directory.
           --output-target <cpp, object> [default: object]
@@ -164,6 +166,7 @@ OPTIONS
     jtl::option<u8> codegen_optimization_level;
 
     jtl::option<jtl::immutable_string> build_dir;
+    jtl::option<jtl::immutable_string> forced_binary_version;
 
     /* Optimization passes. */
     /*** O1 ***/
@@ -195,6 +198,7 @@ OPTIONS
     opts.direct_call = scratch.direct_call.unwrap_or(false);
 
     opts.build_dir = scratch.build_dir.unwrap_or(util::format("{}/_cache", opts.target_dir));
+    opts.forced_binary_version = scratch.forced_binary_version.unwrap_or("");
 
     /* NOLINTNEXTLINE(bugprone-switch-missing-default-case) */
     switch(opts.codegen_optimization_level)
@@ -378,6 +382,10 @@ OPTIONS
         else if(check_flag(it, end, value, "--build-dir", true))
         {
           scratch.build_dir = value;
+        }
+        else if(check_flag(it, end, value, "--force-binary-version", true))
+        {
+          scratch.forced_binary_version = value;
         }
 
         /**** These are command-specific flags which we will store until we know the command. ****/

--- a/compiler+runtime/src/cpp/jank/util/environment_dynamic.cpp
+++ b/compiler+runtime/src/cpp/jank/util/environment_dynamic.cpp
@@ -28,6 +28,11 @@ namespace jank::util
    */
   jtl::immutable_string const &binary_version()
   {
+    if(!util::cli::opts.forced_binary_version.empty())
+    {
+      return util::cli::opts.forced_binary_version;
+    }
+
     static jtl::immutable_string res;
     if(!res.empty())
     {

--- a/compiler+runtime/src/cpp/jank/util/environment_dynamic.cpp
+++ b/compiler+runtime/src/cpp/jank/util/environment_dynamic.cpp
@@ -159,4 +159,9 @@ namespace jank::util
       args.emplace_back(strdup(sdk_path.c_str()));
     }
   }
+
+  jtl::immutable_string build_dir()
+  {
+    return util::format("{}/{}", util::cli::opts.build_dir, binary_version());
+  }
 }

--- a/compiler+runtime/src/cpp/jank/util/environment_static.cpp
+++ b/compiler+runtime/src/cpp/jank/util/environment_static.cpp
@@ -11,6 +11,6 @@ namespace jank::util
 
   jtl::immutable_string build_dir()
   {
-    throw error::runtime_static_feature_disabled("eval");
+    throw error::runtime_static_feature_disabled("build_dir");
   }
 }

--- a/compiler+runtime/src/cpp/jank/util/environment_static.cpp
+++ b/compiler+runtime/src/cpp/jank/util/environment_static.cpp
@@ -9,7 +9,7 @@ namespace jank::util
     return res;
   }
 
-  jtl::immutable_string build_version()
+  jtl::immutable_string build_dir()
   {
     throw error::runtime_static_feature_disabled("eval");
   }

--- a/compiler+runtime/src/cpp/jank/util/environment_static.cpp
+++ b/compiler+runtime/src/cpp/jank/util/environment_static.cpp
@@ -1,4 +1,5 @@
 #include <jank/util/environment.hpp>
+#include <jank/error/runtime.hpp>
 
 namespace jank::util
 {
@@ -6,5 +7,10 @@ namespace jank::util
   {
     static jtl::immutable_string const res{ "static" };
     return res;
+  }
+
+  jtl::immutable_string build_version()
+  {
+    throw error::runtime_static_feature_disabled("eval");
   }
 }

--- a/compiler+runtime/src/cpp/main.cpp
+++ b/compiler+runtime/src/cpp/main.cpp
@@ -72,8 +72,6 @@ namespace jank
       .expect_ok()
       .call(make_box<obj::symbol>("clojure.core"));
 
-    jank::runtime::module::verify_binary_version();
-
     {
       profile::timer const timer{ "eval user code" };
       __rt_ctx->eval_file(util::cli::opts.target_file);
@@ -105,8 +103,6 @@ namespace jank
       profile::timer const timer{ "require clojure.core" };
       __rt_ctx->load_module("clojure.core", module::origin::latest).expect_ok();
     }
-
-    jank::runtime::module::verify_binary_version();
 
     {
       profile::timer const timer{ "eval user code" };
@@ -183,8 +179,6 @@ namespace jank
     {
       __rt_ctx->load_module("clojure.core", module::origin::latest).expect_ok();
     }
-
-    jank::runtime::module::verify_binary_version();
 
     __rt_ctx->compile_module(opts.target_module).expect_ok();
   }
@@ -367,8 +361,6 @@ namespace jank
       __rt_ctx->compile_module("clojure.core").expect_ok();
     }
 #endif
-
-    jank::runtime::module::verify_binary_version();
 
     __rt_ctx->compile_module(opts.target_module).expect_ok();
 

--- a/compiler+runtime/src/cpp/main.cpp
+++ b/compiler+runtime/src/cpp/main.cpp
@@ -25,6 +25,7 @@
 #include <jank/util/string.hpp>
 #include <jank/util/fmt/print.hpp>
 #include <jank/util/try.hpp>
+#include <jank/util/environment.hpp>
 #include <jank/error/report.hpp>
 #include <jank/environment/check_health.hpp>
 #include <jank/runtime/convert/builtin.hpp>
@@ -403,6 +404,11 @@ int main(int const argc, char const **argv)
       {
         return jank::environment::check_health() ? 0 : 1;
       }
+      if(util::cli::opts.command == util::cli::command::print_binary_version)
+      {
+        util::println("{}", util::binary_version());
+        return 0;
+      }
 
       __rt_ctx = new(UseGC) runtime::context{};
 
@@ -478,6 +484,7 @@ int main(int const argc, char const **argv)
           compile();
           break;
         case util::cli::command::check_health:
+        case util::cli::command::print_binary_version:
           break;
       }
       return 0;

--- a/compiler+runtime/test/bash/module/binary-version-tracking/pass-test
+++ b/compiler+runtime/test/bash/module/binary-version-tracking/pass-test
@@ -9,8 +9,7 @@
 
 (def this-nsym (ns-name *ns*))
 
-(defn jank [command module-name & {:keys [extra-module-path
-                                          out
+(defn jank [command module-name & {:keys [out
                                           flags
                                           env]}]
   (let [args (concat ["jank" "--module-path" "src"]

--- a/compiler+runtime/test/bash/module/compiled-modules/pass-test
+++ b/compiler+runtime/test/bash/module/compiled-modules/pass-test
@@ -19,6 +19,8 @@
 
 ;; --- Helper functions for isolated paths ---
 
+(def binary-version (string/trim (:out (proc/sh ["jank" "print-binary-version"]))))
+
 (defn src-dir []
   (fs/path *test-env* "src"))
 
@@ -26,7 +28,7 @@
   (fs/path *test-env* "target"))
 
 (defn build-dir []
-  (fs/path *test-env* "target/_cache"))
+  (fs/path *test-env* "target/_cache/" binary-version))
 
 (defn module-a-path []
   (fs/path (src-dir) "jank_test/a.cljc"))


### PR DESCRIPTION
This change removes the binary version check from jank, so we'll no
longer try to detect out-of-date build directories. Instead, we'll just
append the binary version to our build directly and happily put things
in it. If our binary version changes, we'll use the new directory,
leaving the old one in place. `lein clean` with lein-jank will remove
the whole target directory, which will include all build directories
with all binary versions.

Here's an example lein-jank target tree, with two binary versions for
the same debug profile.

```
target/
├── debug
│   ├── _cache
│   │   └── json-query
│   │       ├── x86_64-unknown-linux-gnu-211eea4be7942af843e902b894e93b6cc665b2aa6943f36f5bca4ddde080972b
│   │       │   └── json_query
│   │       │       └── main.o
│   │       └── x86_64-unknown-linux-gnu-5e3948b46dee3bb4f17fc699e821182481fb5465155bdbc359678f7e6a8db9da
│   │           └── json_query
│   │               └── main.o
│   └── json-query
└── stale
    └── leiningen.core.classpath.extract-native-dependencies
```

Here's an example of using jank to build a program directly, without
lein-jank.

```
.
├── hello.jank
└── target
    ├── a.out
    └── _cache
        └── x86_64-unknown-linux-gnu-deb515fb6fcde162c8cefee396e3090f348d5ec8e2d1a863abf325fa79682321
            └── hello.o
```

To aid in working with these binary versions, this PR also adds the following:

* The ability to override jank's binary version, with the `--force-binary-version` flag, for when having a stable path is important (we use this in CMake)
* The ability to query the binary version, with the `print-binary-version` command, for when having dynamic binary versions is desired but some tooling needs to know where to find things

Aside from a safety check for target/build dirs not being parents of any dirs on the module path, I believe this directory structure and implementation should last us a while, with lein-jank.