### PR TITLE
Speed up lein-jank by lazy loading

### DIFF
--- a/lein-jank/project.clj
+++ b/lein-jank/project.clj
@@ -4,9 +4,9 @@
   :license {:name "MPL 2.0"
             :url "https://www.mozilla.org/en-US/MPL/2.0/"}
   :dependencies [[babashka/fs "0.5.33"]
-                 [babashka/process "0.6.25"]
                  [leiningen-core "2.12.0"]
                  [org.clojure/tools.cli "1.4.256"]
                  [org.clojure/tools.namespace "1.5.1"]]
-  :profiles {:dev {:dependencies [[nubank/matcher-combinators "3.10.0"]]}}
+  :profiles {:dev {:dependencies [[babashka/process "0.6.25"]
+                                  [nubank/matcher-combinators "3.10.0"]]}}
   :eval-in-leiningen true)

--- a/lein-jank/project.clj
+++ b/lein-jank/project.clj
@@ -3,7 +3,8 @@
   :url "https://jank-lang.org/"
   :license {:name "MPL 2.0"
             :url "https://www.mozilla.org/en-US/MPL/2.0/"}
-  :dependencies [[babashka/fs "0.5.33"]
+  :dependencies [[org.clojure/clojure "1.12.5"]
+                 [babashka/fs "0.5.33"]
                  [leiningen-core "2.12.0"]
                  [org.clojure/tools.cli "1.4.256"]
                  [org.clojure/tools.namespace "1.5.1"]]

--- a/lein-jank/src/jank_build/core.clj
+++ b/lein-jank/src/jank_build/core.clj
@@ -123,13 +123,13 @@
         proc         (sandbox/process
                       (not *disable-sandbox*)
                       sandbox-args
-                      ["bb" "--classpath" bb-classpath "--stream" (fs/path src-dir jank-build-file)]
-                      {:in       (pr-str build-input)
-                       :continue true})
+                      {}
+                      ["bb" "--classpath" bb-classpath "--stream" (fs/path src-dir jank-build-file)])
         out-lines    (atom [])]
+    (spit (:in proc) (pr-str build-input))
     (future (wrap-stream (:out proc) out-lines *verbose-build* (str "  \u001b[0;34m" dep-name ">\u001b[0m")))
     (future (wrap-stream (:err proc) out-lines *verbose-build* (str "  \u001b[0;31m" dep-name ">\u001b[0m")))
