### PR TITLE
Support :managed-dependencies in lein-jank.

### DIFF
--- a/lein-jank/src/leiningen/jank/build.clj
+++ b/lein-jank/src/leiningen/jank/build.clj
@@ -253,7 +253,8 @@
     (when *disable-sandbox*
       (println "\u001b[1;31mBuilding with sandboxing disabled is potentially dangerous!\u001b[0m"))
 
-    (let [tree     (->> (mapv #(resolve/dependency-hierarchy project %) (:dependencies project))
+    (let [tree     (->> (mapv #(resolve/dependency-hierarchy project (:managed-dependencies project) %)
+                              (:dependencies project))
                         (apply merge))
            ;; Plan the build steps just for the child dependencies,
            ;; recursively resolving their dependencies and so on.

--- a/lein-jank/src/leiningen/jank/resolve.clj
+++ b/lein-jank/src/leiningen/jank/resolve.clj
@@ -1,5 +1,5 @@
 (ns leiningen.jank.resolve
-  (:require [leiningen.core.classpath :refer [default-aether-args]]
+  (:require [leiningen.core.classpath :refer [default-aether-args normalize-dep-vector]]
             [cemerick.pomegranate.aether :as aether]))
 
 (defn dependency-hierarchy
@@ -8,15 +8,23 @@
 
   This is like `aether/dependency-hierarchy`, but it does not perform
   deduplication on the tree. If the same dependency in two or more subtrees
-  (even the same version), they will remain in the tree returned here."
-  [project dep]
-  (let [opts          (merge (default-aether-args project) {:coordinates [dep]})
+  (even the same version), they will remain in the tree returned here.
+
+  Any time a dep is encountered in the tree which also occurs also in the
+  managed-deps, the version in the tree is replaced by that of the managed dep."
+  [project managed-deps dep]
+  ;; Normalize the dep coordinate because it may have a "nil" version, so as to
+  ;; defer version resolution to a managed dependency entry.
+  (let [dep           (normalize-dep-vector dep)
+        coordinates   (aether/merge-versions-from-managed-coords [dep] managed-deps)
+        opts          (merge (default-aether-args project) {:coordinates         coordinates
+                                                            :managed-coordinates managed-deps})
         full-tree     (aether/resolve-dependencies opts)
         dep-with-meta (first (filter #{dep} (keys full-tree)))]
     (when dep-with-meta
       {dep-with-meta
        (->> (get full-tree dep)
-            (mapv (fn [d] [d (-> (dependency-hierarchy opts d) vals first)]))
+            (mapv (fn [d] [d (-> (dependency-hierarchy project managed-deps d) vals first)]))
             (into {}))})))
 
 (defn dependency-files

--- a/lein-jank/test-data/test-managed-deps/project.clj
+++ b/lein-jank/test-data/test-managed-deps/project.clj
@@ -1,0 +1,11 @@
+(defproject org.jank-lang/test-managed-deps "0.1.0"
+  :description "FIXME: write description"
+  :url "https://example.com/FIXME"
+  :license {:name "MPL 2.0"
+            :url  "https://www.mozilla.org/en-US/MPL/2.0/"}
+  :plugins [[org.jank-lang/lein-jank "LATEST"]]
+  :middleware [leiningen.jank/middleware]
+  :managed-dependencies [[org.jank-lang.commons/imgui-sys "2026.06-1"]]
+  :dependencies [[org.jank-lang.commons/imgui-sys nil]
+                 [org.jank-lang.commons/imgui-opengl2-sys "2026.06-6"]
+                 [org.jank-lang.commons/imgui-glfw-sys "2026.06-1"]])

--- a/lein-jank/test/leiningen/jank/integration_test.clj
+++ b/lein-jank/test/leiningen/jank/integration_test.clj
@@ -5,21 +5,25 @@
             [babashka.fs :as fs]
             [leiningen.install :refer [install]]
             [leiningen.core.project :as lproj]
-            [leiningen.jank.build :as build]))
+            [leiningen.jank.build :as build]
+            [leiningen.jank.resolve :as resolve]))
 
 (def temp-m2-repo (str (fs/create-temp-dir {:prefix "lein-jank-test-m2"})))
 
-(defn load-project [path]
-  (-> (lproj/read path)
+(defn read-test-project [name]
+  (-> (lproj/read (format "test-data/%s/project.clj" name))
       (assoc :local-repo temp-m2-repo)))
 
 ;; Set up an example dependency tree where parent-project -> child-project ->
 ;; grandchild-project -> (build dep) build-dependency.
-(def parent-project (load-project "test-data/test-parent/project.clj"))
-(def child-project (load-project "test-data/test-child/project.clj"))
-(def grandchild-project (load-project "test-data/test-grandchild/project.clj"))
-(def grandchild2-project (load-project "test-data/test-grandchild2/project.clj"))
-(def build-dependency-project (load-project "test-data/test-build-dependency/project.clj"))
+(def parent-project (read-test-project "test-parent"))
+(def child-project (read-test-project "test-child"))
+(def grandchild-project (read-test-project "test-grandchild"))
+(def grandchild2-project (read-test-project "test-grandchild2"))
+
+;; Other top-level projects useful for testing different features.
+(def build-dependency-project (read-test-project "test-build-dependency"))
+(def managed-deps-project (read-test-project "test-managed-deps"))
 
 ;; Children need to be installed into the maven cache to be properly picked up
 ;; by parents.
@@ -30,6 +34,7 @@
     (install grandchild2-project)
     (install child-project)
     (install parent-project)
+    (install managed-deps-project)
     (f)))
 
 (use-fixtures :once setup-fixture)
@@ -65,6 +70,21 @@
                   ;; root project always builds
                   :always-build true}]
                 ops))))
+
+(deftest plan-build-with-managed-deps
+  (let [tree (resolve/dependency-hierarchy
+              managed-deps-project
+              (:managed-dependencies managed-deps-project)
+              '[org.jank-lang/test-managed-deps "0.1.0"])]
+    ;; The project declares an imgui-sys managed dependency version of
+    ;; 2026.06-1. This overrides the nested imgui-sys depenencies, which are on
+    ;; version 2026.06-6.
+    (is (match?
+         {['org.jank-lang/test-managed-deps "0.1.0"]
+          {['org.jank-lang.commons/imgui-glfw-sys "2026.06-1"]    {['org.jank-lang.commons/imgui-sys "2026.06-1"] {}}
+           ['org.jank-lang.commons/imgui-opengl2-sys "2026.06-6"] {['org.jank-lang.commons/imgui-sys "2026.06-1"] {}}
+           ['org.jank-lang.commons/imgui-sys "2026.06-1"]         {}}}
+       tree))))
 
 (deftest run-build-test
   (let [output-dir (fs/create-temp-dir {:prefix "lein-jank-test-out"})


### PR DESCRIPTION
This is just restoring some of the upstream lein features we lost when we bypassed lein's dependency resolution, since it doesn't behave correctly in the presence of native deps (removes duplicate versions from the tree silently).

I think this will be an especially important feature when writing an application, and including native dependencies which may not agree on their own downstream dependency versions, which would normally lead to compiling/linking errors.