### PR TITLE
Add rerun-if[-env]-changed to jank-build

### DIFF
--- a/lein-jank/src/leiningen/jank/build.clj
+++ b/lein-jank/src/leiningen/jank/build.clj
@@ -250,8 +250,7 @@
 
   Returns nil if the build output cannot be read."
   [compile-op]
-  (when-let [directives (-> (read-build-directives (:out-dir compile-op))
-                            (select-keys [:rerun-if-changed :rerun-if-env-changed]))]
+  (when-let [directives (read-build-directives (:out-dir compile-op))]
     (let [paths (->> (:rerun-if-changed directives)
                      (map #(fs/path (:src-dir compile-op) %)))
           vars  (:rerun-if-env-changed directives)]

--- a/lein-jank/src/leiningen/jank/build.clj
+++ b/lein-jank/src/leiningen/jank/build.clj
@@ -5,7 +5,8 @@
             [babashka.fs :as fs]
             [leiningen.core.main :as lmain]
             [leiningen.jank.sandbox.core :as sandbox]
-            [leiningen.jank.resolve :as resolve])
+            [leiningen.jank.resolve :as resolve]
+            [leiningen.jank.changed :as changed])
   (:import (java.security MessageDigest)
            (java.util Base64)
            (java.util.jar JarFile)))
@@ -16,6 +17,7 @@
 
 (def jank-build-file "jank-build.bb")
 (def jank-build-cache-file "jank-build-cache.txt")
+(def jank-build-fingerprint-file "jank-build-fingerprint.txt")
 
 (def default-build-opts
   {:target-dir         "target"
@@ -29,6 +31,12 @@
    (let [valid-keys [:defines :include-dirs :library-dirs :linked-libraries]]
      (reduce (fn [a b] (merge-with into a (select-keys b valid-keys))) maps))))
 
+(defn merge-rerun-flags
+  ([] {})
+  ([& maps]
+   (let [valid-keys [:rerun-if-changed :rerun-if-env-changed]]
+     (reduce (fn [a b] (merge-with into a (select-keys b valid-keys))) maps))))
+
 (defn has-build-file?
   "Returns true if the given directory or jar file has a `jank-build.bb` file in
   the root."
@@ -37,11 +45,6 @@
     (fs/regular-file? (fs/path path jank-build-file))
     (with-open [jar (JarFile. path)]
       (some? (.getEntry jar jank-build-file)))))
-
-(defn has-build-cache-file?
-  "Returns true if the given directory has a jank build cache file."
-  [path]
-  (fs/regular-file? (fs/path path jank-build-cache-file)))
 
 (defn extract-jar!
   "Extract the jar file into `out-dir`, creating it if it does not exist."
@@ -91,10 +94,12 @@
   [line]
   (when-let [[_ k v] (re-matches #"jank-build::(.*?)=(.*)" line)]
     (case k
-      "define"       (let [[a b] (string/split v #"=" 2)] {:defines {a b}})
-      "include-dir"  {:include-dirs [v]}
-      "link-dir"     {:library-dirs [v]}
-      "link-library" {:linked-libraries [v]}
+      "define"               (let [[a b] (string/split v #"=" 2)] {:defines {a b}})
+      "include-dir"          {:include-dirs [v]}
+      "link-dir"             {:library-dirs [v]}
+      "link-library"         {:linked-libraries [v]}
+      "rerun-if-changed"     {:rerun-if-changed [v]}
+      "rerun-if-env-changed" {:rerun-if-env-changed [v]}
       (do (lmain/warn "invalid jank-build directive:" line)
           nil))))
 
@@ -259,10 +264,6 @@
            ;; recursively resolving their dependencies and so on.
           dep-ops  (vec (mapcat #(plan-subtree-build build-opts target-dir %) tree))
            ;; Special handling when the root project has a build script.
-           ;; 
-           ;; TODO: For now we always run the root build script, but we
-           ;; could cache it if we knew its input files. Cargo does this
-           ;; by outputting rerun-if-changed flags from the build script.
           root-ops (when (has-build-file? (:root project))
                      [{:op           :compile
                        :dep          [(symbol (:group project) (:name project)) (:version project)]
@@ -270,10 +271,48 @@
                        :out-dir      (str (target-subdir target-dir "out" (:name project) "XXX"))
                        :build-opts   build-opts
                        :build-inputs (collect-build-deps tree)
-                       :inputs       (collect-out-dirs dep-ops)
-                       :always-build true}])
+                       :inputs       (collect-out-dirs dep-ops)}])
           plan (into dep-ops root-ops)]
       plan)))
+
+(defn read-build-result
+  [out-dir]
+  (let [path (fs/path out-dir jank-build-cache-file)]
+    (when (fs/regular-file? path)
+      (->> path
+           (fs/read-all-lines)
+           (keep process-build-directive)))))
+
+(defn rerun-fingerprint
+  "Compute the fingerprint of a compile operation based on its declared
+  rerun-if*-changed flags.
+
+  Returns nil if the build output cannot be read."
+  [compile-op]
+  (when-let [build-directives (read-build-result (:out-dir compile-op))]
+    (let [rerun-directives (apply merge-rerun-flags build-directives)
+          paths            (:rerun-if-changed rerun-directives)
+          vars             (:rerun-if-env-changed rerun-directives)]
+      (fingerprint {:paths (->> paths
+                                (map #(fs/path (:src-dir compile-op) %))
+                                (map changed/maximum-mtime)
+                                (apply max 0))
+                    :vars  (mapv changed/getenv vars)}))))
+
+(defn needs-compile?
+  "Determine if a compile operation can be skipped based on a matching target
+  cache."
+  [compile-op]
+  (let [fingerprint-path (fs/path (:out-dir compile-op) jank-build-fingerprint-file)]
+    (or
+      ;; No build cache means a successful build has not been performed.
+      (not (fs/regular-file? (fs/path (:out-dir compile-op) jank-build-cache-file)))
+
+      ;; No fingerprint file or a mismatched fingerprint means something in the
+      ;; source or env has changed.
+      (not (fs/regular-file? fingerprint-path))
+      (not= (fs/read-all-lines fingerprint-path)
+            [(rerun-fingerprint compile-op)]))))
 
 (defmulti run-build-op! (fn [_ op] (:op op)))
 
@@ -282,7 +321,7 @@
   ;; If the output dir already exists then the jar has already been extracted.
   ;; Since the out-dir name includes the jar fingerprint, we know that the
   ;; contents will be the same and we can skip the step.
-  (when-not (fs/exists? out-dir)
+  (when-not (fs/directory? out-dir)
     (println (str "\u001b[1;36m" (format "%10s" "Extracting") "\u001b[0m") dep)
     (extract-jar! jar out-dir))
 
@@ -290,18 +329,18 @@
   nil)
 
 (defmethod run-build-op! :compile
-  [plan {:keys [dep out-dir always-build] :as op}]
-  ;; Just like the extract-src case, if the build artifacts already exist in the
-  ;; fingerprinted output dir, then we know the inputs have not changed and
-  ;; there is no need to rebuild.
-  (when (or always-build (not (has-build-cache-file? out-dir)))
+  [plan {:keys [dep out-dir] :as op}]
+  (when (needs-compile? op)
     (println (str "\u001b[1;32m" (format "%10s" "Compiling") "\u001b[0m") dep)
     (build-dep! op))
 
+  ;; Write a fingerprint file to detect any changes in the watched files or env
+  ;; vars on subsequent builds.
+  (when-let [fprint (rerun-fingerprint op)]
+    (fs/write-lines (fs/path (:out-dir op) jank-build-fingerprint-file) [fprint]))
+
   ;; jank flags are extracted from the build cache file
-  (->> (fs/path out-dir jank-build-cache-file)
-       (fs/read-all-lines)
-       (keep process-build-directive)))
+  (read-build-result out-dir))
 
 (defn run-build!
   "Run the sequence of build steps planned by `plan-build`."

--- a/lein-jank/src/leiningen/jank/build.clj
+++ b/lein-jank/src/leiningen/jank/build.clj
@@ -248,17 +248,23 @@
   "Compute the fingerprint of a compile operation based on its declared
   rerun-if*-changed flags.
 
+  If no :rerun-if-changed paths are given, then ALL source paths will be
+  tracked. If no :rerun-if-env-changed variables are given, then NO variables
+  are tracked.
+
   Returns nil if the build output cannot be read."
   [compile-op]
   (when-let [directives (read-build-directives (:out-dir compile-op))]
-    (let [paths (->> (:rerun-if-changed directives)
-                     (map #(fs/path (:src-dir compile-op) %)))
+    (let [paths (if (empty? (:rerun-if-changed directives))
+                  [(:src-dir compile-op)]
+                  (->> (:rerun-if-changed directives)
+                       (map #(fs/path (:src-dir compile-op) %))))
           vars  (:rerun-if-env-changed directives)]
       (change-fingerprint paths vars))))
 
 (defn needs-compile?
-  "Determine if a compile operation can be skipped based on a matching target
-  cache."
+  "Determine if a compile operation can be skipped based on whether it has
+  already been compiled and all of the tracked rerun-if-* have not changed. "
   [compile-op]
   (let [fingerprint-path (fs/path (:out-dir compile-op) jank-build-fingerprint-file)]
     (or

--- a/lein-jank/src/leiningen/jank/build.clj
+++ b/lein-jank/src/leiningen/jank/build.clj
@@ -6,10 +6,9 @@
             [leiningen.core.main :as lmain]
             [leiningen.jank.sandbox.core :as sandbox]
             [leiningen.jank.resolve :as resolve]
-            [leiningen.jank.changed :as changed])
-  (:import (java.security MessageDigest)
-           (java.util Base64)
-           (java.util.jar JarFile)))
+            [leiningen.jank.fingerprint :refer [fingerprint fingerprint-file]]
+            [leiningen.jank.changed :refer [change-fingerprint]])
+  (:import (java.util.jar JarFile)))
 
 (def ^:dynamic *disable-sandbox* false)
 
@@ -25,18 +24,6 @@
    ;; TODO: enable when jank can link to .a files via -L and -l flags.
    :static-build       false})
 
-(defn merge-native-flags
-  ([] {})
-  ([& maps]
-   (let [valid-keys [:defines :include-dirs :library-dirs :linked-libraries]]
-     (reduce (fn [a b] (merge-with into a (select-keys b valid-keys))) maps))))
-
-(defn merge-rerun-flags
-  ([] {})
-  ([& maps]
-   (let [valid-keys [:rerun-if-changed :rerun-if-env-changed]]
-     (reduce (fn [a b] (merge-with into a (select-keys b valid-keys))) maps))))
-
 (defn has-build-file?
   "Returns true if the given directory or jar file has a `jank-build.bb` file in
   the root."
@@ -50,35 +37,6 @@
   "Extract the jar file into `out-dir`, creating it if it does not exist."
   [file out-dir]
   (fs/unzip file out-dir {:replace-existing true}))
-
-(defn base64
-  "Modified base64 encoding which is safe for URLs/file paths."
-  [^bytes bs]
-  (let [enc (-> (Base64/getUrlEncoder)
-                .withoutPadding)]
-    (.encodeToString enc bs)))
-
-(defn fingerprint
-  "Compute a fingerprint of some printable data structure."
-  [data]
-  ;; TODO: We should implement something like Cargo's fingerprint to better
-  ;; react to changes in the environment:
-  ;;
-  ;; https://doc.rust-lang.org/nightly/nightly-rustc/cargo/core/compiler/fingerprint/index.html
-  (let [md     (MessageDigest/getInstance "MD5")
-        baos   (java.io.ByteArrayOutputStream.)]
-    (with-open [writer (io/writer baos)]
-      (binding [*out* writer]
-        (pr data)))
-    (.update md (.toByteArray baos))
-    (base64 (.digest md))))
-
-(defn fingerprint-file
-  "Like `fingerprint` but for the contents of a file."
-  [f]
-  (let [md (MessageDigest/getInstance "MD5")]
-    (.update md (fs/read-all-bytes f))
-    (base64 (.digest md))))
 
 (defn target-subdir
   "Returns a path located in the target directory which is unique based on the
@@ -275,13 +233,16 @@
           plan (into dep-ops root-ops)]
       plan)))
 
-(defn read-build-result
+(defn read-build-directives
+  "Read the jank-build cache file and return a map of the parsed build
+  directives."
   [out-dir]
   (let [path (fs/path out-dir jank-build-cache-file)]
     (when (fs/regular-file? path)
       (->> path
            (fs/read-all-lines)
-           (keep process-build-directive)))))
+           (keep process-build-directive)
+           (apply merge-with into)))))
 
 (defn rerun-fingerprint
   "Compute the fingerprint of a compile operation based on its declared
@@ -289,15 +250,12 @@
 
   Returns nil if the build output cannot be read."
   [compile-op]
-  (when-let [build-directives (read-build-result (:out-dir compile-op))]
-    (let [rerun-directives (apply merge-rerun-flags build-directives)
-          paths            (:rerun-if-changed rerun-directives)
-          vars             (:rerun-if-env-changed rerun-directives)]
-      (fingerprint {:paths (->> paths
-                                (map #(fs/path (:src-dir compile-op) %))
-                                (map changed/maximum-mtime)
-                                (apply max 0))
-                    :vars  (mapv changed/getenv vars)}))))
+  (when-let [directives (-> (read-build-directives (:out-dir compile-op))
+                            (select-keys [:rerun-if-changed :rerun-if-env-changed]))]
+    (let [paths (->> (:rerun-if-changed directives)
+                     (map #(fs/path (:src-dir compile-op) %)))
+          vars  (:rerun-if-env-changed directives)]
+      (change-fingerprint paths vars))))
 
 (defn needs-compile?
   "Determine if a compile operation can be skipped based on a matching target
@@ -340,11 +298,13 @@
     (fs/write-lines (fs/path (:out-dir op) jank-build-fingerprint-file) [fprint]))
 
   ;; jank flags are extracted from the build cache file
-  (read-build-result out-dir))
+  (select-keys (read-build-directives out-dir)
+               [:defines :include-dirs :library-dirs :linked-libraries]))
 
 (defn run-build!
-  "Run the sequence of build steps planned by `plan-build`."
+  "Run the sequence of build steps planned by `plan-build`.
+
+  Returns a map of :defines, :include-dirs, :library-dirs, and :linked-libraries
+  to be passed to the jank compiler."
   [plan]
-  (->> (mapv #(run-build-op! plan %) plan)
-       (flatten)
-       (apply merge-native-flags)))
+  (apply merge (mapv #(run-build-op! plan %) plan)))

--- a/lein-jank/src/leiningen/jank/changed.clj
+++ b/lein-jank/src/leiningen/jank/changed.clj
@@ -1,0 +1,14 @@
+(ns leiningen.jank.changed
+  (:require [babashka.fs :as fs]))
+
+(defn getenv [k]
+  (System/getenv k))
+
+(defn maximum-mtime
+  "Read the mtime of the given file, or the recursive maximum if given a
+  directory."
+  [path]
+  (if (fs/directory? path)
+    (apply max (map maximum-mtime (fs/list-dir path)))
+    (fs/file-time->millis (fs/last-modified-time path))))
+

--- a/lein-jank/src/leiningen/jank/changed.clj
+++ b/lein-jank/src/leiningen/jank/changed.clj
@@ -1,14 +1,34 @@
 (ns leiningen.jank.changed
-  (:require [babashka.fs :as fs]))
+  "For tracking changes in the environment and in build source files."
+  (:require [babashka.fs :as fs]
+            [leiningen.jank.fingerprint :refer [fingerprint]]))
 
-(defn getenv [k]
-  (System/getenv k))
+(defn env
+  "Return a map of resolved environment variables."
+  [vars]
+  (->> vars
+       (map (fn [k] [k (System/getenv k)]))
+       (into {})))
 
 (defn maximum-mtime
-  "Read the mtime of the given file, or the recursive maximum if given a
-  directory."
-  [path]
-  (if (fs/directory? path)
-    (apply max (map maximum-mtime (fs/list-dir path)))
-    (fs/file-time->millis (fs/last-modified-time path))))
+  "Read the mtime of the given paths, or the recursive maximum mtime if a
+  directory is encountered.
 
+  For symlinks, the mtime of the symlink itself is used, and link is not
+  followed."
+  [paths]
+  (->>
+   (for [path paths]
+     (if (fs/directory? path)
+       (maximum-mtime (fs/list-dir path))
+       (-> path
+           (fs/last-modified-time {:nofollow-links true})
+           (fs/file-time->millis))))
+   (apply max 0)))
+
+(defn change-fingerprint
+  "Compute a fingerprint with respect to the mtimes of the given file paths and
+  the contents of the given environment variables."
+  [paths vars]
+  (fingerprint {:paths (maximum-mtime paths)
+                :vars  (env vars)}))

--- a/lein-jank/src/leiningen/jank/core.clj
+++ b/lein-jank/src/leiningen/jank/core.clj
@@ -41,7 +41,7 @@
   (binding [ljb/*disable-sandbox* (or ljb/*disable-sandbox* (:disable-sandbox opts))
             ljb/*verbose-build*   @verbose?]
     (let [native-flags (ljb/run-build! (ljb/plan-build project))]
-      (update project :jank ljb/merge-native-flags native-flags))))
+      (update project :jank #(merge-with into % native-flags)))))
 
 (defn build-module-path [project]
   (->> project

--- a/lein-jank/src/leiningen/jank/fingerprint.clj
+++ b/lein-jank/src/leiningen/jank/fingerprint.clj
@@ -1,0 +1,34 @@
+(ns leiningen.jank.fingerprint
+  (:require [clojure.java.io :as io]
+            [babashka.fs :as fs])
+  (:import (java.security MessageDigest)
+           (java.util Base64)))
+
+(defn base64
+  "Modified base64 encoding which is safe for URLs/file paths."
+  [^bytes bs]
+  (let [enc (-> (Base64/getUrlEncoder)
+                .withoutPadding)]
+    (.encodeToString enc bs)))
+
+(defn fingerprint
+  "Compute a fingerprint of some printable data structure."
+  [data]
+  ;; TODO: We should implement something like Cargo's fingerprint to better
+  ;; react to changes in the environment:
+  ;;
+  ;; https://doc.rust-lang.org/nightly/nightly-rustc/cargo/core/compiler/fingerprint/index.html
+  (let [md   (MessageDigest/getInstance "MD5")
+        baos (java.io.ByteArrayOutputStream.)]
+    (with-open [writer (io/writer baos)]
+      (binding [*out* writer]
+        (pr data)))
+    (.update md (.toByteArray baos))
+    (base64 (.digest md))))
+
+(defn fingerprint-file
+  "Like `fingerprint` but for the contents of a file."
+  [f]
+  (let [md (MessageDigest/getInstance "MD5")]
+    (.update md (fs/read-all-bytes f))
+    (base64 (.digest md))))

--- a/lein-jank/test-data/test-change-detection/jank-build.bb
+++ b/lein-jank/test-data/test-change-detection/jank-build.bb
@@ -1,0 +1,2 @@
+(println "jank-build::rerun-if-changed=test-file")
+(println "jank-build::rerun-if-env-changed=WATCHED_VAR")

--- a/lein-jank/test-data/test-change-detection/project.clj
+++ b/lein-jank/test-data/test-change-detection/project.clj
@@ -3,5 +3,5 @@
   :url "https://example.com/FIXME"
   :license {:name "MPL 2.0"
             :url  "https://www.mozilla.org/en-US/MPL/2.0/"}
-  :plugins [[org.jank-lang/lein-jank "0.7"]]
+  :plugins [[org.jank-lang/lein-jank "LATEST"]]
   :middleware [leiningen.jank/middleware])

--- a/lein-jank/test-data/test-change-detection/project.clj
+++ b/lein-jank/test-data/test-change-detection/project.clj
@@ -1,0 +1,7 @@
+(defproject org.jank-lang/test-change-detection "0.1.0"
+  :description "FIXME: write description"
+  :url "https://example.com/FIXME"
+  :license {:name "MPL 2.0"
+            :url  "https://www.mozilla.org/en-US/MPL/2.0/"}
+  :plugins [[org.jank-lang/lein-jank "0.7"]]
+  :middleware [leiningen.jank/middleware])

--- a/lein-jank/test-data/test-child/project.clj
+++ b/lein-jank/test-data/test-child/project.clj
@@ -3,7 +3,7 @@
   :url "https://example.com/FIXME"
   :license {:name "MPL 2.0"
             :url  "https://www.mozilla.org/en-US/MPL/2.0/"}
-  :plugins [[org.jank-lang/lein-jank "0.7"]]
+  :plugins [[org.jank-lang/lein-jank "LATEST"]]
   :middleware [leiningen.jank/middleware]
   :dependencies [[org.jank-lang/test-grandchild "0.1.0"]
                  [org.jank-lang/test-grandchild2 "0.1.0"]])

--- a/lein-jank/test-data/test-grandchild/project.clj
+++ b/lein-jank/test-data/test-grandchild/project.clj
@@ -3,6 +3,6 @@
   :url "https://example.com/FIXME"
   :license {:name "MPL 2.0"
             :url  "https://www.mozilla.org/en-US/MPL/2.0/"}
-  :plugins [[org.jank-lang/lein-jank "0.7"]]
+  :plugins [[org.jank-lang/lein-jank "LATEST"]]
   :middleware [leiningen.jank/middleware]
   :build-dependencies [[org.jank-lang/test-build-dependency "0.1.0"]])

--- a/lein-jank/test-data/test-grandchild2/project.clj
+++ b/lein-jank/test-data/test-grandchild2/project.clj
@@ -3,6 +3,6 @@
   :url "https://example.com/FIXME"
   :license {:name "MPL 2.0"
             :url  "https://www.mozilla.org/en-US/MPL/2.0/"}
-  :plugins [[org.jank-lang/lein-jank "0.7"]]
+  :plugins [[org.jank-lang/lein-jank "LATEST"]]
   :middleware [leiningen.jank/middleware]
   :build-dependencies [[org.jank-lang/test-build-dependency "0.1.0"]])

--- a/lein-jank/test-data/test-parent/project.clj
+++ b/lein-jank/test-data/test-parent/project.clj
@@ -3,6 +3,6 @@
   :url "https://example.com/FIXME"
   :license {:name "MPL 2.0"
             :url  "https://www.mozilla.org/en-US/MPL/2.0/"}
-  :plugins [[org.jank-lang/lein-jank "0.7"]]
+  :plugins [[org.jank-lang/lein-jank "LATEST"]]
   :middleware [leiningen.jank/middleware]
   :dependencies [[org.jank-lang/test-child "0.1.0"]])

--- a/lein-jank/test/leiningen/jank/integration_test.clj
+++ b/lein-jank/test/leiningen/jank/integration_test.clj
@@ -87,18 +87,14 @@
                        (assoc-in [:jank :target-dir] target-dir)
                        (build/plan-build))
         compile-op (last plan)]
-    (with-redefs [changed/getenv (fn [k] (case k
-                                           "WATCHED_VAR" "a_value"
-                                           "anything"))]
+    (with-redefs [changed/env (fn [ks] {"WATCHED_VAR" "a_value"})]
       ;; Dependency which is not build yet causes a rebuild to trigger.
       (is (build/needs-compile? compile-op))
       (binding [build/*disable-sandbox* true] (build/run-build! plan))
       (is (not (build/needs-compile? compile-op)))
 
       ;; Changing a rerun-if-env-changed variable causes a rebuild to trigger.
-      (with-redefs [changed/getenv (fn [k] (case k
-                                             "WATCHED_VAR" "a_different_value"
-                                             "anything"))]
+      (with-redefs [changed/env (fn [ks] {"WATCHED_VAR" "a_different_value"})]
         (is (build/needs-compile? compile-op)))
 
       ;; Touching a rerun-if-changed file causes a rebuild to trigger.

--- a/lein-jank/test/leiningen/jank/integration_test.clj
+++ b/lein-jank/test/leiningen/jank/integration_test.clj
@@ -5,7 +5,8 @@
             [babashka.fs :as fs]
             [leiningen.install :refer [install]]
             [leiningen.core.project :as lproj]
-            [leiningen.jank.build :as build]))
+            [leiningen.jank.build :as build]
+            [leiningen.jank.changed :as changed]))
 
 (def temp-m2-repo (str (fs/create-temp-dir {:prefix "lein-jank-test-m2"})))
 
@@ -20,6 +21,7 @@
 (def grandchild-project (load-project "test-data/test-grandchild/project.clj"))
 (def grandchild2-project (load-project "test-data/test-grandchild2/project.clj"))
 (def build-dependency-project (load-project "test-data/test-build-dependency/project.clj"))
+(def change-detection-project (load-project "test-data/test-change-detection/project.clj"))
 
 ;; Children need to be installed into the maven cache to be properly picked up
 ;; by parents.
@@ -61,15 +63,13 @@
                  {:op           :compile
                   :dep          '[org.jank-lang/test-grandchild "0.1.0"]
                   :build-inputs [(m/regex #".*\.jar")]
-                  :inputs       (m/equals {})
-                  ;; root project always builds
-                  :always-build true}]
+                  :inputs       (m/equals {})}]
                 ops))))
 
 (deftest run-build-test
-  (let [output-dir (fs/create-temp-dir {:prefix "lein-jank-test-out"})
+  (let [target-dir (fs/create-temp-dir {:prefix "lein-jank-test-out"})
         plan       (-> parent-project
-                       (assoc-in [:jank :output-dir] output-dir)
+                       (assoc-in [:jank :target-dir] target-dir)
                        (build/plan-build))
         result     (binding [build/*disable-sandbox* true]
                      (build/run-build! plan))]
@@ -80,3 +80,31 @@
           :library-dirs     ["somepath"]
           :linked-libraries ["foolib" "barlib"]}
          result))))
+
+(deftest rerun-if-changed-test
+  (let [target-dir (fs/create-temp-dir {:prefix "lein-jank-test-out"})
+        plan       (-> change-detection-project
+                       (assoc-in [:jank :target-dir] target-dir)
+                       (build/plan-build))
+        compile-op (last plan)]
+    (with-redefs [changed/getenv (fn [k] (case k
+                                           "WATCHED_VAR" "a_value"
+                                           "anything"))]
+      ;; Dependency which is not build yet causes a rebuild to trigger.
+      (is (build/needs-compile? compile-op))
+      (binding [build/*disable-sandbox* true] (build/run-build! plan))
+      (is (not (build/needs-compile? compile-op)))
+
+      ;; Changing a rerun-if-env-changed variable causes a rebuild to trigger.
+      (with-redefs [changed/getenv (fn [k] (case k
+                                             "WATCHED_VAR" "a_different_value"
+                                             "anything"))]
+        (is (build/needs-compile? compile-op)))
+
+      ;; Touching a rerun-if-changed file causes a rebuild to trigger.
+      (fs/touch (fs/path (:src-dir compile-op) "test-file"))
+      (is (build/needs-compile? compile-op))
+
+      ;; After building the rebuild trigger is cleared.
+      (binding [build/*disable-sandbox* true] (build/run-build! plan))
+      (is (not (build/needs-compile? compile-op))))))

--- a/lein-jank/test/leiningen/jank/test_build.clj
+++ b/lein-jank/test/leiningen/jank/test_build.clj
@@ -1,20 +1,9 @@
 (ns leiningen.jank.test-build
   (:require [clojure.test :refer [deftest is]]
-            [babashka.fs :as fs]
             [leiningen.core.project :as proj]
             [leiningen.jank.build :as build]))
 
 (def test-project (proj/read "test-project/project.clj"))
-
-(deftest native-flags
-  (is (= (build/merge-native-flags {:defines      {"A" "B"}
-                                    :include-dirs ["a"]}
-                                   {:defines      {"C" "D"}
-                                    :include-dirs ["b"]
-                                    :library-dirs ["c"]})
-         {:defines      {"A" "B" "C" "D"}
-          :include-dirs ["a" "b"]
-          :library-dirs ["c"]})))
 
 (deftest build-directives
   (is (empty? (build/process-build-directive "")))
@@ -29,16 +18,3 @@
   (is (false? (build/build-scoped? '[org.jank/some-dependency "1.0.0"])))
   (is (false? (build/build-scoped? '[org.jank/some-dependency "1.0.0" :exclusions [foo] :classifier "asdf"])))
   (is (true? (build/build-scoped? '[org.jank/some-dependency "1.0.0" :scope "jank-build"]))))
-
-(deftest fingerprint
-  (is (string? (build/fingerprint [1 2 3])))
-  (is (not= (build/fingerprint [1 2 3])
-            (build/fingerprint [3 2 1])))
-  (let [f       (fs/create-temp-file)
-        fprint0 (do (fs/write-lines f ["Hello" "world"])
-                    (build/fingerprint-file f))
-        fprint1 (do (fs/write-lines f ["world" "Hello"])
-                    (build/fingerprint-file f))]
-    (is (string? fprint0))
-    (is (string? fprint1))
-    (is (not= fprint0 fprint1))))

--- a/lein-jank/test/leiningen/jank/test_changed.clj
+++ b/lein-jank/test/leiningen/jank/test_changed.clj
@@ -1,0 +1,32 @@
+(ns leiningen.jank.test-changed
+  (:require [clojure.test :refer [deftest is]]
+            [babashka.fs :as fs]
+            [leiningen.core.project :as proj]
+            [leiningen.jank.changed :as changed]))
+
+(def test-project (proj/read "test-project/project.clj"))
+
+(deftest change-fingerprint
+  (let [f1 (changed/change-fingerprint ["test-project/"] [])
+        f2 (changed/change-fingerprint ["test-project/"] [])]
+    (is (= f1 f2)))
+
+  (let [f1 (changed/change-fingerprint ["test-project/"] [])
+        _  (fs/touch "test-project/project.clj")
+        f2 (changed/change-fingerprint ["test-project/"] [])]
+    (is (not= f1 f2)))
+
+  (is (= (with-redefs [changed/env (fn [ks] {"A" "B"})]
+           (changed/change-fingerprint [] ["A"]))
+         (with-redefs [changed/env (fn [ks] {"A" "B"})]
+           (changed/change-fingerprint [] ["A"]))))
+
+  (is (not= (with-redefs [changed/env (fn [ks] {"A" "B"})]
+              (changed/change-fingerprint [] ["A"]))
+            (with-redefs [changed/env (fn [ks] {"C" "D"})]
+              (changed/change-fingerprint [] ["C"]))))
+
+  (is (not= (with-redefs [changed/env (fn [ks] {"A" "B"})]
+              (changed/change-fingerprint [] ["A"]))
+            (with-redefs [changed/env (fn [ks] {"A" "NOT_B"})]
+              (changed/change-fingerprint [] ["A"])))))

--- a/lein-jank/test/leiningen/jank/test_fingerprint.clj
+++ b/lein-jank/test/leiningen/jank/test_fingerprint.clj
@@ -1,0 +1,20 @@
+(ns leiningen.jank.test-fingerprint
+  (:require [clojure.test :refer [deftest is]]
+            [babashka.fs :as fs]
+            [leiningen.core.project :as proj]
+            [leiningen.jank.fingerprint :as fprint]))
+
+(def test-project (proj/read "test-project/project.clj"))
+
+(deftest fingerprint
+  (is (string? (fprint/fingerprint [1 2 3])))
+  (is (not= (fprint/fingerprint [1 2 3])
+            (fprint/fingerprint [3 2 1])))
+  (let [f       (fs/create-temp-file)
+        fprint0 (do (fs/write-lines f ["Hello" "world"])
+                    (fprint/fingerprint-file f))
+        fprint1 (do (fs/write-lines f ["world" "Hello"])
+                    (fprint/fingerprint-file f))]
+    (is (string? fprint0))
+    (is (string? fprint1))
+    (is (not= fprint0 fprint1))))


### PR DESCRIPTION
Eliminates unnecessary reruns of top-level jank-builds when the source does not change. Conversely, prevents stale builds when some external env var changes (like $CC or $TARGET).

See: https://doc.rust-lang.org/cargo/reference/build-scripts.html#change-detection