### PR TITLE
Allow :static? flag in project.clj

### DIFF
--- a/lein-jank/src/leiningen/jank/core.clj
+++ b/lein-jank/src/leiningen/jank/core.clj
@@ -94,6 +94,10 @@
     :linked-libraries
     (map (fn [v] (str "-l" v)) value)
 
+    ;; pass through to jank-build
+    :static?
+    []
+
     (lmain/warn (str "Unknown flag " flag))))
 
 (defn build-declarative-flags [project]


### PR DESCRIPTION
Some flags don't result in jank CLI flags, but are used in jank-build. We shouldn't print a warning when these are in the project.clj `:jank` section.