### PR TITLE
Enable `clojure.core-test.str`

### DIFF
--- a/compiler+runtime/include/cpp/jtl/string_builder.hpp
+++ b/compiler+runtime/include/cpp/jtl/string_builder.hpp
@@ -41,6 +41,7 @@ namespace jtl
     string_builder &operator()(unsigned long d) &;
     string_builder &operator()(unsigned long long d) &;
     string_builder &operator()(jank::native_big_integer const &d) &;
+    string_builder &operator()(jank::native_big_decimal const &d) &;
     string_builder &operator()(jank::runtime::obj::ratio_data const &r) &;
     string_builder &operator()(char d) &;
     string_builder &operator()(char32_t d) &;

--- a/compiler+runtime/src/cpp/jank/runtime/module/loader_dynamic.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/module/loader_dynamic.cpp
@@ -760,7 +760,7 @@ namespace jank::runtime::module
       case module_type::cpp:
       default:
         res = error::internal_runtime_failure(
-          util::format("Unknown module type '{}'.", module_type_to_load));
+          util::format("Unknown module type '{}'.", module_type_str(module_type_to_load)));
     }
 
     if(res.is_err())

--- a/compiler+runtime/src/cpp/jank/runtime/obj/big_decimal.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/big_decimal.cpp
@@ -155,17 +155,22 @@ namespace jank::runtime::obj
 
   jtl::immutable_string big_decimal::to_string() const
   {
-    return data.str();
+    jtl::string_builder sb;
+    sb(data);
+    return sb.release();
   }
 
   void big_decimal::to_string(jtl::string_builder &buff) const
   {
-    buff(data.str());
+    buff(data);
   }
 
   jtl::immutable_string big_decimal::to_code_string() const
   {
-    return to_string() + 'M';
+    jtl::string_builder sb;
+    sb(data);
+    sb('M');
+    return sb.release();
   }
 
   uhash big_decimal::to_hash() const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/number.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/number.cpp
@@ -296,16 +296,16 @@ namespace jank::runtime::obj
     {
       if(data < 0)
       {
-        buff("##-Inf");
+        buff("-Infinity");
       }
       else
       {
-        buff("##Inf");
+        buff("Infinity");
       }
     }
     else if(std::isnan(data))
     {
-      buff("##NaN");
+      buff("NaN");
     }
     else
     {
@@ -315,7 +315,25 @@ namespace jank::runtime::obj
 
   jtl::immutable_string real::to_code_string() const
   {
-    return to_string();
+    if(std::isinf(data))
+    {
+      if(data < 0)
+      {
+        return "##-Inf";
+      }
+      else
+      {
+        return "##Inf";
+      }
+    }
+    else if(std::isnan(data))
+    {
+      return "##NaN";
+    }
+    else
+    {
+      return to_string();
+    }
   }
 
   uhash real::to_hash() const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/ratio.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/ratio.cpp
@@ -37,9 +37,9 @@ namespace jank::runtime::obj
     }
     else
     {
-      throw std::runtime_error{
-        util::format("Type {} cannot be used as a ratio numerator or denominator.", d.get_type())
-      };
+      throw std::runtime_error{ util::format(
+        "Type {} cannot be used as a ratio numerator or denominator.",
+        object_type_str(d.get_type())) };
     }
     return result;
   }

--- a/compiler+runtime/src/cpp/jtl/string_builder.cpp
+++ b/compiler+runtime/src/cpp/jtl/string_builder.cpp
@@ -133,12 +133,24 @@ namespace jtl
   {
     if(std::isinf(d))
     {
-      constexpr jtl::immutable_string_view const infinity{ "INFINITY" };
-      maybe_realloc(*this, infinity.size());
+      if(d < 0)
+      {
+        constexpr jtl::immutable_string_view const minus_infinity{ "-INFINITY" };
+        maybe_realloc(*this, minus_infinity.size());
 
-      /* NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg) */
-      snprintf(buffer + pos, capacity - pos, "%s", infinity.data());
-      pos += infinity.size();
+        /* NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg) */
+        snprintf(buffer + pos, capacity - pos, "%s", minus_infinity.data());
+        pos += minus_infinity.size();
+      }
+      else
+      {
+        constexpr jtl::immutable_string_view const infinity{ "INFINITY" };
+        maybe_realloc(*this, infinity.size());
+
+        /* NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg) */
+        snprintf(buffer + pos, capacity - pos, "%s", infinity.data());
+        pos += infinity.size();
+      }
     }
     else if(std::isnan(d))
     {

--- a/compiler+runtime/src/cpp/jtl/string_builder.cpp
+++ b/compiler+runtime/src/cpp/jtl/string_builder.cpp
@@ -274,6 +274,17 @@ namespace jtl
     return (*this)(d.str());
   }
 
+  string_builder &string_builder::operator()(jank::native_big_decimal const &d) &
+  {
+    auto const s(d.str());
+    (*this)(s);
+    if(s.find('.') == std::string::npos)
+    {
+      (*this)(".0");
+    }
+    return *this;
+  }
+
   string_builder &string_builder::operator()(jank::runtime::obj::ratio_data const &r) &
   {
     (*this)(r.numerator);

--- a/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
+++ b/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
@@ -196,7 +196,7 @@
     ; clojure.core-test.special-symbol-qmark ; TODO: port special-symbol?
     ; clojure.core-test.star ; FIXME: Failing tests.
     clojure.core-test.star-squote
-    ; clojure.core-test.str ; FIXME: Failing tests.
+    clojure.core-test.str
     clojure.core-test.string-qmark
     ; clojure.core-test.subs ; FIXME: Failing tests.
     clojure.core-test.subvec


### PR DESCRIPTION
~Depends on https://github.com/jank-lang/clojure-test-suite/pull/923 to fix the following failures~:

```clojure
FAIL in (nil) (:)
expected: (= "0.0" (str 0M))
  actual: (not (= "0.0" "0"))

FAIL in (nil) (:)
expected: (= "1.0" (str 1M))
  actual: (not (= "1.0" "1"))

FAIL in (nil) (:)
expected: (= "-1.0" (str -1M))
  actual: (not (= "-1.0" "-1"))
```