### PR TITLE
Add ability to link static libs into JIT runtime

### DIFF
--- a/compiler+runtime/include/cpp/jank/jit/processor.hpp
+++ b/compiler+runtime/include/cpp/jank/jit/processor.hpp
@@ -56,6 +56,7 @@ namespace jank::jit
     void eval_string(jtl::immutable_string const &s, clang::Value *) const;
     void load_object(jtl::immutable_string_view const &path) const;
     void load_dynamic_library(jtl::immutable_string const &path) const;
+    void load_static_library(jtl::immutable_string const &path) const;
     void load_ir_module(llvm::orc::ThreadSafeModule &&m) const;
     void load_bitcode(jtl::immutable_string const &module,
                       jtl::immutable_string_view const &bitcode) const;
@@ -64,8 +65,8 @@ namespace jank::jit
     jtl::string_result<void *> find_symbol(jtl::immutable_string const &name) const;
 
     jtl::result<void, jtl::immutable_string>
-    load_dynamic_libs(native_vector<jtl::immutable_string> const &libs) const;
-    jtl::option<jtl::immutable_string> find_dynamic_lib(jtl::immutable_string const &lib) const;
+    load_libs(native_vector<jtl::immutable_string> const &libs) const;
+    jtl::option<jtl::immutable_string> find_lib(jtl::immutable_string const &lib) const;
 
     /*** XXX: Everything here is immutable after initialization. ***/
     /*** XXX: Calls through the interpreter and LLVM JIT runtime are thread-safe. ***/

--- a/compiler+runtime/src/cpp/jank/jit/processor_dynamic.cpp
+++ b/compiler+runtime/src/cpp/jank/jit/processor_dynamic.cpp
@@ -52,9 +52,15 @@ namespace jank::jit
 #endif
 
   static jtl::immutable_string static_lib_name(jtl::immutable_string const &lib)
+#if defined(JANK_WINDOWS_LIKE)
+  {
+    return util::format("lib{}.lib", lib);
+  }
+#else
   {
     return util::format("lib{}.a", lib);
   }
