### PR TITLE
Fix lexing of multi-byte UTF-8 characters in comments

### DIFF
--- a/compiler+runtime/src/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/src/cpp/jank/read/lex.cpp
@@ -653,7 +653,7 @@ namespace jank::read::lex
               hit_non_semi = true;
             }
 
-            ++pos;
+            pos += oc.expect_ok().len;
           }
           if(pos == token_start)
           {
@@ -1396,7 +1396,7 @@ namespace jank::read::lex
                     break;
                   }
 
-                  ++pos;
+                  pos += oc.expect_ok().len;
                 }
 
                 ++pos;

--- a/compiler+runtime/test/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/test/cpp/jank/read/lex.cpp
@@ -259,6 +259,27 @@ namespace jank::read::lex
                 { { { 9, 2, 1 } }, { { 10, 2, 2 } }, token_kind::integer,       2ll }
         }));
       }
+
+      SUBCASE("Multi-byte UTF-8 content")
+      {
+        processor p{ "; a ▀ comment\n1" };
+        native_vector<jtl::result<token, error_ref>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                {  { { 0, 1, 1 } }, { { 15, 1, 16 } }, token_kind::comment, " a ▀ comment"sv },
+                { { { 16, 2, 1 } }, { { 17, 2, 2 } },  token_kind::integer,              1ll }
+        }));
+      }
+
+      SUBCASE("Multi-byte UTF-8 content at end of file")
+      {
+        processor p{ "; ▀é🍜" };
+        native_vector<jtl::result<token, error_ref>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 11, token_kind::comment, " ▀é🍜"sv }
+        }));
+      }
     }
 
     TEST_CASE("List")
@@ -2137,6 +2158,16 @@ namespace jank::read::lex
           CHECK(tokens
                 == make_tokens({
                   { 0, 9, token_kind::comment, "#!#!foo"sv }
+          }));
+        }
+
+        SUBCASE("Multi-byte UTF-8 content")
+        {
+          processor p{ "#! ▀é🍜" };
+          native_vector<jtl::result<token, error_ref>> const tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 12, token_kind::comment, " ▀é🍜"sv }
           }));
         }
 


### PR DESCRIPTION
## Problem

Any comment containing non-ASCII text fails to lex:

```clojure
; comment with ▀ in it
(println "ok")
```

```
─ lex/invalid-unicode ────────────
error: Unfinished character.
```

## Cause

Both comment-scanning loops — line comments (`case ';'`) and shebang comments (`#!`) — advance by a single byte (`++pos`) after `peek()` decodes a full codepoint. For a multi-byte UTF-8 character, the next `peek()` lands mid-sequence, returns an error, and silently breaks out of the comment loop; the orphaned continuation bytes are then lexed as a new token, surfacing as a spurious `lex/invalid-unicode` error.

## Fix

Advance by the decoded codepoint's byte length (`pos += oc.expect_ok().len;`), exactly as symbol lexing already does a few lines above.

## Tests

Added lexer subcases covering 2-, 3-, and 4-byte codepoints (`é`, `▀`, `🍜`):
- `;` comment with multi-byte content followed by more code
- `;` comment with multi-byte content at EOF
- `#!` comment with multi-byte content

Verified locally against a build of the current lexer: without the fix, exactly these three new subcases fail (the `;` cases via the reported error, matching the user-visible bug); with the fix, the full lexer suite passes (20 test cases, 220 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)