-    (if (zero? (:exit @proc))
+    (if (zero? @(:exit proc))
       ;; Build succeeded. Cache all of the build stdout output. Later we will
       ;; parse the build directives.
       (fs/write-lines (fs/path out-dir jank-build-cache-file) @out-lines)

--- a/lein-jank/src/jank_build/sandbox/core.clj
+++ b/lein-jank/src/jank_build/sandbox/core.clj
@@ -1,20 +1,19 @@
 (ns jank-build.sandbox.core
-  (:require [babashka.process :as proc]
-            [jank-build.sandbox.bwrap :as bwrap]
+  (:require [jank-build.sandbox.bwrap :as bwrap]
             [jank-build.util :as util]))
 
 (defn process
-  "Pass `cmd` and `sh-opts` to `babashka.process/process` running inside of a
-  sandboxed container specified by `sandbox-opts`.
+  "Pass `cmd` and `sh-opts` to `jank-build.util/sh` running inside of
+  a sandboxed container specified by `sandbox-opts`.
 
   Setting the `enable?` flag to false allows sandboxing to be skipped entirely
   and the command will be run as a standard shell process."
-  [enable? sandbox-opts cmd sh-opts]
+  [enable? sandbox-opts sh-opts cmd]
   ;; TODO: handle Windows and MacOS, either by a fake sandbox or using their
   ;; native constructs for containerization.
   (cond
     (not enable?)
-    (proc/process cmd sh-opts)
+    (util/sh sh-opts cmd)
 
     (not (bwrap/which-bwrap))
     (util/abort
@@ -25,4 +24,4 @@
 
     :else
     (let [bwrap-prefix (bwrap/bwrap (into bwrap/standard-binds sandbox-opts))]
-      (proc/process (concat bwrap-prefix cmd) sh-opts))))
+      (util/sh sh-opts (concat bwrap-prefix cmd)))))

--- a/lein-jank/src/jank_build/util.clj
+++ b/lein-jank/src/jank_build/util.clj
@@ -1,4 +1,5 @@
-(ns jank-build.util)
+(ns jank-build.util
+  (:require [clojure.java.process :as proc]))
 
 (defn warn [& args]
   (apply println args))
@@ -6,3 +7,13 @@
 (defn abort [& args]
   (apply println args)
   (System/exit 1))
+
+(defn sh
+  "A wrapper around `clojure.java.process` which forward the opts and
+  cmd, and returns a map of: :in, :out, :err, :exit."
+  [opts cmd]
+  (let [p (apply proc/start opts (mapv str cmd))]
+    {:in   (proc/stdin p)
+     :out  (proc/stdout p)
+     :err  (proc/stderr p)
+     :exit (proc/exit-ref p)}))

--- a/lein-jank/src/leiningen/jank.clj
+++ b/lein-jank/src/leiningen/jank.clj
@@ -3,9 +3,9 @@
   (:require [leiningen.core.main :as lmain]
             [leiningen.core.project :as lproj]
             [leiningen.jank.core :as ljc]
-            [leiningen.jank.test :as ljt]
             [leiningen.help :as lhelp]
-            [babashka.fs :as fs]))
+            [clojure.java.io :as io])
+  (:import [java.nio.file Files]))
 
 (defn find-deprecated-flags [project]
   (doseq [[k] (:jank project)]
@@ -107,11 +107,15 @@ To override the inferred output target, you can pass `--output-target TARGET`
 Keyword arguments are interpreted as test selectors and other arguments as test
 namespaces or files."
   [project & args]
-  (let [project          (lproj/merge-profiles project [:leiningen/test :test])
-        [opts args]      (ljc/parse-opts #'test! args ljc/standard-options)
-        [nses selectors] (ljt/read-args args project)
-        test-runner      (ljt/generate-test-runner! nses (vec selectors))]
-    (dispatch-jank project opts "run" [test-runner] [])))
+  ;; Lazy load the leiningen.jank.test namespace, since it's only
+  ;; needed for this command.
+  (let [read-args             (requiring-resolve 'leiningen.jank.test/read-args)
+        generate-test-runner! (requiring-resolve 'leiningen.jank.test/generate-test-runner!)]
+    (let [project          (lproj/merge-profiles project [:leiningen/test :test])
+          [opts args]      (ljc/parse-opts #'test! args ljc/standard-options)
+          [nses selectors] (read-args args project)
+          test-runner      (generate-test-runner! nses (vec selectors))]
+      (dispatch-jank project opts "run" [test-runner] []))))
 
 (defn check-health!
   "Perform a health check on your jank install."
@@ -203,6 +207,12 @@ namespaces or files."
           (with-meta result (apply deep-merge-metadata maps))
           result)))))
 
+(defn relativize [base target]
+  (let [base   (.toPath (io/file base))
+        target (.toPath (io/file target))]
+    (->> (.relativize base target)
+         (.toFile))))
+
 (defn verbatim->filespecs
   "Specify filespecs to copy files or directories in the :verbatim-paths project
   key into the output archive.
@@ -211,18 +221,18 @@ namespaces or files."
   strip the path prefix such that the entries appear directly on the classpath
   when the jar is loaded."
   [{:keys [verbatim-paths] :as project}]
-  (for [path  verbatim-paths
-        f     (if (fs/directory? path)
-                (fs/glob (fs/path (:root project) path) "**")
-                [(fs/path (:root project) path)])
-        :when (fs/regular-file? f)]
+  (for [path  (mapv io/file verbatim-paths)
+        f     (if (.isDirectory path)
+                (file-seq path)
+                [path])
+        :when (.isFile f)]
     ;; Lazy :fn type filespecs so that the file contents are only loaded when
     ;; needed, rather than every time the middleware is executed.
     {:type :fn
      :fn   (fn [project]
              {:type  :bytes
-              :path  (str (fs/relativize (:root project) f))
-              :bytes (fs/read-all-bytes f)})}))
+              :path  (str (relativize (:root project) f))
+              :bytes (Files/readAllBytes (.toPath f))})}))
 
 (defn build-dependencies->dependencies
   "Compute regular :dependencies coordinates from the jank-specific
@@ -236,7 +246,7 @@ namespaces or files."
 (defn middleware
   "Inject jank project details into your current project."
   [project]
-  (let [project (update project :verbatim-paths conj "jank-build.bb")]
+  (let [project (update project :verbatim-paths conj (io/file (:root project) "jank-build.bb"))]
     (-> (deep-merge (default-project project) project)
         (update :filespecs concat (verbatim->filespecs project))
         (update :dependencies concat (build-dependencies->dependencies project)))))

--- a/lein-jank/src/leiningen/jank/core.clj
+++ b/lein-jank/src/leiningen/jank/core.clj
@@ -3,11 +3,9 @@
    [clojure.string :as string]
    [clojure.tools.cli :as cli]
    [leiningen.core.classpath :as lcp]
-   [babashka.fs :as fs]
-   [babashka.process :as ps]
    [leiningen.core.main :as lmain]
    [leiningen.jank.resolve :as resolve]
-   [jank-build.core :as build])
+   [jank-build.util :as util])
   (:import [java.io File]))
 
 (defonce verbose? (atom false))
