### PR TITLE
Fix AOT compilation on Intel (x86-64) macOS

### DIFF
--- a/compiler+runtime/src/cpp/jank/aot/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/aot/processor.cpp
@@ -224,7 +224,11 @@ int main(int argc, const char** argv)
 
     if constexpr(jtl::current_platform == jtl::platform::macos_like)
     {
+      /* Homebrew's prefix differs by architecture: /opt/homebrew on Apple
+       * Silicon, /usr/local on Intel. Add both; an absent -L path is a
+       * harmless no-op for the linker. */
       compiler_args.push_back(strdup("-L/opt/homebrew/lib"));
+      compiler_args.push_back(strdup("-L/usr/local/lib"));
     }
 
     for(auto const &library_dir : util::cli::opts.library_dirs)

--- a/compiler+runtime/src/cpp/jank/jit/processor_dynamic.cpp
+++ b/compiler+runtime/src/cpp/jank/jit/processor_dynamic.cpp
@@ -221,9 +221,24 @@ namespace jank::jit
 
     //util::println("jit flags {}", args);
 
+    /* CodeModel::Large combined with Reloc::PIC_ produces object code with
+     * absolute-address text relocations on x86-64 Darwin, which the linker
+     * rejects ("illegal text-relocations") when that code is reused during
+     * AOT linking of a position-independent executable. Every other target
+     * we support handles Large+PIC_ fine, so we only narrow the code model
+     * here. */
+    constexpr auto code_model{
+#if defined(__x86_64__)
+      jtl::current_platform == jtl::platform::macos_like ? llvm::CodeModel::Small
+                                                          : llvm::CodeModel::Large
+#else
+      llvm::CodeModel::Large
+#endif
+    };
+
     /* We don't actually own this interpreter. CppInterOp does. */
     interpreter.reset(static_cast<CppInternal::Interpreter *>(
-      Cpp::CreateInterpreter(args, {}, vfs, static_cast<int>(llvm::CodeModel::Large))));
+      Cpp::CreateInterpreter(args, {}, vfs, static_cast<int>(code_model))));
 
     /* Enabling perf support requires registering a couple of plugins with LLVM. These
      * plugins will generate files which perf can then use to inject additional info

--- a/compiler+runtime/src/cpp/jank/jit/processor_dynamic.cpp
+++ b/compiler+runtime/src/cpp/jank/jit/processor_dynamic.cpp
@@ -230,7 +230,7 @@ namespace jank::jit
     constexpr auto code_model{
 #if defined(__x86_64__)
       jtl::current_platform == jtl::platform::macos_like ? llvm::CodeModel::Small
-                                                          : llvm::CodeModel::Large
+                                                         : llvm::CodeModel::Large
 #else
       llvm::CodeModel::Large
 #endif

--- a/compiler+runtime/src/cpp/jank/runtime/context_dynamic.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/context_dynamic.cpp
@@ -306,7 +306,7 @@ namespace jank::runtime
           constexpr auto code_model{
 #if defined(__x86_64__)
             jtl::current_platform == jtl::platform::macos_like ? llvm::CodeModel::Small
-                                                                : llvm::CodeModel::Large
+                                                               : llvm::CodeModel::Large
 #else
             llvm::CodeModel::Large
 #endif

--- a/compiler+runtime/src/cpp/jank/runtime/context_dynamic.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/context_dynamic.cpp
@@ -289,15 +289,28 @@ namespace jank::runtime
           //module->print(llvm::outs(), nullptr);
 
           auto const target_triple{ util::default_target_triple() };
+          llvm::Triple const triple{ target_triple.c_str() };
           std::string target_error;
-          auto const target{
-            llvm::TargetRegistry::lookupTarget(llvm::Triple{ target_triple.c_str() }, target_error)
-          };
+          auto const target{ llvm::TargetRegistry::lookupTarget(triple, target_error) };
           if(!target)
           {
             return err(target_error);
           }
           llvm::TargetOptions const opt;
+          /* CodeModel::Large combined with Reloc::PIC_ produces object code
+           * with absolute-address text relocations on x86-64 Darwin, which
+           * the linker rejects ("illegal text-relocations") when that code
+           * is reused during AOT linking of a position-independent
+           * executable. Every other target we support handles Large+PIC_
+           * fine, so we only narrow the code model here. */
+          constexpr auto code_model{
+#if defined(__x86_64__)
+            jtl::current_platform == jtl::platform::macos_like ? llvm::CodeModel::Small
+                                                                : llvm::CodeModel::Large
+#else
+            llvm::CodeModel::Large
+#endif
+          };
           llvm::CodeGenOptLevel level{ llvm::CodeGenOptLevel::Default };
           switch(util::cli::opts.codegen_optimization_level)
           {
@@ -317,14 +330,13 @@ namespace jank::runtime
               break;
           }
 
