### PR TITLE
Extract jank-build into its own lein-free namespace

### DIFF
--- a/lein-jank/src/jank_build/change_detection.clj
+++ b/lein-jank/src/jank_build/change_detection.clj
@@ -1,7 +1,8 @@
-(ns leiningen.jank.changed
-  "For tracking changes in the environment and in build source files."
+(ns jank-build.change-detection
+  "For tracking changes in the environment and in build source files, which can
+  be used to determine if a rebuild is necessary."
   (:require [babashka.fs :as fs]
-            [leiningen.jank.fingerprint :refer [fingerprint]]))
+            [jank-build.fingerprint :refer [fingerprint]]))
 
 (defn env
   "Return a map of resolved environment variables."

--- a/lein-jank/src/jank_build/core.clj
+++ b/lein-jank/src/jank_build/core.clj
@@ -1,13 +1,12 @@
-(ns leiningen.jank.build
+(ns jank-build.core
   "Tools for building jank libraries which include native code."
   (:require [clojure.string :as string]
             [clojure.java.io :as io]
             [babashka.fs :as fs]
-            [leiningen.core.main :as lmain]
-            [leiningen.jank.sandbox.core :as sandbox]
-            [leiningen.jank.resolve :as resolve]
-            [leiningen.jank.fingerprint :refer [fingerprint fingerprint-file]]
-            [leiningen.jank.changed :refer [change-fingerprint]])
+            [jank-build.change-detection :refer [change-fingerprint]]
+            [jank-build.fingerprint :refer [fingerprint fingerprint-file]]
+            [jank-build.sandbox.core :as sandbox]
+            [jank-build.util :as util])
   (:import (java.util.jar JarFile)))
 
 (def ^:dynamic *disable-sandbox* false)
@@ -58,7 +57,7 @@
       "link-library"         {:linked-libraries [v]}
       "rerun-if-changed"     {:rerun-if-changed [v]}
       "rerun-if-env-changed" {:rerun-if-env-changed [v]}
-      (do (lmain/warn "invalid jank-build directive:" line)
+      (do (util/warn "invalid jank-build directive:" line)
           nil))))
 
 (defn wrap-stream
@@ -104,7 +103,7 @@
   [{:keys [src-dir out-dir] :as op}]
   (fs/delete-tree out-dir)
   (fs/create-dirs out-dir)
-  (let [dep-name     (first (:dep op))
+  (let [dep-name     (first (:coord (:dep op)))
         build-dir    (fs/create-temp-dir {:prefix "jank-build-"})
         op           (assoc op :build-dir (str build-dir))
         ;; The sandbox gets standard mounts for a scratch directory and build
@@ -141,11 +140,7 @@
         (when-not *verbose-build*
           (println (string/join "\n" @out-lines))
           (println (string/join "\n" @out-lines)))
-        (lmain/abort "failed to run build command")))))
-
-(defn build-scoped? [coord]
-  (let [m (apply hash-map coord)]
-    (= (:scope m) "jank-build")))
+        (util/abort "failed to run build command")))))
 
 (defn collect-build-deps
   "Given a dependency tree, identify its jank-build scoped elements and resolve
@@ -154,10 +149,7 @@
   Build dependencies are not transitive, so only the first layer of the tree is
   searched. Deeper build-scoped dependencies will be ignored."
   [tree]
-  (->> tree
-       (filter (fn [[k v]] (build-scoped? k)))
-       (into {})
-       (resolve/dependency-files)))
+  (keep #(when (:build-scoped %) (:file %)) tree))
 
 (defn collect-out-dirs
   "Collect the output directories from all build steps in the given operations
@@ -166,13 +158,14 @@
   (letfn [(simple-dep-name [coord] (-> coord first str))]
     (->> plan-ops
          (keep (fn [op] (when (:out-dir op)
-                          [(simple-dep-name (:dep op))
+                          [(simple-dep-name (:coord (:dep op)))
                            (str (:out-dir op))])))
          (into {}))))
 
-(defn plan-subtree-build [build-opts target-dir [dep subtree]]
-  (let [subtree-ops (vec (mapcat #(plan-subtree-build build-opts target-dir %) subtree))
-        src-jar     (first (resolve/dependency-files {dep nil}))
+(defn plan-subtree-build [build-opts target-dir dep]
+  (let [subtree     (:children dep)
+        subtree-ops (vec (mapcat #(plan-subtree-build build-opts target-dir %) subtree))
+        src-jar     (:file dep)
         jar-name    (-> src-jar fs/file-name fs/strip-ext)]
     ;; NOTE: make sure all outputs here are pure Clojure data. We use (pr ops)
     ;; to compute a subtree hash to determine if the build has changed and needs
@@ -210,28 +203,26 @@
 
   Returns a map, including the build operations and additional build metadata,
   which can be executed by `run-build!`."
-  [project]
+  [project dependency-tree]
   (let [build-opts (merge default-build-opts (:jank project))
         target-dir (:target-dir build-opts)]
     (when *disable-sandbox*
       (println "\u001b[1;31mBuilding with sandboxing disabled is potentially dangerous!\u001b[0m"))
 
-    (let [tree     (->> (mapv #(resolve/dependency-hierarchy project (:managed-dependencies project) %)
-                              (:dependencies project))
-                        (apply merge))
-           ;; Plan the build steps just for the child dependencies,
-           ;; recursively resolving their dependencies and so on.
-          dep-ops  (vec (mapcat #(plan-subtree-build build-opts target-dir %) tree))
-           ;; Special handling when the root project has a build script.
-          root-ops (when (has-build-file? (:root project))
-                     [{:op           :compile
-                       :dep          [(symbol (:group project) (:name project)) (:version project)]
-                       :src-dir      (str (:root project))
-                       :out-dir      (str (target-subdir target-dir "out" (:name project) "XXX"))
-                       :build-opts   build-opts
-                       :build-inputs (collect-build-deps tree)
-                       :inputs       (collect-out-dirs dep-ops)}])
-          plan (into dep-ops root-ops)]
+    (let [;; Plan the build steps just for the child dependencies,
+          ;; recursively resolving their dependencies and so on.
+          subtree-ops (vec (mapcat #(plan-subtree-build build-opts target-dir %)
+                                   (filter some? dependency-tree)))
+          ;; Special handling when the root project has a build script.
+          root-ops    (when (has-build-file? (:root project))
+                        [{:op           :compile
+                          :dep          {:coord [(symbol (:group project) (:name project)) (:version project)]}
+                          :src-dir      (str (:root project))
+                          :out-dir      (str (target-subdir target-dir "out" (:name project) "XXX"))
+                          :build-opts   build-opts
+                          :build-inputs (collect-build-deps dependency-tree)
+                          :inputs       (collect-out-dirs subtree-ops)}])
+          plan        (into subtree-ops root-ops)]
       plan)))
 
 (defn read-build-directives
@@ -265,7 +256,7 @@
 
 (defn needs-compile?
   "Determine if a compile operation can be skipped based on whether it has
-  already been compiled and all of the tracked rerun-if-* have not changed. "
+  already been compiled and all of the tracked rerun-if-* have not changed."
   [compile-op]
   (let [fingerprint-path (fs/path (:out-dir compile-op) jank-build-fingerprint-file)]
     (or
@@ -286,7 +277,7 @@
   ;; Since the out-dir name includes the jar fingerprint, we know that the
   ;; contents will be the same and we can skip the step.
   (when-not (fs/directory? out-dir)
-    (println (str "\u001b[1;36m" (format "%10s" "Extracting") "\u001b[0m") dep)
+    (println (str "\u001b[1;36m" (format "%10s" "Extracting") "\u001b[0m") (:coord dep))
     (extract-jar! jar out-dir))
 
   ;; does not produce any jank flags
@@ -295,7 +286,7 @@
 (defmethod run-build-op! :compile
   [plan {:keys [dep out-dir] :as op}]
   (when (needs-compile? op)
-    (println (str "\u001b[1;32m" (format "%10s" "Compiling") "\u001b[0m") dep)
+    (println (str "\u001b[1;32m" (format "%10s" "Compiling") "\u001b[0m") (:coord dep))
     (build-dep! op))
 
   ;; Write a fingerprint file to detect any changes in the watched files or env
@@ -313,4 +304,7 @@
   Returns a map of :defines, :include-dirs, :library-dirs, and :linked-libraries
   to be passed to the jank compiler."
   [plan]
-  (apply merge (mapv #(run-build-op! plan %) plan)))
+  (reduce
+   (fn [m op] (merge-with into m (run-build-op! plan op)))
+   {}
+   plan))

--- a/lein-jank/src/jank_build/fingerprint.clj
+++ b/lein-jank/src/jank_build/fingerprint.clj
@@ -1,4 +1,4 @@
-(ns leiningen.jank.fingerprint
+(ns jank-build.fingerprint
   (:require [clojure.java.io :as io]
             [babashka.fs :as fs])
   (:import (java.security MessageDigest)

--- a/lein-jank/src/jank_build/sandbox/bwrap.clj
+++ b/lein-jank/src/jank_build/sandbox/bwrap.clj
@@ -1,6 +1,5 @@
-(ns leiningen.jank.sandbox.bwrap
-  (:require [babashka.fs :as fs]
-            [babashka.process :as proc]))
+(ns jank-build.sandbox.bwrap
+  (:require [babashka.fs :as fs]))
 
 ;; TODO: consider the merits of an allowlist vs. denylist of mounts. Per the
 ;; bwrap documentation, we definitely want to avoid mounting /var which may

--- a/lein-jank/src/jank_build/sandbox/core.clj
+++ b/lein-jank/src/jank_build/sandbox/core.clj
@@ -1,7 +1,7 @@
-(ns leiningen.jank.sandbox.core
+(ns jank-build.sandbox.core
   (:require [babashka.process :as proc]
-            [leiningen.jank.sandbox.bwrap :as bwrap]
-            [leiningen.core.main :as lmain]))
+            [jank-build.sandbox.bwrap :as bwrap]
+            [jank-build.util :as util]))
 
 (defn process
   "Pass `cmd` and `sh-opts` to `babashka.process/process` running inside of a
@@ -17,7 +17,7 @@
     (proc/process cmd sh-opts)
 
     (not (bwrap/which-bwrap))
-    (lmain/abort
+    (util/abort
      (str "No 'bwrap' executable found. If bubblewrap is not available on your"
           " platform then you can build with the lein option :disable-sandbox,"
           " however this allows potentially nefarious build scripts free rein"

--- a/lein-jank/src/jank_build/util.clj
+++ b/lein-jank/src/jank_build/util.clj
@@ -1,0 +1,8 @@
+(ns jank-build.util)
+
+(defn warn [& args]
+  (apply println args))
+
+(defn abort [& args]
+  (apply println args)
+  (System/exit 1))

--- a/lein-jank/src/leiningen/jank/core.clj
+++ b/lein-jank/src/leiningen/jank/core.clj
@@ -6,7 +6,8 @@
    [babashka.fs :as fs]
    [babashka.process :as ps]
    [leiningen.core.main :as lmain]
-   [leiningen.jank.build :as ljb])
+   [leiningen.jank.resolve :as resolve]
+   [jank-build.core :as build])
   (:import [java.io File]))
 
 (defonce verbose? (atom false))
@@ -38,9 +39,14 @@
   ensure the native libraries are up-to-date. Any work which doesn't need to be
   recomputed will be cached."
   [project opts]
-  (binding [ljb/*disable-sandbox* (or ljb/*disable-sandbox* (:disable-sandbox opts))
-            ljb/*verbose-build*   @verbose?]
-    (let [native-flags (ljb/run-build! (ljb/plan-build project))]
+  (binding [build/*disable-sandbox* (or build/*disable-sandbox* (:disable-sandbox opts))
+            build/*verbose-build*   @verbose?]
+    (let [deps-tree    (resolve/dependency-hierarchies
+                        project
+                        (:managed-dependencies project)
+                        (:dependencies project))
+          build-plan   (build/plan-build project deps-tree)
+          native-flags (build/run-build! build-plan)]
       (update project :jank #(merge-with into % native-flags)))))
 
 (defn build-module-path [project]

--- a/lein-jank/src/leiningen/jank/resolve.clj
+++ b/lein-jank/src/leiningen/jank/resolve.clj
@@ -2,6 +2,10 @@
   (:require [leiningen.core.classpath :refer [default-aether-args normalize-dep-vector]]
             [cemerick.pomegranate.aether :as aether]))
 
+(defn build-scoped? [coord]
+  (let [m (apply hash-map coord)]
+    (= (:scope m) "jank-build")))
+
 (defn dependency-hierarchy
   "Resolve the full dependency tree from a given root coordinate. All tree
   entries are annotated with aether metadata.
@@ -22,38 +26,24 @@
         full-tree     (aether/resolve-dependencies opts)
         dep-with-meta (first (filter #{dep} (keys full-tree)))]
     (when dep-with-meta
-      {dep-with-meta
-       (->> (get full-tree dep)
-            (mapv (fn [d] [d (-> (dependency-hierarchy project managed-deps d) vals first)]))
-            (into {}))})))
+      {:coord        dep
+       :build-scoped (build-scoped? dep-with-meta)
+       :file         (-> dep-with-meta meta :file str)
+       :children     (->> (get full-tree dep)
+                          (mapv #(dependency-hierarchy project managed-deps %)))})))
 
-(defn dependency-files
-  "For a dependency tree, resolve all of the artifact paths, returned as a
-  sequence of string paths.
-
-  NOTE: The coordinates must be augmented with aether metadata returned by e.g.
-  `resolve-tree`."
-  [tree]
-  (let [top-deps  (mapv str (aether/dependency-files tree))
-        rest-deps (mapv dependency-files (vals tree))]
-    (apply concat top-deps rest-deps)))
+(defn dependency-hierarchies
+  [project managed-deps deps]
+  (mapv #(dependency-hierarchy project managed-deps %) deps))
 
 (comment
   (require 'leiningen.core.project)
   (def project (leiningen.core.project/read "test-data/test-parent/project.clj"))
 
-  (dependency-hierarchy project '[org.jank-lang.commons/imgui-sys "2026.06-1"])
-  ;; => {[org.jank-lang.commons/imgui-sys "2026.06-1"]
-  ;;     {[org.jank-lang.commons/jank-build-cmake "2026.06-1" :scope "jank-build"] {},
-  ;;      [org.jank-lang.commons/gl-sys "2026.06-1"] {[org.jank-lang.commons/jank-build-pkg-config "2026.06-1" :scope "jank-build"] {}},
-  ;;      [org.jank-lang.commons/glfw-sys "2026.06-1"] {[org.jank-lang.commons/jank-build-pkg-config "2026.06-1" :scope "jank-build"] {}}}}
-
-  (->> (dependency-hierarchy project '[org.jank-lang.commons/imgui-sys "2026.06-1"])
-       (dependency-files))
-  ;; => ("/home/kyle/.m2/repository/org/jank-lang/commons/imgui-sys/2026.06-1/imgui-sys-2026.06-1.jar"
-  ;;     "/home/kyle/.m2/repository/org/jank-lang/commons/jank-build-cmake/2026.06-1/jank-build-cmake-2026.06-1.jar"
-  ;;     "/home/kyle/.m2/repository/org/jank-lang/commons/gl-sys/2026.06-1/gl-sys-2026.06-1.jar"
-  ;;     "/home/kyle/.m2/repository/org/jank-lang/commons/glfw-sys/2026.06-1/glfw-sys-2026.06-1.jar"
-  ;;     "/home/kyle/.m2/repository/org/jank-lang/commons/jank-build-pkg-config/2026.06-1/jank-build-pkg-config-2026.06-1.jar"
-  ;;     "/home/kyle/.m2/repository/org/jank-lang/commons/jank-build-pkg-config/2026.06-1/jank-build-pkg-config-2026.06-1.jar")
+  (dependency-hierarchy project {} '[org.jank-lang.commons/imgui-sys "2026.06-1"])
+  ;; => {:coord [org.jank-lang.commons/imgui-sys "2026.06-1"],
+  ;;     :build-scoped false,
+  ;;     :file
+  ;;     "/home/kyle/.m2/repository/org/jank-lang/commons/imgui-sys/2026.06-1/imgui-sys-2026.06-1.jar",
+  ;;     :children {}}
   )

--- a/lein-jank/test/leiningen/jank/integration_test.clj
+++ b/lein-jank/test/leiningen/jank/integration_test.clj
@@ -5,9 +5,9 @@
             [babashka.fs :as fs]
             [leiningen.install :refer [install]]
             [leiningen.core.project :as lproj]
-            [leiningen.jank.build :as build]
-            [leiningen.jank.changed :as changed]
-            [leiningen.jank.resolve :as resolve]))
+            [leiningen.jank.resolve :as resolve]
+            [jank-build.change-detection :as changed]
+            [jank-build.core :as build]))
 
 (def temp-m2-repo (str (fs/create-temp-dir {:prefix "lein-jank-test-m2"})))
 
@@ -41,56 +41,93 @@
 
 (use-fixtures :once setup-fixture)
 
+(defn resolve-deps [project]
+  (resolve/dependency-hierarchies project (:managed-dependencies project) (:dependencies project)))
+
 (deftest detect-jank-build-file-test
   (is (false? (build/has-build-file? (:root parent-project))))
   (is (false? (build/has-build-file? (:root child-project))))
   (is (true? (build/has-build-file? (:root grandchild-project)))))
 
 (deftest plan-build-test
-  (let [ops (build/plan-build parent-project)]
+  (let [project   parent-project
+        deps-tree (resolve-deps project)
+        ops       (build/plan-build project deps-tree)]
     ;; Only test-grandchild has a jank-build file, so it is the only dep which
     ;; will generate build plan steps.
     (is (match? [{:op  :extract-src
-                  :dep '[org.jank-lang/test-grandchild "0.1.0"]}
+                  :dep {:coord '[org.jank-lang/test-grandchild "0.1.0"]}}
                  {:op           :compile
-                  :dep          '[org.jank-lang/test-grandchild "0.1.0"]
+                  :dep          {:coord '[org.jank-lang/test-grandchild "0.1.0"]}
                   :build-inputs [(m/regex #".*\.jar")]
                   :inputs       (m/equals {})}
                  {:op  :extract-src
-                  :dep '[org.jank-lang/test-grandchild2 "0.1.0"]}
+                  :dep {:coord '[org.jank-lang/test-grandchild2 "0.1.0"]}}
                  {:op  :compile
-                  :dep '[org.jank-lang/test-grandchild2 "0.1.0"]}]
+                  :dep {:coord '[org.jank-lang/test-grandchild2 "0.1.0"]}}]
                 ops))))
 
 (deftest plan-build-with-root-jank-build-test
-  (let [ops (build/plan-build grandchild-project)]
+  (let [project   grandchild-project
+        deps-tree (resolve-deps project)
+        ops       (build/plan-build project deps-tree)]
     (is (match? [;; no extract-src since we are building the root from source
                  {:op           :compile
-                  :dep          '[org.jank-lang/test-grandchild "0.1.0"]
+                  :dep          {:coord '[org.jank-lang/test-grandchild "0.1.0"]}
                   :build-inputs [(m/regex #".*\.jar")]
                   :inputs       (m/equals {})}]
                 ops))))
 
 (deftest plan-build-with-managed-deps
-  (let [tree (resolve/dependency-hierarchy
-              managed-deps-project
-              (:managed-dependencies managed-deps-project)
-              '[org.jank-lang/test-managed-deps "0.1.0"])]
+  (let [project managed-deps-project
+        tree    (resolve/dependency-hierarchy
+                 project
+                 (:managed-dependencies project)
+                 '[org.jank-lang/test-managed-deps "0.1.0"])]
     ;; The project declares an imgui-sys managed dependency version of
     ;; 2026.06-1. This overrides the nested imgui-sys depenencies, which are on
     ;; version 2026.06-6.
+    ;;
+    ;; Non-exhaustive listing:
     (is (match?
-         {['org.jank-lang/test-managed-deps "0.1.0"]
-          {['org.jank-lang.commons/imgui-glfw-sys "2026.06-1"]    {['org.jank-lang.commons/imgui-sys "2026.06-1"] {}}
-           ['org.jank-lang.commons/imgui-opengl2-sys "2026.06-6"] {['org.jank-lang.commons/imgui-sys "2026.06-1"] {}}
-           ['org.jank-lang.commons/imgui-sys "2026.06-1"]         {}}}
-       tree))))
+         {:coord        ['org.jank-lang/test-managed-deps "0.1.0"],
+          :build-scoped false,
+          :file         (m/regex #".*\.jar")
+          :children
+          [{:coord        '[org.jank-lang.commons/imgui-glfw-sys "2026.06-1"],
+            :build-scoped false,
+            :file         (m/regex #".*\.jar")
+            :children
+            [{:coord        '[org.jank-lang.commons/imgui-sys "2026.06-1"],
+              :build-scoped false,
+              :file         (m/regex #".*\.jar")
+              :children     []}
+             {:coord        '[org.jank-lang.commons/glfw-sys "2026.06-1"],
+              :build-scoped false,
+              :file         (m/regex #".*\.jar")
+              :children     []}]}
+           {:coord        '[org.jank-lang.commons/imgui-sys "2026.06-1"],
+            :build-scoped false,
+            :file         (m/regex #".*\.jar")
+            :children     []}
+           {:coord        '[org.jank-lang.commons/imgui-opengl2-sys "2026.06-6"],
+            :build-scoped false,
+            :file         (m/regex #".*\.jar")
+            :children
+            [{:coord        '[org.jank-lang.commons/gl-sys "2026.06-1"],
+              :build-scoped false,
+              :file         (m/regex #".*\.jar")
+              :children     []}
+             {:coord        '[org.jank-lang.commons/imgui-sys "2026.06-1"],
+              :build-scoped false,
+              :file         (m/regex #".*\.jar")
+              :children     []}]}]}
+         tree))))
 
 (deftest run-build-test
   (let [target-dir (fs/create-temp-dir {:prefix "lein-jank-test-out"})
-        plan       (-> parent-project
-                       (assoc-in [:jank :target-dir] target-dir)
-                       (build/plan-build))
+        project    (assoc-in parent-project [:jank :target-dir] target-dir)
+        plan       (build/plan-build project (resolve-deps project))
         result     (binding [build/*disable-sandbox* true]
                      (build/run-build! plan))]
     ;; These are the results from the test-grandchild jank-build.bb script.
@@ -103,9 +140,8 @@
 
 (deftest rerun-if-changed-test
   (let [target-dir (fs/create-temp-dir {:prefix "lein-jank-test-out"})
-        plan       (-> change-detection-project
-                       (assoc-in [:jank :target-dir] target-dir)
-                       (build/plan-build))
+        project    (assoc-in change-detection-project [:jank :target-dir] target-dir)
+        plan       (build/plan-build project (resolve-deps project))
         compile-op (last plan)]
     (with-redefs [changed/env (fn [ks] {"WATCHED_VAR" "a_value"})]
       ;; Dependency which is not build yet causes a rebuild to trigger.

--- a/lein-jank/test/leiningen/jank/test_bb.clj
+++ b/lein-jank/test/leiningen/jank/test_bb.clj
@@ -1,0 +1,9 @@
+(ns leiningen.jank.test-bb
+  (:require [clojure.test :refer [deftest]]
+            [babashka.process :as proc]))
+
+;; Verify that jank-build loads without errors in Babashka.
+(deftest load-jank-build-in-bb
+  (->
+   (proc/sh "bb -cp src/ -e \"(require 'jank-build.core)\"")
+   (proc/check)))

--- a/lein-jank/test/leiningen/jank/test_build.clj
+++ b/lein-jank/test/leiningen/jank/test_build.clj
@@ -1,7 +1,8 @@
 (ns leiningen.jank.test-build
   (:require [clojure.test :refer [deftest is]]
             [leiningen.core.project :as proj]
-            [leiningen.jank.build :as build]))
+            [leiningen.jank.resolve :as resolve]
+            [jank-build.core :as build]))
 
 (def test-project (proj/read "test-project/project.clj"))
 
@@ -15,6 +16,6 @@
   (is (= (build/process-build-directive "jank-build::link-library=a-lib") {:linked-libraries ["a-lib"]})))
 
 (deftest build-scoped
-  (is (false? (build/build-scoped? '[org.jank/some-dependency "1.0.0"])))
-  (is (false? (build/build-scoped? '[org.jank/some-dependency "1.0.0" :exclusions [foo] :classifier "asdf"])))
-  (is (true? (build/build-scoped? '[org.jank/some-dependency "1.0.0" :scope "jank-build"]))))
+  (is (false? (resolve/build-scoped? '[org.jank/some-dependency "1.0.0"])))
+  (is (false? (resolve/build-scoped? '[org.jank/some-dependency "1.0.0" :exclusions [foo] :classifier "asdf"])))
+  (is (true? (resolve/build-scoped? '[org.jank/some-dependency "1.0.0" :scope "jank-build"]))))

--- a/lein-jank/test/leiningen/jank/test_changed.clj
+++ b/lein-jank/test/leiningen/jank/test_changed.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer [deftest is]]
             [babashka.fs :as fs]
             [leiningen.core.project :as proj]
-            [leiningen.jank.changed :as changed]))
+            [jank-build.change-detection :as changed]))
 
 (def test-project (proj/read "test-project/project.clj"))
 

--- a/lein-jank/test/leiningen/jank/test_fingerprint.clj
+++ b/lein-jank/test/leiningen/jank/test_fingerprint.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer [deftest is]]
             [babashka.fs :as fs]
             [leiningen.core.project :as proj]
-            [leiningen.jank.fingerprint :as fprint]))
+            [jank-build.fingerprint :as fprint]))
 
 (def test-project (proj/read "test-project/project.clj"))
 


### PR DESCRIPTION
Let's keep jank-build small and not depending on leiningen. It now uses only babashka-compatible dependencies and Java classes.

There is still some implicit leiningen dependency on the `project.clj` structure, which we pass around in jank-build. We can tackle this later.

- Moved any lein-specific behavior (like dependency resolution) up above jank-build
- Added a unit test to load `jank-build.core` via bb to ensure we don't break compatibility
- Little bit of cleanup here and there