### PR TITLE
Allow :rename without :only in refer-global

### DIFF
--- a/compiler+runtime/include/cpp/jank/runtime/ns.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/ns.hpp
@@ -69,5 +69,8 @@ namespace jank::runtime
 
   private:
     lazy_meta meta;
+
+    jtl::result<void, error_ref>
+    refer_global_impl(decltype(referred_cpp_globals)::LockedPtr &, object_ref const sym);
   };
 }

--- a/compiler+runtime/src/cpp/jank/runtime/module/loader_dynamic.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/module/loader_dynamic.cpp
@@ -401,7 +401,7 @@ namespace jank::runtime::module
     paths += util::format("{}{}", module_separator, (resource_dir / "src/jank").string());
 
     /* These paths below are only used during development. */
-    paths += util::format("{}{}", module_separator, (jank_path / "core-libs/_cache").string());
+    paths += util::format("{}{}", module_separator, (jank_path / "core-libs/_cache/0").string());
     paths += util::format("{}{}", module_separator, (jank_path / target_dir.c_str()).string());
     paths += util::format("{}{}", module_separator, (jank_path / "../src/jank").string());
 

--- a/compiler+runtime/src/cpp/jank/runtime/ns.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/ns.cpp
@@ -231,13 +231,6 @@ namespace jank::runtime
             return error::runtime_invalid_referred_global_symbol(object_source(new_name));
           }
 
-          if(!referred_names_without_renames.find(old_name))
-          {
-            return error::runtime_invalid_referred_global_rename(
-              "Symbols in :rename must also be referred in :only.",
-              object_source(old_name));
-          }
-
           auto const existing_var{ find_var(expect_object<obj::symbol>(new_name)) };
           if(existing_var.is_some())
           {

--- a/compiler+runtime/src/cpp/jank/runtime/ns.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/ns.cpp
@@ -3,8 +3,6 @@
 #include <jank/runtime/context.hpp>
 #include <jank/runtime/core/to_string.hpp>
 #include <jank/runtime/core/meta.hpp>
-#include <jank/runtime/sequence_range.hpp>
-#include <jank/runtime/visit.hpp>
 #include <jank/util/fmt/print.hpp>
 #include <jank/error/report.hpp>
 #include <jank/error/runtime.hpp>
@@ -192,67 +190,6 @@ namespace jank::runtime
     }
     *locked_vars = make_box<obj::persistent_hash_map>((*locked_vars)->data.set(sym, var));
     return ok();
-  }
-
-  jtl::result<void, error_ref> ns::rename_referred_globals(object_ref const rename_map)
-  {
-    runtime::detail::native_transient_hash_set referred_names_without_renames;
-    auto locked_globals(referred_cpp_globals.wlock());
-
-    /* We want to clear all previous renames so that the new rename map is all that we have.
-     * This is important for REPL-based development, where we re-evaluated the ns form with
-     * different renames. However, we want to keep :only names as they are. */
-    for(auto const p : (*locked_globals)->data)
-    {
-      if(p.first == p.second)
-      {
-        referred_names_without_renames.insert(p.first);
-        continue;
-      }
-
-      *locked_globals = (*locked_globals)->dissoc(p.first);
-    }
-
-    auto res{ visit_map_like(
-      [&](auto const typed_rename_map) -> jtl::result<void, error_ref> {
-        for(auto const p : make_sequence_range(typed_rename_map))
-        {
-          auto const old_name{ first(p) };
-          auto const new_name{ second(p) };
-
-          if(old_name.get_type() != object_type::symbol
-             || !expect_object<obj::symbol>(old_name)->ns.empty())
-          {
-            return error::runtime_invalid_referred_global_symbol(object_source(old_name));
-          }
-          if(new_name.get_type() != object_type::symbol
-             || !expect_object<obj::symbol>(new_name)->ns.empty())
-          {
-            return error::runtime_invalid_referred_global_symbol(object_source(new_name));
-          }
-
-          auto const existing_var{ find_var(expect_object<obj::symbol>(new_name)) };
-          if(existing_var.is_some())
-          {
-            return error::runtime_invalid_referred_global_rename(
-              util::format(
-                "'{}' already refers to {} in namespace '{}'. A '{}' referred global will not be "
-                "accessible, since vars are resolved before C++ referred globals.",
-                new_name.to_code_string(),
-                existing_var->to_code_string(),
-                name->to_string(),
-                new_name.to_code_string()),
-              object_source(new_name));
-          }
-
-          *locked_globals = (*locked_globals)->assoc(new_name, old_name);
-        }
-
-        return ok();
-      },
-      rename_map) };
-
-    return res;
   }
 
   obj::symbol_ref ns::find_referred_global(obj::symbol_ref const sym)

--- a/compiler+runtime/src/cpp/jank/runtime/ns_dynamic.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/ns_dynamic.cpp
@@ -1,13 +1,17 @@
 #include <jank/runtime/ns.hpp>
 #include <jank/runtime/rtti.hpp>
 #include <jank/runtime/core/meta.hpp>
