### PR TITLE
Fix `lein test` test var resolution

### DIFF
--- a/lein-jank/src/leiningen/jank/test.clj
+++ b/lein-jank/src/leiningen/jank/test.clj
@@ -102,7 +102,7 @@
   `(distinct
     (for [ns# ~ns-sym
           [_# var#] (ns-publics ns#)
-          :when (and (clojure.test/-workaround-get-test var#)
+          :when (and (-> var# meta :test)
                      (some (fn [[selector# args#]]
 
                              (apply (if (vector? selector#)


### PR DESCRIPTION
`-workaround-get-test` was removed in 308a8570c. Matches [upstream implementation](https://github.com/technomancy/leiningen/blob/main/src/leiningen/test.clj#L64C22-L64C42) now.

Tested on a hello world clojure.test project.