+#endif
 
   static bool is_static_lib(jtl::immutable_string const &lib)
   {
@@ -524,20 +530,21 @@ namespace jank::jit
 
   jtl::option<jtl::immutable_string> processor::find_lib(jtl::immutable_string const &lib) const
   {
+    if(lib.starts_with("./"))
+    {
+      if(std::filesystem::is_regular_file(lib.c_str()))
+      {
+        return std::filesystem::absolute(lib.c_str());
+      }
+      return none;
+    }
+
     for(auto const &lib_dir : library_dirs)
     {
-      auto default_lib_abs_path{ util::format("{}/{}", lib_dir.string(), lib) };
-      if(std::filesystem::exists(default_lib_abs_path.c_str()))
+      auto lib_abs_path{ util::format("{}/{}", lib_dir.string(), lib) };
+      if(std::filesystem::is_regular_file(lib_abs_path.c_str()))
       {
-        return default_lib_abs_path;
-      }
-      else
-      {
-        auto lib_abs_path{ util::format("{}/{}", lib_dir.string(), lib) };
-        if(std::filesystem::exists(lib_abs_path.c_str()))
-        {
-          return lib_abs_path;
-        }
+        return lib_abs_path;
       }
     }
 
@@ -549,8 +556,15 @@ namespace jank::jit
   {
     for(auto const &lib : libs)
     {
-      if(std::filesystem::path{ lib.c_str() }.is_absolute())
+      /* If we have an absolue path, there's nothing more to search for. Just load.
+       * Example: -l/foo/bar/libfoo.so */
+      std::filesystem::path const lib_path{ lib.c_str() };
+      if(lib_path.is_absolute())
       {
+        if(!std::filesystem::is_regular_file(lib_path))
+        {
+          return err(util::format("Failed to find library '{}'.", lib));
+        }
         if(is_static_lib(lib))
         {
           load_static_library(lib);
@@ -559,20 +573,67 @@ namespace jank::jit
         {
           load_dynamic_library(lib);
         }
+
+        continue;
       }
-      else if(lib.starts_with(':'))
+
+      /* Try finding the lib literally, in case it contains a file name or a relative path.
+       * Example: -llibfoo.a or -l./libfoo.so */
       {
+        auto const result{ processor::find_lib(lib) };
+        if(result.is_some())
+        {
+          auto const &found_lib{ result.unwrap() };
+          if(is_static_lib(found_lib))
+          {
+            load_static_library(found_lib);
+          }
+          else
+          {
+            load_dynamic_library(found_lib);
+          }
+          continue;
+        }
+      }
+
+      /* If the lib starts with a colon, force static lib loading, by still try to find it
+       * normally.
+       * Example: -l:foo or -l:libfoo.a or -l:./libfoo.so */
+      if(lib.starts_with(':'))
+      {
+        auto result{ processor::find_lib(lib.substr(1)) };
+        if(result.is_some())
+        {
+          if(!is_static_lib(result.unwrap()))
+          {
+            return err(
+              util::format("Failed to find static library '{}'. This library is not static.",
+                           lib.substr(1)));
+          }
+          load_static_library(result.unwrap());
+          continue;
+        }
+
         auto const &stat{ static_lib_name(lib.substr(1)) };
-        auto const result{ processor::find_lib(stat) };
+        result = processor::find_lib(stat);
         if(result.is_none())
         {
-          return err(util::format("Failed to load static library '{}'.", lib.substr(1)));
+          return err(util::format("Failed to find static library '{}'.", lib.substr(1)));
         }
         else
         {
+          if(!is_static_lib(result.unwrap()))
+          {
+            return err(
+              util::format("Failed to find static library '{}'. This library is not static.",
+                           lib.substr(1)));
+          }
           load_static_library(result.unwrap());
         }
       }
+      /* Otherwise, just try to find the lib as first a dynamic lib and then a static lib.
+       * This is the typical case.
+       * Example: -lfoo */
       else
       {
         auto const &shared{ shared_lib_name(lib) };
@@ -583,7 +644,7 @@ namespace jank::jit
           result = processor::find_lib(stat);
           if(result.is_none())
           {
-            return err(util::format("Failed to load library '{}'.", lib));
+            return err(util::format("Failed to find library '{}'.", lib));
           }
           else
           {

--- a/compiler+runtime/src/cpp/jank/jit/processor_dynamic.cpp
+++ b/compiler+runtime/src/cpp/jank/jit/processor_dynamic.cpp
@@ -530,6 +530,18 @@ namespace jank::jit
 
   jtl::option<jtl::immutable_string> processor::find_lib(jtl::immutable_string const &lib) const
   {
+    std::filesystem::path const lib_path{ lib.c_str() };
+    if(lib_path.is_absolute())
+    {
+      if(!std::filesystem::is_regular_file(lib_path))
+      {
+        return none;
+      }
+      return lib_path.string();
+
+      return none;
+    }
+
     if(lib.starts_with("./"))
     {
       if(std::filesystem::is_regular_file(lib.c_str()))
@@ -556,29 +568,8 @@ namespace jank::jit
   {
     for(auto const &lib : libs)
     {
-      /* If we have an absolue path, there's nothing more to search for. Just load.
-       * Example: -l/foo/bar/libfoo.so */
-      std::filesystem::path const lib_path{ lib.c_str() };
-      if(lib_path.is_absolute())
-      {
-        if(!std::filesystem::is_regular_file(lib_path))
-        {
-          return err(util::format("Failed to find library '{}'.", lib));
-        }
-        if(is_static_lib(lib))
-        {
-          load_static_library(lib);
-        }
-        else
-        {
-          load_dynamic_library(lib);
-        }
-
-        continue;
-      }
-
-      /* Try finding the lib literally, in case it contains a file name or a relative path.
-       * Example: -llibfoo.a or -l./libfoo.so */
+      /* Try finding the lib literally, in case it contains a file name or a path.
+       * Example: -llibfoo.a or -l./libfoo.so or -l/path/to/libfoo.a */
       {
         auto const result{ processor::find_lib(lib) };
         if(result.is_some())
@@ -598,7 +589,7 @@ namespace jank::jit
 
       /* If the lib starts with a colon, force static lib loading, by still try to find it
        * normally.
-       * Example: -l:foo or -l:libfoo.a or -l:./libfoo.so */
+       * Example: -l:foo or -l:libfoo.a or -l:./libfoo.so or -l:/path/to/libfoo.a */
       if(lib.starts_with(':'))
       {
         auto result{ processor::find_lib(lib.substr(1)) };

--- a/compiler+runtime/src/cpp/jank/jit/processor_dynamic.cpp
+++ b/compiler+runtime/src/cpp/jank/jit/processor_dynamic.cpp
@@ -36,7 +36,7 @@
 
 namespace jank::jit
 {
-  static jtl::immutable_string default_shared_lib_name(jtl::immutable_string const &lib)
+  static jtl::immutable_string shared_lib_name(jtl::immutable_string const &lib)
 #if defined(__APPLE__)
   {
     return util::format("lib{}.dylib", lib);
@@ -50,6 +50,16 @@ namespace jank::jit
     return util::format("{}.dll", lib);
   }
 #endif
+
+  static jtl::immutable_string static_lib_name(jtl::immutable_string const &lib)
+  {
+    return util::format("lib{}.a", lib);
+  }
+
+  static bool is_static_lib(jtl::immutable_string const &lib)
+  {
+    return lib.ends_with(".a");
+  }
 
   [[maybe_unused]]
   static void
@@ -262,7 +272,7 @@ namespace jank::jit
                                                                    true));
     }
 
-    auto const &load_result{ load_dynamic_libs(util::cli::opts.libs) };
+    auto const &load_result{ load_libs(util::cli::opts.libs) };
     if(load_result.is_err())
     {
       throw error::system_failure(load_result.expect_err().c_str());
@@ -512,13 +522,11 @@ namespace jank::jit
     return err(util::format("Failed to find symbol: '{}'", name));
   }
 
-  jtl::option<jtl::immutable_string>
-  processor::find_dynamic_lib(jtl::immutable_string const &lib) const
+  jtl::option<jtl::immutable_string> processor::find_lib(jtl::immutable_string const &lib) const
   {
-    auto const &default_lib_name{ default_shared_lib_name(lib) };
     for(auto const &lib_dir : library_dirs)
     {
-      auto default_lib_abs_path{ util::format("{}/{}", lib_dir.string(), default_lib_name) };
+      auto default_lib_abs_path{ util::format("{}/{}", lib_dir.string(), lib) };
       if(std::filesystem::exists(default_lib_abs_path.c_str()))
       {
         return default_lib_abs_path;
@@ -537,20 +545,50 @@ namespace jank::jit
   }
 
   jtl::result<void, jtl::immutable_string>
-  processor::load_dynamic_libs(native_vector<jtl::immutable_string> const &libs) const
+  processor::load_libs(native_vector<jtl::immutable_string> const &libs) const
   {
     for(auto const &lib : libs)
     {
       if(std::filesystem::path{ lib.c_str() }.is_absolute())
       {
-        load_dynamic_library(lib);
+        if(is_static_lib(lib))
+        {
+          load_static_library(lib);
+        }
+        else
+        {
+          load_dynamic_library(lib);
+        }
+      }
+      else if(lib.starts_with(':'))
+      {
+        auto const &stat{ static_lib_name(lib.substr(1)) };
+        auto const result{ processor::find_lib(stat) };
+        if(result.is_none())
+        {
+          return err(util::format("Failed to load static library '{}'.", lib.substr(1)));
+        }
+        else
+        {
+          load_static_library(result.unwrap());
+        }
       }
       else
       {
-        auto const result{ processor::find_dynamic_lib(lib) };
+        auto const &shared{ shared_lib_name(lib) };
+        auto result{ processor::find_lib(shared) };
         if(result.is_none())
         {
-          return err(util::format("Failed to load dynamic library '{}'.", lib));
+          auto const &stat{ static_lib_name(lib) };
+          result = processor::find_lib(stat);
+          if(result.is_none())
+          {
+            return err(util::format("Failed to load library '{}'.", lib));
+          }
+          else
+          {
+            load_static_library(result.unwrap());
+          }
         }
         else
         {
@@ -565,5 +603,11 @@ namespace jank::jit
   void processor::load_dynamic_library(jtl::immutable_string const &path) const
   {
     llvm::cantFail(static_cast<clang::Interpreter &>(*interpreter).LoadDynamicLibrary(path.data()));
+  }
+
+  void processor::load_static_library(jtl::immutable_string const &path) const
+  {
+    auto const ee{ interpreter->getExecutionEngine() };
+    llvm::cantFail(ee->linkStaticLibraryInto(ee->getMainJITDylib(), path.c_str()));
   }
 }

--- a/compiler+runtime/src/cpp/jank/jit/processor_dynamic.cpp
+++ b/compiler+runtime/src/cpp/jank/jit/processor_dynamic.cpp
@@ -534,7 +534,7 @@ namespace jank::jit
     {
       if(std::filesystem::is_regular_file(lib.c_str()))
       {
-        return std::filesystem::absolute(lib.c_str());
+        return std::filesystem::absolute(lib.c_str()).string();
       }
       return none;
     }

--- a/compiler+runtime/test/bash/ahead-of-time/pass-test
+++ b/compiler+runtime/test/bash/ahead-of-time/pass-test
@@ -117,7 +117,7 @@
   (when (or (empty? (System/getenv "JANK_SKIP_AOT_CHECK"))
             ; Windows is sometimes failing in CI, presumably due to a race condition.
             ; An example failure is here: https://github.com/jank-lang/jank/actions/runs/28888267509/job/85694092257?pr=846
-            (fs/windows?))
+            (not (fs/windows?)))
     (proc/sh {:out *out* :err *out*} "jank check-health")
     (System/exit
      (if (t/successful? (t/run-tests this-nsym))

--- a/compiler+runtime/test/bash/ahead-of-time/pass-test
+++ b/compiler+runtime/test/bash/ahead-of-time/pass-test
@@ -114,10 +114,10 @@
       (is (string= expected-output (-> default-output-file-path proc/sh :out))))))
 
 (defn -main []
-  (when (or (empty? (System/getenv "JANK_SKIP_AOT_CHECK"))
-            ; Windows is sometimes failing in CI, presumably due to a race condition.
-            ; An example failure is here: https://github.com/jank-lang/jank/actions/runs/28888267509/job/85694092257?pr=846
-            (not (fs/windows?)))
+  (when (and (empty? (System/getenv "JANK_SKIP_AOT_CHECK"))
+             ; Windows is sometimes failing in CI, presumably due to a race condition.
+             ; An example failure is here: https://github.com/jank-lang/jank/actions/runs/28888267509/job/85694092257?pr=846
+             (not (fs/windows?)))
     (proc/sh {:out *out* :err *out*} "jank check-health")
     (System/exit
      (if (t/successful? (t/run-tests this-nsym))

--- a/compiler+runtime/test/bash/library-linking/pass-test
+++ b/compiler+runtime/test/bash/library-linking/pass-test
@@ -92,6 +92,7 @@
 ;     -l:foo (with static lib)
 ;     -l:./libfoo.a
 ;     -l:libfoo.a
+;     -l:/foo/bar/libfoo.a
 ;
 ;     -l:foo (with dynamic lib)
 ;     -l:./libfoo.so
@@ -129,6 +130,7 @@
     (is-static? both-dir ":foo")
     (is-static? both-dir (str ":" (fs/path "./" relative-both-dir static-lib)))
     (is-static? nil (str ":" (fs/path "./" relative-both-dir static-lib)))
+    (is-static? both-dir (str ":" (fs/path both-dir static-lib)))
 
     (is-failure? dynamic-dir ":foo")
     (is-failure? both-dir (str ":" (fs/path "./" relative-both-dir dynamic-lib)))

--- a/compiler+runtime/test/bash/library-linking/pass-test
+++ b/compiler+runtime/test/bash/library-linking/pass-test
@@ -145,7 +145,8 @@
     (is-failure? both-dir "missing")))
 
 (defn -main []
-  (when (empty? (System/getenv "JANK_SKIP_AOT_CHECK"))
+  (when (and (empty? (System/getenv "JANK_SKIP_AOT_CHECK"))
+             (not (fs/windows?)))
     (System/exit
      (if (t/successful? (t/run-tests this-nsym))
        0

--- a/compiler+runtime/test/bash/library-linking/pass-test
+++ b/compiler+runtime/test/bash/library-linking/pass-test
@@ -1,0 +1,153 @@
+#!/usr/bin/env bb
+
+(ns jank.test.library-linking
+  (:require [babashka.fs :as fs]
+            [babashka.process :as proc]
+            [clojure.string :as str]
+            [clojure.test :as t :refer [deftest is testing use-fixtures]]))
+
+(def this-nsym (ns-name *ns*))
+
+(def os-name (str/lower-case (System/getProperty "os.name")))
+(def os (cond
+          (str/includes? os-name "win") :windows
+          (str/includes? os-name "mac") :macos
+          (or (str/includes? os-name "nix")
+              (str/includes? os-name "nux")
+              (str/includes? os-name "linux")) :linux
+          :else (throw (ex-info "Unknown OS" {:os os-name}))))
+
+(def relative-both-dir "target/both")
+(def both-dir (fs/path (fs/cwd) relative-both-dir))
+(def relative-dynamic-dir "target/dynamic")
+(def dynamic-dir (fs/path (fs/cwd) relative-dynamic-dir))
+(def relative-static-dir "target/static")
+(def static-dir (fs/path (fs/cwd) relative-static-dir))
+(def dynamic-lib (case os
+                   :linux "libfoo.so"
+                   :macos "libfoo.dylib"
+                   :windows "libfoo.dll"))
+(def static-lib (case os
+                   :linux "libfoo.a"
+                   :macos "libfoo.a"
+                   :windows "libfoo.lib"))
+(def missing-lib (case os
+                   :linux "libmissing.a"
+                   :macos "libmissing.a"
+                   :windows "libmissing.lib"))
+
+(defn jank [link-dir lib]
+  (let [command (str "jank "
+                     (when link-dir
+                       (str "-L " link-dir))
+                     " -l" lib " run src/main.jank")]
+    ;(println command)
+    (:out (proc/sh {:err :out} command))))
+
+(defn is-dynamic? [link-dir lib]
+  (is (str/includes? (jank link-dir lib) "loaded dynamic lib")))
+
+(defn is-static? [link-dir lib]
+  (is (str/includes? (jank link-dir lib) "loaded static lib")))
+
+(defn is-failure? [link-dir lib]
+  (is (str/includes? (jank link-dir lib) "Failed to find")))
+
+(defn compile-libs []
+  (fs/delete-tree "./target")
+  (fs/create-dirs both-dir)
+  (proc/sh (format "clang++ -fPIC -shared src/dynamic.cpp -o %s/%s" both-dir dynamic-lib))
+  (proc/sh (format "clang++ -c src/static.cpp -o %s/static.o" both-dir))
+  (proc/sh (format "ar qc %s/%s %s/static.o" both-dir static-lib both-dir))
+
+  (fs/create-dirs static-dir)
+  (fs/copy (format "%s/%s" both-dir static-lib) (format "%s/%s" static-dir static-lib))
+  (fs/create-dirs dynamic-dir)
+  (fs/copy (format "%s/%s" both-dir dynamic-lib) (format "%s/%s" dynamic-dir dynamic-lib)))
+
+(use-fixtures :once
+              (fn [f]
+                (compile-libs)
+                (f)))
+
+; Cases
+;   Absolute
+;     -l/foo/bar/libfoo.so
+;     -l/foo/bar/libfoo.a
+;
+;     -l/foo/bar/libmissing.a
+;     -l/foo/bar
+;   Relative
+;     -l./libfoo.so
+;     -l./libfoo.a
+;
+;     -l./libmissing.so
+;     -l./
+;   File
+;     -llibfoo.so
+;     -llibfoo.a
+;
+;     -llibmissing.so
+;   Static
+;     -l:foo (with static lib)
+;     -l:./libfoo.a
+;     -l:libfoo.a
+;
+;     -l:foo (with dynamic lib)
+;     -l:./libfoo.so
+;     -l:libfoo.so
+;     -l:libmissing.a
+;   General
+;     -lfoo (with static lib)
+;     -lfoo (with dynamic lib)
+;     -lfoo (with both libs)
+;
+;     -lmissing
+
+(deftest library-linking
+  (testing "Absolute"
+    (is-dynamic? both-dir (fs/path both-dir dynamic-lib))
+    (is-static? both-dir (fs/path both-dir static-lib))
+
+    (is-failure? both-dir (fs/path both-dir missing-lib))
+    (is-failure? both-dir both-dir))
+
+  (testing "Relative"
+    (is-dynamic? nil (fs/path "./" relative-both-dir dynamic-lib))
+    (is-static? nil (fs/path "./" relative-both-dir static-lib))
+
+    (is-failure? nil (fs/path "./" relative-both-dir missing-lib))
+    (is-failure? nil (fs/path "./" relative-both-dir)))
+
+  (testing "File"
+    (is-dynamic? both-dir dynamic-lib)
+    (is-static? both-dir static-lib)
+
+    (is-failure? both-dir missing-lib))
+
+  (testing "Static"
+    (is-static? both-dir ":foo")
+    (is-static? both-dir (str ":" (fs/path "./" relative-both-dir static-lib)))
+    (is-static? nil (str ":" (fs/path "./" relative-both-dir static-lib)))
+
+    (is-failure? dynamic-dir ":foo")
+    (is-failure? both-dir (str ":" (fs/path "./" relative-both-dir dynamic-lib)))
+    (is-failure? both-dir (str ":" dynamic-lib))
+    (is-failure? both-dir (str ":" missing-lib)))
+
+  (testing "General"
+    (is-static? static-dir "foo")
+    (is-dynamic? dynamic-dir "foo")
+    (is-dynamic? both-dir "foo")
+
+    (is-failure? both-dir "missing")))
+
+(defn -main []
+  (when (empty? (System/getenv "JANK_SKIP_AOT_CHECK"))
+    (System/exit
+     (if (t/successful? (t/run-tests this-nsym))
+       0
+       1))))
+
+(when (= *file* (System/getProperty "babashka.file"))
+  (apply -main *command-line-args*))

--- a/compiler+runtime/test/bash/library-linking/src/dynamic.cpp
+++ b/compiler+runtime/test/bash/library-linking/src/dynamic.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+extern "C" void foo()
+{
+  std::cout << "loaded dynamic lib\n";
+}

--- a/compiler+runtime/test/bash/library-linking/src/main.jank
+++ b/compiler+runtime/test/bash/library-linking/src/main.jank
@@ -1,0 +1,3 @@
+(cpp/raw "extern \"C\" void foo();")
+
+(cpp/foo)

--- a/compiler+runtime/test/bash/library-linking/src/static.cpp
+++ b/compiler+runtime/test/bash/library-linking/src/static.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+extern "C" void foo()
+{
+  std::cout << "loaded static lib\n";
+}


### PR DESCRIPTION
With this PR, jank will support linking static libs via `-lfoo`. If both static and dynamic are present, jank will choose the dynamic lib, following Clang's behavior. To force the static lib, jank supports the `-l:foo` syntax. If `-l:foo` is provided and there's not static lib, but there is a dynamic lib, the dynamic lib will not be chosen.