+#include <jank/runtime/visit.hpp>
+#include <jank/runtime/sequence_range.hpp>
 #include <jank/analyze/processor.hpp>
 #include <jank/error/runtime.hpp>
 #include <jank/util/fmt/print.hpp>
 
 namespace jank::runtime
 {
-  jtl::result<void, error_ref> ns::refer_global(object_ref const sym)
+  jtl::result<void, error_ref>
+  ns::refer_global_impl(decltype(ns::referred_cpp_globals)::LockedPtr &locked_globals,
+                        object_ref const sym)
   {
     if(sym.get_type() != object_type::symbol)
     {
@@ -22,7 +26,6 @@ namespace jank::runtime
     }
 
     {
-      auto locked_globals(referred_cpp_globals.rlock());
       if(auto const found{ (*locked_globals)->data.find(sym_obj) }; found)
       {
         return ok();
@@ -53,10 +56,80 @@ namespace jank::runtime
         object_source(sym_obj));
     }
 
-    {
-      auto locked_globals(referred_cpp_globals.wlock());
-      *locked_globals = (*locked_globals)->assoc(sym_obj, sym_obj);
-    }
+    *locked_globals = (*locked_globals)->assoc(sym_obj, sym_obj);
     return ok();
   }
+
+  jtl::result<void, error_ref> ns::refer_global(object_ref const sym)
+  {
+    auto locked_globals(referred_cpp_globals.wlock());
+    return refer_global_impl(locked_globals, sym);
+  }
+
+  jtl::result<void, error_ref> ns::rename_referred_globals(object_ref const rename_map)
+  {
+    runtime::detail::native_transient_hash_set referred_names_without_renames;
+    auto locked_globals(referred_cpp_globals.wlock());
+
+    /* We want to clear all previous renames so that the new rename map is all that we have.
+     * This is important for REPL-based development, where we re-evaluated the ns form with
+     * different renames. However, we want to keep :only names as they are. */
+    for(auto const p : (*locked_globals)->data)
+    {
+      if(p.first == p.second)
+      {
+        referred_names_without_renames.insert(p.first);
+        continue;
+      }
+
+      *locked_globals = (*locked_globals)->dissoc(p.first);
+    }
+
+    auto res{ visit_map_like(
+      [&](auto const typed_rename_map) -> jtl::result<void, error_ref> {
+        for(auto const p : make_sequence_range(typed_rename_map))
+        {
+          auto const old_name{ first(p) };
+          auto const new_name{ second(p) };
+
+          if(old_name.get_type() != object_type::symbol
+             || !expect_object<obj::symbol>(old_name)->ns.empty())
+          {
+            return error::runtime_invalid_referred_global_symbol(object_source(old_name));
+          }
+          if(new_name.get_type() != object_type::symbol
+             || !expect_object<obj::symbol>(new_name)->ns.empty())
+          {
+            return error::runtime_invalid_referred_global_symbol(object_source(new_name));
+          }
+
+          if(!referred_names_without_renames.find(old_name))
+          {
+            refer_global_impl(locked_globals, old_name).expect_ok();
+          }
+
+          auto const existing_var{ find_var(expect_object<obj::symbol>(new_name)) };
+          if(existing_var.is_some())
+          {
+            return error::runtime_invalid_referred_global_rename(
+              util::format(
+                "'{}' already refers to {} in namespace '{}'. A '{}' referred global will not be "
+                "accessible, since vars are resolved before C++ referred globals.",
+                new_name.to_code_string(),
+                existing_var->to_code_string(),
+                name->to_string(),
+                new_name.to_code_string()),
+              object_source(new_name));
+          }
+
+          *locked_globals = (*locked_globals)->assoc(new_name, old_name);
+        }
+
+        return ok();
+      },
+      rename_map) };
+
+    return res;
+  }
+
 }

--- a/compiler+runtime/src/cpp/jank/runtime/ns_static.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/ns_static.cpp
@@ -6,4 +6,9 @@ namespace jank::runtime
   {
     return ok();
   }
+
+  jtl::result<void, error_ref> ns::rename_referred_globals(object_ref const)
+  {
+    return ok();
+  }
 }

--- a/compiler+runtime/src/jank/clojure/core.jank
+++ b/compiler+runtime/src/jank/clojure/core.jank
@@ -4748,7 +4748,7 @@
                       (cpp/clojure.core_native.throw_runtime_invalid_referred_global_rename (str "Referred global '" k "' is being renamed to '" v "', but '" v "' is already a referred global.")
                                                                                             v existing)
                                                                                                                                                                                                  (conj acc v)))
-                    (into #{} (:only actions))
+                    (into #{} (concat (:only actions) (keys (:rename actions))))
                                                                                                                                                                                                  (:rename actions))]
     (doseq [only (:only actions)]
       (cpp/clojure.core_native.refer_global only))

--- a/compiler+runtime/test/bash/module/refer-global/src/fail-unknown-rename.jank
+++ b/compiler+runtime/test/bash/module/refer-global/src/fail-unknown-rename.jank
@@ -1,5 +1,5 @@
 (ns test
   (:refer-global :only []
-                 :rename {std.string foo}))
+                 :rename {std.string.not_found foo}))
 
 (println :success)

--- a/compiler+runtime/test/bash/module/refer-global/src/pass-rename-without-only.jank
+++ b/compiler+runtime/test/bash/module/refer-global/src/pass-rename-without-only.jank
@@ -1,0 +1,5 @@
+(ns test
+  (:refer-global :rename {std.string.npos foo}))
+
+(if (= -1 foo)
+  (println :success))


### PR DESCRIPTION
This is a departure from the CLJS behavior, but the CLJS behavior is silly.