### PR TITLE
Enable `clojure.core-test.char`

### DIFF
--- a/compiler+runtime/include/cpp/jtl/utf8.hpp
+++ b/compiler+runtime/include/cpp/jtl/utf8.hpp
@@ -34,4 +34,7 @@ namespace jtl
 
     immutable_string data;
   };
+
+  immutable_string::size_type
+  next_char_size(immutable_string const &s, immutable_string::size_type const i);
 }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string_sequence.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string_sequence.cpp
@@ -105,7 +105,7 @@ namespace jank::runtime::obj
 
   persistent_string_sequence_ref persistent_string_sequence::next() const
   {
-    auto n(index + jtl::next_char_size(str->data, index));
+    auto const n(index + jtl::next_char_size(str->data, index));
 
     if(n == str->data.size())
     {

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string_sequence.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string_sequence.cpp
@@ -1,5 +1,8 @@
+#include <jtl/utf8.hpp>
+
 #include <jank/runtime/obj/persistent_string_sequence.hpp>
 #include <jank/runtime/obj/persistent_string.hpp>
+#include <jank/runtime/obj/character.hpp>
 #include <jank/runtime/core/seq_ext.hpp>
 #include <jank/runtime/core/make_box.hpp>
 
@@ -34,20 +37,34 @@ namespace jank::runtime::obj
 
   void persistent_string_sequence::to_string(jtl::string_builder &buff) const
   {
-    runtime::to_string(str->data.begin() + index, str->data.end(), "(", ')', buff);
+    auto const range(jtl::utf8_range(str->data.substr(index)));
+    auto const begin(range.begin());
+    auto const end(range.end());
+
+    buff('(');
+    for(auto i(begin); i != end; ++i)
+    {
+      buff(character{ *i }.to_code_string());
+      auto n(i);
+      if(++n != end)
+      {
+        buff(' ');
+      }
+    }
+    buff(')');
   }
 
   jtl::immutable_string persistent_string_sequence::to_string() const
   {
     jtl::string_builder buff;
-    runtime::to_string(str->data.begin() + index, str->data.end(), "(", ')', buff);
+    to_string(buff);
     return buff.release();
   }
 
   jtl::immutable_string persistent_string_sequence::to_code_string() const
   {
     jtl::string_builder buff;
-    runtime::to_code_string(str->data.begin() + index, str->data.end(), "(", ')', buff);
+    to_string(buff);
     return buff.release();
   }
 
@@ -59,7 +76,13 @@ namespace jank::runtime::obj
   /* behavior::countable */
   usize persistent_string_sequence::count() const
   {
-    return str->data.size() - index;
+    usize count{};
+    auto const size(str->data.size());
+    for(auto i(index); i < size; i += jtl::next_char_size(str->data, i))
+    {
+      ++count;
+    }
+    return count;
   }
 
   /* behavior::seqable */
@@ -76,13 +99,13 @@ namespace jank::runtime::obj
   /* behavior::sequenceable */
   object_ref persistent_string_sequence::first() const
   {
-    return make_box(str->data[index]);
+    auto const size(jtl::next_char_size(str->data, index));
+    return make_box<character>(str->data.substr(index, size));
   }
 
   persistent_string_sequence_ref persistent_string_sequence::next() const
   {
-    auto n(index);
-    ++n;
+    auto n(index + jtl::next_char_size(str->data, index));
 
     if(n == str->data.size())
     {

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string_sequence.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string_sequence.cpp
@@ -76,6 +76,7 @@ namespace jank::runtime::obj
   /* behavior::countable */
   usize persistent_string_sequence::count() const
   {
+    /* TODO: Cache count if it becomes an issue */
     usize count{};
     auto const size(str->data.size());
     for(auto i(index); i < size; i += jtl::next_char_size(str->data, i))

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string_sequence.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string_sequence.cpp
@@ -117,7 +117,7 @@ namespace jank::runtime::obj
 
   persistent_string_sequence_ref persistent_string_sequence::next_in_place()
   {
-    ++index;
+    index += jtl::next_char_size(str->data, index);
 
     if(index == str->data.size())
     {

--- a/compiler+runtime/src/cpp/jtl/utf8.cpp
+++ b/compiler+runtime/src/cpp/jtl/utf8.cpp
@@ -5,9 +5,9 @@ namespace jtl
   using value_type = utf8_iterator::value_type;
   using size_type = value_type::size_type;
 
-  static size_type next_char_size(immutable_string const &s, size_type const i)
+  size_type next_char_size(immutable_string const &s, size_type const i)
   {
-    auto const c(s[i]);
+    auto const c(static_cast<u8>(s[i]));
     if(c <= 0x7f)
     {
       return 1;

--- a/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
+++ b/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
@@ -35,7 +35,7 @@
     ; clojure.core-test.butlast ; "TODO: port int-array"
     ; clojure.core-test.byte ; TODO: port byte, Expecting whitespace after the last token. due to M.
     ; clojure.core-test.case ; analyze/invalid-case error: Unable to resolve symbol 'of'.
-    ; clojure.core-test.char ; FIXME: Failing unicode character tests.
+    clojure.core-test.char
     clojure.core-test.char-qmark
     ; clojure.core-test.coll-qmark ; TODO: port array-map, TODO: port object-array
     clojure.core-test.comment
@@ -62,7 +62,7 @@
     clojure.core-test.double-qmark
     clojure.core-test.drop
     ; clojure.core-test.drop-last ; "TODO: port int-array"
-    clojure.core-test.drop-while
+    ; clojure.core-test.drop-while ; "TODO: port int-array" /  "TODO: port sequence"
     clojure.core-test.empty
     clojure.core-test.empty-qmark
     ; clojure.core-test.eq ; TODO: port sorted-map-by, not yet implemented: sorted-set-by
@@ -118,14 +118,14 @@
     clojure.core-test.nan-qmark
     clojure.core-test.neg-int-qmark
     clojure.core-test.neg-qmark
-    clojure.core-test.next
+    ; clojure.core-test.next ; "TODO: port int-array"
     clojure.core-test.nfirst
     clojure.core-test.nil-qmark
     clojure.core-test.nnext
     clojure.core-test.not
     ; clojure.core-test.not_empty ; libc++abi: terminating due to uncaught exception of type jank::runtime::oref<jank::runtime::object>.
     ; clojure.core-test.not-eq ; TODO: port sorted-map-by, not yet implemented: sorted-set-by
-    clojure.core-test.nth
+    ; clojure.core-test.nth ; "TODO: port int-array"
     clojure.core-test.nthnext
     clojure.core-test.nthrest
     ; clojure.core-test.num ; TODO: port short, TODO: port byte & TODO: port long.


### PR DESCRIPTION
Depends on https://github.com/jank-lang/clojure-test-suite/pull/946 for tests to pass.

```clojure
% jank repl
user=> (seq "𐅧")
(\𐅧)
user=> (first (seq "𐅧"))
\𐅧
user=> (seq "𐅧 𐅧 𐅧")
(\𐅧 \space \𐅧 \space \𐅧)
user=> (count (seq "𐅧 𐅧 𐅧"))
5
user=> (map str (seq "𐅧 𐅧 𐅧"))
("𐅧" " " "𐅧" " " "𐅧")
user=> (map (comp count str) (seq "𐅧 𐅧 𐅧"))
(4 1 4 1 4)
user=> (count "𐅧 𐅧 𐅧")
14
user=> (seq "👋 😃")
(\👋 \space \😃)
user=> (nth (seq "👋 😃") 0)
\👋
user=> (nth (seq "👋 😃") 2)
\😃
user=> (apply str (seq "👋 😃"))
"👋 😃"
```