### PR TITLE
Fix `vec`

### DIFF
--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_vector.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_vector.cpp
@@ -51,8 +51,11 @@ namespace jank::runtime::obj
     return visit_object(
       [](auto const typed_s) -> persistent_vector_ref {
         using T = typename decltype(typed_s)::value_type;
-
-        if constexpr(behavior::sequenceable<T>)
+        if constexpr(std::same_as<T, obj::persistent_vector>)
+        {
+          return typed_s->with_meta(jank_nil);
+        }
+        else if constexpr(behavior::seqable<T>)
         {
           runtime::detail::native_transient_vector v;
           for(auto const e : make_sequence_range(typed_s))


### PR DESCRIPTION
Fixes https://github.com/jank-lang/jank/discussions/895

When I disable the test with `to-array`, everything else passes in `clojure.core-test.vec`:

```clojure
% ./pass-test 
warning: 'sleep' already referred to #'clojure.core/sleep in namespace 'clojure.core-test.portability' but has been replaced by #'clojure.core-test.portability/sleep

Testing clojure.core-test.vec

Ran 1 tests containing 18 assertions.
0 failures, 0 errors.
:clojure-test-suite-successful
```