### PR TITLE
Standardize `lein test` CLI and native build handling

### DIFF
--- a/lein-jank/src/leiningen/jank.clj
+++ b/lein-jank/src/leiningen/jank.clj
@@ -1,6 +1,7 @@
 (ns leiningen.jank
   (:refer-clojure :exclude [run!])
   (:require [leiningen.core.main :as lmain]
+            [leiningen.core.project :as lproj]
             [leiningen.jank.core :as ljc]
             [leiningen.jank.test :as ljt]
             [leiningen.help :as lhelp]
@@ -81,6 +82,18 @@ To override the inferred output target, you can pass `--output-target TARGET`
                    (concat [(:module opts)] name-opts target-opts)
                    args)))
 
+(defn test!
+  "Run the project's tests.
+
+Keyword arguments are interpreted as test selectors and other arguments as test
+namespaces."
+  [project & args]
+  (let [project          (lproj/merge-profiles project [:leiningen/test :test])
+        [opts args]      (ljc/parse-opts #'test! args ljc/standard-options)
+        [nses selectors] (ljt/read-args args project)
+        test-runner      (ljt/generate-test-runner! nses (vec selectors))]
+    (dispatch-jank project opts "run" [test-runner] [])))
+
 (defn check-health!
   "Perform a health check on your jank install."
   [project & args]
@@ -92,7 +105,7 @@ To override the inferred output target, you can pass `--output-target TARGET`
                       :compile #'compile!
                       :compile-module #'compile-module!
                       :check-health #'check-health!
-                      :test #'ljt/test!})
+                      :test #'test!})
 
 (defn jank
   "Compile, run, test and repl into jank.

--- a/lein-jank/src/leiningen/jank.clj
+++ b/lein-jank/src/leiningen/jank.clj
@@ -86,7 +86,7 @@ To override the inferred output target, you can pass `--output-target TARGET`
   "Run the project's tests.
 
 Keyword arguments are interpreted as test selectors and other arguments as test
-namespaces."
+namespaces or files."
   [project & args]
   (let [project          (lproj/merge-profiles project [:leiningen/test :test])
         [opts args]      (ljc/parse-opts #'test! args ljc/standard-options)

--- a/lein-jank/src/leiningen/jank/test.clj
+++ b/lein-jank/src/leiningen/jank/test.clj
@@ -46,7 +46,7 @@
             vars))])
 
 (defn ^:internal read-args [args project]
-  (let [args (->> args (map convert-to-ns) (map read-string))
+  (let [args (->> args (map (comp str convert-to-ns)) (map read-string))
         [nses given-selectors] (split-selectors args)
         nses (or (seq nses)
                  (sort (d/jank-namespaces (distinct (:test-paths project)))))

--- a/lein-jank/src/leiningen/jank/test.clj
+++ b/lein-jank/src/leiningen/jank/test.clj
@@ -129,8 +129,9 @@
                                   (int (:fail summary#))))]
            (cpp/exit exit-code#))))))
 
-(defn- generate-test-runner! [form]
-  (let [test-runner-file (fs/create-temp-file {:prefix "jank_test_runner"
+(defn generate-test-runner! [nses selectors]
+  (let [form (form-for-testing-namespaces nses selectors)
+        test-runner-file (fs/create-temp-file {:prefix "jank_test_runner"
                                                :suffix ".jank"})]
     (spit (fs/file test-runner-file)
           (string/join
@@ -140,12 +141,3 @@
             (pr-str form)]))
 
     test-runner-file))
-
-(defn test! [project & args]
-  (let [project (p/merge-profiles project [:leiningen/test :test])
-        cp-str (ljc/build-module-path project)
-        [nses selectors] (read-args args project)
-        form (form-for-testing-namespaces nses (vec selectors))
-
-        test-runner-file (generate-test-runner! form)]
-    (ljc/shell-out! project cp-str "run" [(str test-runner-file)] [])))


### PR DESCRIPTION
- Native build step now runs before tests like other lein-jank commands
- `lein help test` returns a nice string like the other lein-jank commands
- Standard CLI options like -v and --disable-sandbox now apply
- Passing a file to `lein test` works now