### PR TITLE
Add UTF-8 lexing support in comments

### DIFF
--- a/compiler+runtime/src/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/src/cpp/jank/read/lex.cpp
@@ -653,7 +653,7 @@ namespace jank::read::lex
               hit_non_semi = true;
             }
 
-            ++pos;
+            pos += oc.expect_ok().len;
           }
           if(pos == token_start)
           {
@@ -1396,7 +1396,7 @@ namespace jank::read::lex
                     break;
                   }
 
-                  ++pos;
+                  pos += oc.expect_ok().len;
                 }
 
                 ++pos;

--- a/compiler+runtime/test/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/test/cpp/jank/read/lex.cpp
@@ -259,6 +259,27 @@ namespace jank::read::lex
                 { { { 9, 2, 1 } }, { { 10, 2, 2 } }, token_kind::integer,       2ll }
         }));
       }
+
+      SUBCASE("Multi-byte UTF-8 content")
+      {
+        processor p{ "; a 🐝 comment\n1" };
+        native_vector<jtl::result<token, error_ref>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                {  { { 0, 1, 1 } }, { { 16, 1, 17 } }, token_kind::comment, " a 🐝 comment"sv },
+                { { { 17, 2, 1 } },  { { 18, 2, 2 } }, token_kind::integer,               1ll }
+        }));
+      }
+
+      SUBCASE("Multi-byte UTF-8 content at end of file")
+      {
+        processor p{ "; ¡ ষ 𐅦" };
+        native_vector<jtl::result<token, error_ref>> const tokens(p.begin(), p.end());
+        CHECK(tokens
+              == make_tokens({
+                { 0, 13, token_kind::comment, " ¡ ষ 𐅦"sv }
+        }));
+      }
     }
 
     TEST_CASE("List")
@@ -2137,6 +2158,16 @@ namespace jank::read::lex
           CHECK(tokens
                 == make_tokens({
                   { 0, 9, token_kind::comment, "#!#!foo"sv }
+          }));
+        }
+
+        SUBCASE("Multi-byte UTF-8 content")
+        {
+          processor p{ "#! ¡ ষ 𐅦" };
+          native_vector<jtl::result<token, error_ref>> const tokens(p.begin(), p.end());
+          CHECK(tokens
+                == make_tokens({
+                  { 0, 14, token_kind::comment, " ¡ ষ 𐅦"sv }
           }));
         }
 


### PR DESCRIPTION
This was originally fixed here: #898.