### PR TITLE
Clean up handling of lein-jank CLI args

### DIFF
--- a/lein-jank/project.clj
+++ b/lein-jank/project.clj
@@ -6,6 +6,7 @@
   :dependencies [[babashka/fs "0.5.33"]
                  [babashka/process "0.6.25"]
                  [leiningen-core "2.12.0"]
+                 [org.clojure/tools.cli "1.4.256"]
                  [org.clojure/tools.namespace "1.5.1"]]
   :profiles {:dev {:dependencies [[nubank/matcher-combinators "3.10.0"]]}}
   :eval-in-leiningen true)

--- a/lein-jank/src/leiningen/jank.clj
+++ b/lein-jank/src/leiningen/jank.clj
@@ -1,138 +1,114 @@
 (ns leiningen.jank
   (:refer-clojure :exclude [run!])
-  (:require [clojure.pprint :as pp]
-            [leiningen.core.main :as lmain]
+  (:require [leiningen.core.main :as lmain]
             [leiningen.jank.core :as ljc]
             [leiningen.jank.test :as ljt]
-            [leiningen.jank.build :as ljb]
+            [leiningen.help :as lhelp]
             [babashka.fs :as fs]))
 
-(defn process-task-args
-  "Extract task-specific args from the list and return the parsed options and
-  the leftover arguments."
-  [project args]
-  (let [[args extra] (lmain/parse-options args)
-        opts         (reduce (fn [opts arg]
-                               (case arg
-                                 [:--disable-sandbox true]
-                                 (assoc opts :disable-sandbox true)
+(defn- dispatch-jank [project opts cmd jank-args prog-args]
+  (when (:verbose opts)
+    (reset! ljc/verbose? true))
+  (let [project     (ljc/native-build project opts)
+        cp-str      (ljc/build-module-path project)]
+    (ljc/shell-out! project cp-str cmd jank-args prog-args)))
 
-                                 project))
-                             {}
-                             args)]
-    [opts extra]))
-
-(defn native-build [project opts]
-  (binding [ljb/*disable-sandbox* (or ljb/*disable-sandbox* (:disable-sandbox opts))
-            ljb/*verbose-build*   @ljc/verbose?]
-    (let [native-flags (ljb/run-build! (ljb/plan-build project))]
-      (update project :jank ljb/merge-native-flags native-flags))))
+(def run-cli-options
+  [["-m" "--main NAMESPACE" "override main namespace"]])
 
 (defn run!
-  "Run your project, starting at the main entrypoint."
+  "Run your project, starting at the :main entrypoint.
+
+  USAGE: lein run [--] [ARGS...]
+  Calls the -main function in the namespace specified as :main in project.clj.
+  ARGS are forwarded to -main.
+
+  USAGE: lein run -m/--main NAMESPACE [--] [ARGS...]
+  Calls the -main function in the given namespace."
   [project & args]
-  (let [[opts args] (process-task-args project args)
-        project     (native-build project opts)
-        cp-str      (ljc/build-module-path project)]
-    (if (:main project)
-      (ljc/shell-out! project cp-str "run-main" [(:main project)] args)
+  (let [cli-options (into ljc/standard-options run-cli-options)
+        [opts args] (ljc/parse-opts #'run! args cli-options)]
+    (if-let [main (or (:main opts) (:main project))]
+      (dispatch-jank project opts "run-main" [main] args)
       (lmain/warn "No :main entrypoint for project."))))
 
 (defn repl!
-  "Start a terminal REPL in your :main ns."
+  "Start a terminal REPL and nREPL server in your :main ns, or the user ns if no
+  :main is specified."
   [project & args]
-  (let [[opts args] (process-task-args project args)
-        project     (native-build project opts)
-        cp-str      (ljc/build-module-path project)]
-    (if (:main project)
-      (ljc/shell-out! project cp-str "repl" [(:main project)] args)
-      (lmain/warn "No :main entrypoint for project."))))
+  (let [[opts args] (ljc/parse-opts #'repl! args ljc/standard-options)
+        main        (:main project)]
+    (dispatch-jank project opts "repl" (if main [main] []) args)))
 
 (defn compile!
   "Compile your project to an executable."
   [project & args]
-  (let [[opts args] (process-task-args project args)
-        project     (native-build project opts)
-        cp-str      (ljc/build-module-path project)]
-    (if (:main project)
-      (ljc/shell-out! project cp-str "compile" [(:main project)] args)
+  (let [[opts args] (ljc/parse-opts #'compile! args ljc/standard-options)]
+    (if-let [main (:main project)]
+      (dispatch-jank project opts "compile" [main] args)
       (lmain/warn "No :main entrypoint for project."))))
 
 (defn compile-module!
   "Compile a single module and its dependencies to object files."
   [project & args]
-  (let [[opts args] (process-task-args project args)
-        project     (native-build project opts)
-        cp-str      (ljc/build-module-path project)]
-    (ljc/shell-out! project cp-str "compile-module" [] args)))
+  (let [[opts args] (ljc/parse-opts #'compile-module! args ljc/standard-options)]
+    (dispatch-jank project opts "compile-module" [] args)))
 
 (defn check-health!
   "Perform a health check on your jank install."
   [project & args]
-  (let [cp-str (ljc/build-module-path project)]
-    (ljc/shell-out! project cp-str "check-health" [] args)))
-
-(declare print-help!)
+  (let [[opts args] (ljc/parse-opts #'check-health! args ljc/standard-options)]
+    (dispatch-jank project opts "check-health" [] args)))
 
 (def subtask-kw->var {:run #'run!
                       :repl #'repl!
                       :compile #'compile!
                       :compile-module #'compile-module!
                       :check-health #'check-health!
-                      :test #'ljt/test!
-                      :help #'print-help!})
-
-(defn print-help!
-  "Show this help message."
-  [& _args]
-  (pp/print-table
-   (map (fn [[sub fn-ref]]
-          {:sub-command (name sub)
-           :help (-> fn-ref meta :doc)})
-        subtask-kw->var)))
-
-(defn process-jank-args [args]
-  (loop [args args
-         ret []]
-    (if (empty? args)
-      ret
-      (let [arg (first args)
-            ret (case arg
-                  "-v" (do
-                         (reset! ljc/verbose? true)
-                         ret)
-                  (conj ret arg))]
-        (recur (rest args) ret)))))
+                      :test #'ljt/test!})
 
 (defn jank
-  "Compile, run, test and repl into jank."
+  "Compile, run, test and repl into jank.
+
+  Prefer using the top-level run, compile, etc. commands directly."
   [project subcmd & args]
   (if-some [handler (subtask-kw->var (keyword subcmd))]
-    (apply handler project (process-jank-args args))
-    (do
-      (lmain/warn "Invalid subcommand!")
-      (print-help!)
-      (lmain/exit 1))))
+    (apply handler project args)
+    (lmain/abort "Invalid subcommand!")))
+
+;; Make e.g. "lein help run" resolve to the "jank run" alias, and so on for all
+;; defined jank aliases. Or fall back to the default lein help if a jank alias
+;; does not exist.
+
+(def orig-help-for lhelp/help-for)
+
+(defn jank-help-for
+  ([task-name] (orig-help-for task-name))
+  ([project task-name]
+   (if-some [handler (subtask-kw->var (keyword task-name))]
+     (:doc (meta handler))
+     (orig-help-for project task-name))))
+(alter-var-root #'lhelp/help-for (constantly jank-help-for))
 
 (defn default-project [project]
-  {:jank {:name (:name project)}
-   :aliases {"run" ^{:doc "Run your project, starting at the main entrypoint."}
-             ["jank" "run"]
+  {:jank     {:name (:name project)}
+   :aliases  {"run" ^{:doc "Run your project, starting at the main entrypoint."}
+              ["jank" "run"]
 
-             "repl" ^{:doc "Start a terminal REPL in your :main ns."}
-             ["jank" "repl"]
+              "repl" ^{:doc "Start a terminal REPL in your :main or user ns."}
+              ["jank" "repl"]
 
-             "compile" ^{:doc "Compile your project to an executable."}
-             ["jank" "compile"]
+              "compile" ^{:doc "Compile your project to an executable."}
+              ["jank" "compile"]
 
-             "compile-module" ^{:doc "Compile a single module and its dependencies to object files."}
-             ["jank" "compile-module"]
+              "compile-module" ^{:doc "Compile a single module and its dependencies to object files."}
+              ["jank" "compile-module"]
 
-             "test" ^{:doc "Run your project's test suite."}
-             ["jank" "test"]
+              "test" ^{:doc "Run your project's test suite."}
+              ["jank" "test"]
 
-             "check-health" ^{:doc "Perform a health check on your jank install."}
-             ["jank" "check-health"]}})
+              "check-health" ^{:doc "Perform a health check on your jank install."}
+              ["jank" "check-health"]}})
 
 (defn deep-merge-metadata
   "Deep merges metadata from multiple maps. Returns merged metadata or nil."
@@ -175,7 +151,7 @@
   These paths are copied exactly, whereas the standard keys like :source-paths
   strip the path prefix such that the entries appear directly on the classpath
   when the jar is loaded."
-  [{:keys [root verbatim-paths] :as project}]
+  [{:keys [verbatim-paths] :as project}]
   (for [path  verbatim-paths
         f     (if (fs/directory? path)
                 (fs/glob (fs/path (:root project) path) "**")

--- a/lein-jank/src/leiningen/jank.clj
+++ b/lein-jank/src/leiningen/jank.clj
@@ -19,12 +19,12 @@
 (defn run!
   "Run your project, starting at the :main entrypoint.
 
-  USAGE: lein run [--] [ARGS...]
-  Calls the -main function in the namespace specified as :main in project.clj.
-  ARGS are forwarded to -main.
+USAGE: lein run [--] [ARGS...]
+Calls the -main function in the namespace specified as :main in project.clj.
+ARGS are forwarded to -main.
 
-  USAGE: lein run -m/--main NAMESPACE [--] [ARGS...]
-  Calls the -main function in the given namespace."
+USAGE: lein run -m/--main NAMESPACE [--] [ARGS...]
+Calls the -main function in the given namespace."
   [project & args]
   (let [cli-options (into ljc/standard-options run-cli-options)
         [opts args] (ljc/parse-opts #'run! args cli-options)]

--- a/lein-jank/src/leiningen/jank/core.clj
+++ b/lein-jank/src/leiningen/jank/core.clj
@@ -1,13 +1,47 @@
 (ns leiningen.jank.core
   (:require
    [clojure.string :as string]
+   [clojure.tools.cli :as cli]
    [leiningen.core.classpath :as lcp]
    [babashka.fs :as fs]
    [babashka.process :as ps]
-   [leiningen.core.main :as lmain])
+   [leiningen.core.main :as lmain]
+   [leiningen.jank.build :as ljb])
   (:import [java.io File]))
 
 (defonce verbose? (atom false))
+
+(def standard-options
+  "Standard command line options shared by all lein-jank tasks"
+  [["-v" "--verbose" "verbose output"]
+   [nil  "--disable-sandbox" "disable jank-build sandboxing"]])
+
+(defn parse-opts
+  "Process the args using the given clojure.tools.cli option-specs. If given
+  invalid arguments, print and exit. Otherwise, returns a vector of the parsed
+  options and any leftover arguments."
+  [task-sym args option-specs]
+  (let [{:keys [options arguments errors summary]} (cli/parse-opts args option-specs)]
+    (if-not errors
+      [options arguments]
+      (lmain/abort (str "Error parsing task arguments:\n"
+                        (string/join "\n" (map #(str "  " %) errors))
+                        "\n\nValid arguments are:\n"
+                        summary
+                        "\n\nFull task usage:\n"
+                        (-> task-sym meta :doc))))))
+
+(defn native-build
+  "Execute the native build step for the project and its dependencies.
+
+  This should be called whenever running or compiling the main project, to
+  ensure the native libraries are up-to-date. Any work which doesn't need to be
+  recomputed will be cached."
+  [project opts]
+  (binding [ljb/*disable-sandbox* (or ljb/*disable-sandbox* (:disable-sandbox opts))
+            ljb/*verbose-build*   @verbose?]
+    (let [native-flags (ljb/run-build! (ljb/plan-build project))]
+      (update project :jank ljb/merge-native-flags native-flags))))
 
 (defn build-module-path [project]
   (->> project


### PR DESCRIPTION
- Overrides standard lein help strings with our jank alias doc strings. Generally our commands are not compatible with all of the upstream leiningen arguments, so it was confusing for users. The implementation is pretty hacky though...
- Adds some compatibility with standard lein commands, such as specifying `lein run -m/--main` to override the main namespace
- `lein repl` doesn't need a `:main` namespace
- Consolidate some duplicated arg parsing logic, introduce `clojure.tools.cli`, print a nicer help message on invalid task args

Example session:

```
$ lein help run
Run your project, starting at the :main entrypoint.

  USAGE: lein run [--] [ARGS...]
  Calls the -main function in the namespace specified as :main in project.clj.
  ARGS are forwarded to -main.

  USAGE: lein run -m/--main NAMESPACE [--] [ARGS...]
  Calls the -main function in the given namespace.

$ lein run -m e07-weather --disable-sandbox -- --prog-arg
Building with sandboxing disabled is potentially dangerous!
 Compiling [io.github.kylc/jank-slint 0.1.1]
^C⏎                                                                                                                     

$ lein run -m e07-weather --disable-sandbox --fake-arg -- --prog-arg
Error parsing task arguments:
  Unknown option: "--fake-arg"

Valid arguments are:
  -v, --verbose          verbose output
      --disable-sandbox  disable jank-build sandboxing
  -m, --main NAMESPACE   override main namespace

Full task usage:
Run your project, starting at the :main entrypoint.

  USAGE: lein run [--] [ARGS...]
  Calls the -main function in the namespace specified as :main in project.clj.
  ARGS are forwarded to -main.

  USAGE: lein run -m/--main NAMESPACE [--] [ARGS...]
  Calls the -main function in the given namespace.
```