@@ -39,15 +37,26 @@
   ensure the native libraries are up-to-date. Any work which doesn't need to be
   recomputed will be cached."
   [project opts]
-  (binding [build/*disable-sandbox* (or build/*disable-sandbox* (:disable-sandbox opts))
-            build/*verbose-build*   @verbose?]
-    (let [deps-tree    (resolve/dependency-hierarchies
-                        project
-                        (:managed-dependencies project)
-                        (:dependencies project))
-          build-plan   (build/plan-build project deps-tree)
-          native-flags (build/run-build! build-plan)]
-      (update project :jank #(merge-with into % native-flags)))))
+  ;; The below is all an effort to load the jank-build namespace only
+  ;; when necessary, as it's slow to load.
+  ;;
+  ;; NOTE: Can't use (bindings) here because of the late-resolved dynamic vars.
+  (let [plan-build      (requiring-resolve 'jank-build.core/plan-build)
+        run-build!      (requiring-resolve 'jank-build.core/run-build!)
+        disable-sandbox (requiring-resolve 'jank-build.core/*disable-sandbox*)
+        verbose-build   (requiring-resolve 'jank-build.core/*verbose-build*)]
+    (push-thread-bindings {disable-sandbox (or @disable-sandbox (:disable-sandbox opts))
+                           verbose-build   @verbose?})
+    (try
+      (let [deps-tree    (resolve/dependency-hierarchies
+                          project
+                          (:managed-dependencies project)
+                          (:dependencies project))
+            build-plan   (plan-build project deps-tree)
+            native-flags (run-build! build-plan)]
+        (update project :jank #(merge-with into % native-flags)))
+      (finally
+        (pop-thread-bindings)))))
 
 (defn build-module-path [project]
   (->> project
@@ -96,15 +105,25 @@
 
     (lmain/warn (str "Unknown flag " flag))))
 
+(defn verify-jank!
+  "Verify that we can run the jank executable, or crash with the
+  reason we cannot."
+  []
+  (try
+    (util/sh {} ["jank"])
+    (catch Exception e
+      ;; Will print a nice message on failure like "Cannot run program
+      ;; 'jank': ..."
+      (lmain/abort (.getMessage e)))))
+
 (defn build-declarative-flags [project]
   (flatten (map (fn [[flag value]]
                   (build-declarative-flag flag value))
                 (:jank project))))
 
 (defn shell-out! [project classpath command compiler-args runtime-args]
-  (let [jank (fs/which "jank")
-        env (System/getenv)
-        args (concat [jank command "--module-path" classpath]
+  (verify-jank!)
+  (let [args (concat ["jank" command "--module-path" classpath]
                      ; The normal build dir would be <target dir>/_cache, but we want
                      ; to nest one level deeper, so that files from this project don't
                      ; interfere with files from the dependencies. So we specify our
@@ -118,14 +137,13 @@
                      compiler-args
                      ["--"]
                      runtime-args)
-        ; TODO: Better error handling.
-        _ (assert (some? jank))
-        _ (when @verbose?
-            (println ">" (clojure.string/join " " args)))
-        proc (apply ps/shell
-                    {:continue true
-                     :dir (:root project)
-                     :extra-env env}
-                    args)]
-    (when-not (zero? (:exit proc))
-      (System/exit (:exit proc)))))
+        _    (when @verbose?
+               (println ">" (clojure.string/join " " args)))
+        exit @(->> (mapv str args)
+                   (util/sh {:out :inherit
+                             :err :inherit
+                             :in  :inherit
+                             :dir (:root project)})
+                   :exit)]
+    (when-not (zero? exit)
+      (System/exit exit))))

--- a/lein-jank/src/leiningen/jank/test.clj
+++ b/lein-jank/src/leiningen/jank/test.clj
@@ -1,11 +1,9 @@
 (ns leiningen.jank.test
-  (:require [leiningen.jank.discovery :as d]
-            [clojure.java.io :as io]
+  (:require [clojure.java.io :as io]
             [clojure.string :as string]
+            [babashka.fs :as fs]
             [leiningen.core.main :as lmain]
-            [leiningen.core.project :as p]
-            [leiningen.jank.core :as ljc]
-            [babashka.fs :as fs]))
+            [leiningen.jank.discovery :as d]))
 
 (defn- convert-to-ns [possible-file]
   (if (d/valid-source-file? (io/file possible-file))

--- a/lein-jank/test/leiningen/jank/integration_test.clj
+++ b/lein-jank/test/leiningen/jank/integration_test.clj
@@ -154,6 +154,7 @@
         (is (build/needs-compile? compile-op)))
 
       ;; Touching a rerun-if-changed file causes a rebuild to trigger.
+      (Thread/sleep 100)
       (fs/touch (fs/path (:src-dir compile-op) "test-file"))
       (is (build/needs-compile? compile-op))
 


### PR DESCRIPTION
Another approach to speeding up lein-jank.

There are a few namespaces which each add 100-200ms of load time: clojure.tools.namespace (this one is really bad), babashka.fs, and babashka.process. If we can avoid loading these in commands that don't use them, or replace them entirely (babashka.process -> clojure.java.process), then everything gets faster.

Here are the before/after comparison (I installed the lein-jank from this PR during the sleep):

```
$ hyperfine --setup 'sleep 5' -r 5 'lein run --help' 'lein run --help'
Benchmark 1: lein run --help
  Time (mean ± σ):      1.202 s ±  0.028 s    [User: 1.649 s, System: 0.174 s]
  Range (min … max):    1.167 s …  1.244 s    5 runs
 
Benchmark 2: lein run --help
  Time (mean ± σ):     689.2 ms ±  16.8 ms    [User: 1024.2 ms, System: 125.5 ms]
  Range (min … max):   673.8 ms … 716.3 ms    5 runs
 
Summary
  lein run --help ran
    1.74 ± 0.06 times faster than lein run --help
```
```
$ hyperfine --setup 'sleep 5' -r 5 'lein run -v' 'lein run -v'
Benchmark 1: lein run -v
  Time (mean ± σ):      1.319 s ±  0.035 s    [User: 1.751 s, System: 0.199 s]
  Range (min … max):    1.275 s …  1.359 s    5 runs
 
Benchmark 2: lein run -v
  Time (mean ± σ):     984.0 ms ±  29.4 ms    [User: 1386.5 ms, System: 188.9 ms]
  Range (min … max):   951.5 ms … 1015.6 ms    5 runs
 
Summary
  lein run -v ran
    1.34 ± 0.05 times faster than lein run -v
```

There is probably more speedup if we can replace `babashka.fs` in jank-build, but we use it pretty heavily so I haven't done it here.

Also improved the message when the `jank` binary cannot be found/run.