### PR TITLE
Enable AOT compilation for lein-jank

### DIFF
--- a/lein-jank/project.clj
+++ b/lein-jank/project.clj
@@ -2,11 +2,24 @@
   :description "Build your jank projects using Leiningen."
   :url "https://jank-lang.org/"
   :license {:name "MPL 2.0"
-            :url "https://www.mozilla.org/en-US/MPL/2.0/"}
+            :url  "https://www.mozilla.org/en-US/MPL/2.0/"}
   :dependencies [[babashka/fs "0.5.33"]
                  [babashka/process "0.6.25"]
                  [leiningen-core "2.12.0"]
                  [org.clojure/tools.cli "1.4.256"]
                  [org.clojure/tools.namespace "1.5.1"]]
-  :profiles {:dev {:dependencies [[nubank/matcher-combinators "3.10.0"]]}}
-  :eval-in-leiningen true)
+  :profiles {:dev      {:dependencies      [[nubank/matcher-combinators "3.10.0"]]
+                        :eval-in-leiningen :true}
+             :provided {:dependencies [[org.clojure/clojure "1.12.5"]]}
+             :release  {:aot [jank-build.core
+                              jank-build.change-detection
+                              jank-build.fingerprint
+                              jank-build.util
+                              jank-build.sandbox.core
+                              jank-build.sandbox.bwrap
+                              ;; TODO: fails to AOT compile
+                              ;; leiningen.jank
+                              leiningen.jank.core
+                              leiningen.jank.discovery
+                              leiningen.jank.resolve
+                              leiningen.jank.test]}})


### PR DESCRIPTION
Before/after benchmarks of a trivial command which loads up the middleware (in the `minitui` project) but doesn't execute jank. Seems to be about a 45% improvement.

```
$ hyperfine -r 5 "lein run --help"
Benchmark 1: lein run --help
  Time (mean ± σ):      1.177 s ±  0.010 s    [User: 1.627 s, System: 0.167 s]
  Range (min … max):    1.166 s …  1.192 s    5 runs
```
```
$ hyperfine -r 5 "lein run --help"
Benchmark 1: lein run --help
  Time (mean ± σ):     653.0 ms ±   6.8 ms    [User: 938.1 ms, System: 118.6 ms]
  Range (min … max):   645.5 ms … 661.8 ms    5 runs
  ```

 A `lein run` which does invoke jank is ~35% faster.

I'm not sure of the implications of this. Does it break if someone is using an older Clojure than the one used to AOT compile? Seems worth investigating.

Also testing the new JDK `-XX:AOTCache` features, the above benchmark gets down to ~500ms :fast_forward:.

NOTE: will need to be deployed with `lein with-profile +release ...`