-          auto const target_machine{ target->createTargetMachine(
-            llvm::Triple{ target_triple.c_str() },
-            "generic",
-            "",
-            opt,
-            llvm::Reloc::PIC_,
-            llvm::CodeModel::Large,
-            level) };
+          auto const target_machine{ target->createTargetMachine(triple,
+                                                                 "generic",
+                                                                 "",
+                                                                 opt,
+                                                                 llvm::Reloc::PIC_,
+                                                                 code_model,
+                                                                 level) };
           if(!target_machine)
           {
             return err(util::format("Failed to create target machine for '{}'.", target_triple));


### PR DESCRIPTION
Fixes #866.

## Problem

On Intel (x86-64) macOS, `jank`'s AOT compilation path fails at link
time with `ld: Found illegal text-relocations`, and forcing a non-PIE
link instead crashes at startup (SIGBUS). Every other platform we
support (arm64 Darwin, Linux) is unaffected. Regular JIT execution
(`jank run`, interactive eval) also works correctly — only the AOT
path (`jank compile`, and `check-health`'s AOT self-test) is broken.

## Root cause

`CodeModel::Large` combined with `Reloc::PIC_` produces object code
with absolute-address text relocations on x86-64 Darwin. The linker
rejects that when the code is reused during AOT linking of a
position-independent executable. This affects two call sites that
both construct target machines for jank-compiled code:

- `jit/processor_dynamic.cpp` — the JIT interpreter's own target
  machine (`Cpp::CreateInterpreter`'s `CodeModel` argument).
- `runtime/context_dynamic.cpp` — the AOT `compile-module
  --output-target object` codegen path.

I also found and fixed a smaller, related issue while diagnosing
this: `aot/processor.cpp` unconditionally passes `-L/opt/homebrew/lib`
during AOT linking, which is only the Apple Silicon Homebrew prefix.
On Intel macOS, Homebrew installs to `/usr/local`, so
Homebrew-provided AOT link dependencies (e.g. `-lzstd`) were never
found without manually passing an extra `-L` flag.

## Fix

Use `CodeModel::Small` instead of `Large`, scoped narrowly to
x86-64+macOS (`#if defined(__x86_64__)` combined with
`jtl::current_platform == jtl::platform::macos_like`), leaving every
other platform untouched. I deliberately didn't change the code model
globally — `Large` may genuinely be needed elsewhere for bigger
binaries, and this bug only reproduces on this one platform
combination.

Also add `-L/usr/local/lib` alongside the existing
`-L/opt/homebrew/lib` in the AOT linker args; a nonexistent `-L`
directory is a harmless no-op for the linker.

## Verification

- `./build/jank check-health` — all green including
  `jank can aot compile working binaries`, using **stock** Homebrew
  LLVM 22.1.8 (no custom LLVM build required).
- Minimal repro: `jank compile` on a trivial `-main` namespace, then
  running the resulting binary — prints correctly instead of crashing.
- Full real-world test: built and ran a jank+OpenGL game engine
  project (private repo, uses ENet networking, ozz animation, etc.)
  end-to-end on this Intel Mac for the first time — client/server
  connected and exchanged messages correctly over real UDP
  networking.

Environment: macOS 26.5.1, Intel x86-64 (i7-9750H), Homebrew LLVM
22.1.8.
