### PR TITLE
Plan all visit changes

### DIFF
--- a/compiler+runtime/src/cpp/clojure/data/json_native.cpp
+++ b/compiler+runtime/src/cpp/clojure/data/json_native.cpp
@@ -41,6 +41,7 @@ namespace clojure::data::json_native
 
   static nlohmann::json write(object_ref const o, write_options const &opts)
   {
+    /* TODO: Port visit_object: Not using all objects. */
     return visit_object(
       [&](auto const typed_o) -> nlohmann::json {
         using T = typename decltype(typed_o)::value_type;

--- a/compiler+runtime/src/cpp/jank/analyze/pass/strip_source_meta.cpp
+++ b/compiler+runtime/src/cpp/jank/analyze/pass/strip_source_meta.cpp
@@ -27,6 +27,7 @@ namespace jank::analyze::pass
           }
           else if constexpr(jtl::is_same<T, expr::primitive_literal>)
           {
+            /* TODO: Port visit_object: metadatable. */
             runtime::visit_object(
               [](auto const typed_obj) {
                 using O = typename decltype(typed_obj)::value_type;

--- a/compiler+runtime/src/cpp/jank/analyze/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/analyze/processor.cpp
@@ -2007,6 +2007,7 @@ namespace jank::analyze
       {
         auto arity_list_obj(it.first().unwrap());
 
+        /* TODO: Port visit_object: sequenceable. */
         auto const err(runtime::visit_object(
           [&](auto const typed_arity_list) -> jtl::result<void, error_ref> {
             using T = typename decltype(typed_arity_list)::value_type;
@@ -4780,6 +4781,7 @@ namespace jank::analyze
                      jtl::option<expr::function_context_ref> const &fn_ctx,
                      bool const needs_box)
   {
+    /* TODO: Port visit_object: sequential. */
     return runtime::visit_object(
       [&](auto const typed_o) -> processor::expression_result {
         using T = typename decltype(typed_o)::value_type;

--- a/compiler+runtime/src/cpp/jank/codegen/cpp_processor.cpp
+++ b/compiler+runtime/src/cpp/jank/codegen/cpp_processor.cpp
@@ -239,6 +239,7 @@ namespace jank::codegen
 
     static void gen_constant(object_ref const o, jtl::string_builder &buffer, bool const is_boxed)
     {
+      /* TODO: Port visit_object: seqable. */
       visit_object(
         [&](auto const typed_o) {
           using T = typename decltype(typed_o)::value_type;

--- a/compiler+runtime/src/cpp/jank/hash.cpp
+++ b/compiler+runtime/src/cpp/jank/hash.cpp
@@ -167,6 +167,7 @@ namespace jank::hash
 
   u32 ordered(runtime::oref<runtime::object> const sequence)
   {
+    /* TODO: Port visit_object: sequenceable. */
     return runtime::visit_object(
       [](auto const typed_sequence) -> u32 {
         using T = typename decltype(typed_sequence)::value_type;
@@ -192,6 +193,7 @@ namespace jank::hash
 
   u32 unordered(runtime::object_ref const sequence)
   {
+    /* TODO: Port visit_object: sequenceable. */
     return runtime::visit_object(
       [](auto const typed_sequence) -> u32 {
         using T = typename decltype(typed_sequence)::value_type;

--- a/compiler+runtime/src/cpp/jank/read/parse.cpp
+++ b/compiler+runtime/src/cpp/jank/read/parse.cpp
@@ -600,6 +600,7 @@ namespace jank::read::parse
       return error::parse_invalid_meta_hint_value({ start_token.start, latest_token.end });
     }
 
+    /* TODO: Port visit_object: Not using all objects. */
     auto meta_result(visit_object(
       [&](auto const typed_val) -> processor::object_result {
         using T = typename jtl::decay_t<decltype(typed_val)>::value_type;
@@ -645,6 +646,7 @@ namespace jank::read::parse
                                                    "Value missing after hint.");
     }
 
+    /* TODO: Port visit_object: metadatable. */
     return visit_object(
       [&](auto const typed_val) -> processor::object_result {
         using T = typename jtl::decay_t<decltype(typed_val)>::value_type;

--- a/compiler+runtime/src/cpp/jank/runtime/core.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core.cpp
@@ -73,6 +73,7 @@ namespace jank::runtime
 
   obj::symbol_ref to_unqualified_symbol(object_ref const o)
   {
+    /* TODO: Port visit_object: Not all types. */
     return runtime::visit_object(
       [&](auto const typed_o) -> obj::symbol_ref {
         using T = typename jtl::decay_t<decltype(typed_o)>::value_type;
@@ -129,6 +130,7 @@ namespace jank::runtime
   {
     auto const out{ get_stdout() };
 
+    /* TODO: Port visit_object: sequenceable. */
     visit_object(
       [&](auto const typed_args) {
         using T = typename jtl::decay_t<decltype(typed_args)>::value_type;
@@ -166,6 +168,7 @@ namespace jank::runtime
   {
     auto const out{ get_stdout() };
 
+    /* TODO: Port visit_object: sequenceable. */
     visit_object(
       [&](auto const typed_more) {
         using T = typename jtl::decay_t<decltype(typed_more)>::value_type;
@@ -200,6 +203,7 @@ namespace jank::runtime
   {
     auto const out{ get_stdout() };
 
+    /* TODO: Port visit_object: sequenceable. */
     visit_object(
       [&](auto const typed_args) {
         using T = typename jtl::decay_t<decltype(typed_args)>::value_type;
@@ -229,6 +233,7 @@ namespace jank::runtime
   {
     auto const out{ get_stdout() };
 
+    /* TODO: Port visit_object: sequenceable. */
     visit_object(
       [&](auto const typed_args) {
         using T = typename jtl::decay_t<decltype(typed_args)>::value_type;
@@ -461,6 +466,7 @@ namespace jank::runtime
 
   bool is_named(object_ref const o)
   {
+    /* TODO: Port visit_object: nameable. */
     return visit_object(
       [](auto const typed_o) {
         using T = typename jtl::decay_t<decltype(typed_o)>::value_type;
@@ -472,6 +478,7 @@ namespace jank::runtime
 
   jtl::immutable_string name(object_ref const o)
   {
+    /* TODO: Port visit_object: nameable. */
     return visit_object(
       [](auto const typed_o) -> jtl::immutable_string {
         using T = typename jtl::decay_t<decltype(typed_o)>::value_type;
@@ -494,6 +501,7 @@ namespace jank::runtime
 
   object_ref namespace_(object_ref const o)
   {
+    /* TODO: Port visit_object: nameable. */
     return visit_object(
       [](auto const typed_o) -> object_ref {
         using T = typename jtl::decay_t<decltype(typed_o)>::value_type;
@@ -572,6 +580,7 @@ namespace jank::runtime
 
   uhash to_hash(object_ref const o)
   {
+    /* TODO: Port visit_object: All types. */
     return visit_object([=](auto const typed_o) -> uhash { return typed_o.to_hash(); }, o);
   }
 
@@ -663,6 +672,7 @@ namespace jank::runtime
 
   object_ref deref(object_ref const o)
   {
+    /* TODO: Port visit_object: derefable. */
     return visit_object(
       [=](auto const typed_o) -> object_ref {
         using T = typename jtl::decay_t<decltype(typed_o)>::value_type;
@@ -682,6 +692,7 @@ namespace jank::runtime
 
   bool is_realized(object_ref const o)
   {
+    /* TODO: Port visit_object: realizable. */
     return visit_object(
       [=](auto const typed_o) -> bool {
         using T = typename jtl::decay_t<decltype(typed_o)>::value_type;

--- a/compiler+runtime/src/cpp/jank/runtime/core/equal.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/equal.cpp
@@ -27,6 +27,7 @@ namespace jank::runtime
       return false;
     }
 
+    /* TODO: Port visit_object: All types. */
     return visit_object([&](auto const typed_lhs) { return typed_lhs.equal(rhs); }, lhs);
   }
 

--- a/compiler+runtime/src/cpp/jank/runtime/core/math.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/math.cpp
@@ -679,6 +679,7 @@ namespace jank::runtime
 
   obj::big_integer_ref to_big_integer(object_ref const o)
   {
+    /* TODO: Port visit_object: Not all types. */
     return visit_object(
       [&](auto const typed_o) -> obj::big_integer_ref {
         using T = typename decltype(typed_o)::value_type;
@@ -720,6 +721,7 @@ namespace jank::runtime
 
   obj::big_decimal_ref to_big_decimal(object_ref const o)
   {
+    /* TODO: Port visit_object: Not all types. */
     return visit_object(
       [&](auto const typed_o) -> obj::big_decimal_ref {
         using T = typename jtl::decay_t<decltype(typed_o)>::value_type;

--- a/compiler+runtime/src/cpp/jank/runtime/core/meta.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/meta.cpp
@@ -17,6 +17,7 @@ namespace jank::runtime
       return m;
     }
 
+    /* TODO: Port visit_object: metadatable. */
     return visit_object(
       [](auto const typed_m) -> object_ref {
         using T = typename jtl::decay_t<decltype(typed_m)>::value_type;
@@ -35,6 +36,7 @@ namespace jank::runtime
 
   object_ref with_meta(object_ref const o, object_ref const m)
   {
+    /* TODO: Port visit_object: metadatable. */
     return visit_object(
       [&o](auto const typed_o, object_ref const m) -> object_ref {
         using T = typename jtl::decay_t<decltype(typed_o)>::value_type;
@@ -61,6 +63,7 @@ namespace jank::runtime
    * is done with the meta. */
   object_ref with_meta_graceful(object_ref const o, object_ref const m)
   {
+    /* TODO: Port visit_object: metadatable. */
     return visit_object(
       [](auto const typed_o, object_ref const m) -> object_ref {
         using T = typename jtl::decay_t<decltype(typed_o)>::value_type;
@@ -80,6 +83,7 @@ namespace jank::runtime
 
   object_ref reset_meta(object_ref const o, object_ref const m)
   {
+    /* TODO: Port visit_object: metadatable. */
     return visit_object(
       [](auto const typed_o, object_ref const m) -> object_ref {
         using T = typename jtl::decay_t<decltype(typed_o)>::value_type;

--- a/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
@@ -26,6 +26,7 @@ namespace jank::runtime
 {
   bool is_empty(object_ref const o)
   {
+    /* TODO: Port visit_object: countable, seqable. */
     return visit_object(
       [=](auto const typed_o) -> bool {
         using T = typename jtl::decay_t<decltype(typed_o)>::value_type;
@@ -53,6 +54,7 @@ namespace jank::runtime
 
   bool is_seq(object_ref const o)
   {
+    /* TODO: Port visit_object: sequenceable. */
     return visit_object(
       [=](auto const typed_o) -> bool {
         using T = typename jtl::decay_t<decltype(typed_o)>::value_type;
@@ -71,6 +73,7 @@ namespace jank::runtime
 
   bool is_sequential(object_ref const o)
   {
+    /* TODO: Port visit_object: sequential. */
     return visit_object(
       [=](auto const typed_o) -> bool {
         using T = typename jtl::decay_t<decltype(typed_o)>::value_type;
@@ -82,6 +85,7 @@ namespace jank::runtime
 
   bool is_collection(object_ref const o)
   {
+    /* TODO: Port visit_object: collection_like. */
     return visit_object(
       [=](auto const typed_o) -> bool {
         using T = typename jtl::decay_t<decltype(typed_o)>::value_type;
@@ -112,6 +116,7 @@ namespace jank::runtime
 
   bool is_associative(object_ref const o)
   {
+    /* TODO: Port visit_object: associatively_writable. */
     return visit_object(
       [=](auto const typed_o) -> bool {
         using T = typename jtl::decay_t<decltype(typed_o)>::value_type;
@@ -129,6 +134,7 @@ namespace jank::runtime
 
   bool is_counted(object_ref const o)
   {
+    /* TODO: Port visit_object: countable. */
     return visit_object(
       [=](auto const typed_o) -> bool {
         using T = typename jtl::decay_t<decltype(typed_o)>::value_type;
@@ -140,6 +146,7 @@ namespace jank::runtime
 
   bool is_transientable(object_ref const o)
   {
+    /* TODO: Port visit_object: transientable. */
     return visit_object(
       [=](auto const typed_o) -> bool {
         using T = typename jtl::decay_t<decltype(typed_o)>::value_type;
@@ -157,6 +164,7 @@ namespace jank::runtime
 
   object_ref transient(object_ref const o)
   {
+    /* TODO: Port visit_object: transientable. */
     return visit_object(
       [=](auto const typed_o) -> object_ref {
         using T = typename jtl::decay_t<decltype(typed_o)>::value_type;
@@ -176,6 +184,7 @@ namespace jank::runtime
 
   object_ref persistent(object_ref const o)
   {
+    /* TODO: Port visit_object: persistentable. */
     return visit_object(
       [=](auto const typed_o) -> object_ref {
         using T = typename jtl::decay_t<decltype(typed_o)>::value_type;
@@ -195,6 +204,7 @@ namespace jank::runtime
 
   object_ref conj_in_place(object_ref const coll, object_ref const o)
   {
+    /* TODO: Port visit_object: conjable_in_place. */
     return visit_object(
       [](auto const typed_coll, auto const &o) -> object_ref {
         using T = typename jtl::decay_t<decltype(typed_coll)>::value_type;
@@ -231,6 +241,7 @@ namespace jank::runtime
 
   object_ref assoc_in_place(object_ref const coll, object_ref const k, object_ref const v)
   {
+    /* TODO: Port visit_object: associatively_writable_in_place. */
     return visit_object(
       [](auto const typed_coll, auto const &k, auto const &v) -> object_ref {
         using T = typename jtl::decay_t<decltype(typed_coll)>::value_type;
@@ -252,6 +263,7 @@ namespace jank::runtime
 
   object_ref dissoc_in_place(object_ref const coll, object_ref const k)
   {
+    /* TODO: Port visit_object: associatively_writable_in_place. */
     return visit_object(
       [](auto const typed_coll, auto const &k) -> object_ref {
         using T = typename jtl::decay_t<decltype(typed_coll)>::value_type;
@@ -278,6 +290,7 @@ namespace jank::runtime
 
   object_ref seq(object_ref const s)
   {
+    /* TODO: Port visit_object: seqable. */
     return visit_object(
       [](auto const typed_s) -> object_ref {
         using T = typename jtl::decay_t<decltype(typed_s)>::value_type;
@@ -306,6 +319,7 @@ namespace jank::runtime
 
   object_ref fresh_seq(object_ref const s)
   {
+    /* TODO: Port visit_object: seqable. */
     return visit_object(
       [](auto const typed_s) -> object_ref {
         using T = typename jtl::decay_t<decltype(typed_s)>::value_type;
@@ -334,6 +348,7 @@ namespace jank::runtime
 
   object_ref first(object_ref const s)
   {
+    /* TODO: Port visit_object: seqable. */
     return visit_object(
       [](auto const typed_s) -> object_ref {
         using T = typename jtl::decay_t<decltype(typed_s)>::value_type;
@@ -371,6 +386,7 @@ namespace jank::runtime
 
   object_ref next(object_ref const s)
   {
+    /* TODO: Port visit_object: seqable. */
     return visit_object(
       [](auto const typed_s) -> object_ref {
         using T = typename jtl::decay_t<decltype(typed_s)>::value_type;
@@ -403,6 +419,7 @@ namespace jank::runtime
 
   object_ref next_in_place(object_ref const s)
   {
+    /* TODO: Port visit_object: sequenceable. */
     return visit_object(
       [](auto const typed_s) -> object_ref {
         using T = typename jtl::decay_t<decltype(typed_s)>::value_type;
@@ -497,6 +514,7 @@ namespace jank::runtime
 
   object_ref conj(object_ref const s, object_ref const o)
   {
+    /* TODO: Port visit_object: conjable. */
     return visit_object(
       [&](auto const typed_s) -> object_ref {
         using T = typename jtl::decay_t<decltype(typed_s)>::value_type;
@@ -539,6 +557,7 @@ namespace jank::runtime
 
   object_ref assoc(object_ref const m, object_ref const k, object_ref const v)
   {
+    /* TODO: Port visit_object: associatively_writable. */
     return visit_object(
       [&](auto const typed_m) -> object_ref {
         using T = typename jtl::decay_t<decltype(typed_m)>::value_type;
@@ -558,6 +577,7 @@ namespace jank::runtime
 
   object_ref dissoc(object_ref const m, object_ref const k)
   {
+    /* TODO: Port visit_object: associatively_writable. */
     return visit_object(
       [&](auto const typed_m) -> object_ref {
         using T = typename jtl::decay_t<decltype(typed_m)>::value_type;
@@ -647,6 +667,7 @@ namespace jank::runtime
 
   object_ref merge(object_ref const m, object_ref const other)
   {
+    /* TODO: Port visit_object: associatively_writable. */
     return visit_object(
       [](auto const typed_m, object_ref const other) -> object_ref {
         using T = typename jtl::decay_t<decltype(typed_m)>::value_type;
@@ -688,6 +709,7 @@ namespace jank::runtime
     {
       return m;
     }
+    /* TODO: Port visit_object: associatively_writable. */
     return visit_object(
       [](auto const typed_m, auto const &other) -> object_ref {
         using T = typename jtl::decay_t<decltype(typed_m)>::value_type;
@@ -751,6 +773,7 @@ namespace jank::runtime
       return o;
     }
 
+    /* TODO: Port visit_object: indexable, seqable, sequential. */
     return visit_object(
       [&](auto const typed_o) -> object_ref {
         using T = typename jtl::decay_t<decltype(typed_o)>::value_type;
@@ -789,6 +812,7 @@ namespace jank::runtime
       return fallback;
     }
 
+    /* TODO: Port visit_object: indexable, seqable, sequential. */
     return visit_object(
       [&](auto const typed_o) -> object_ref {
         using T = typename jtl::decay_t<decltype(typed_o)>::value_type;
@@ -826,6 +850,7 @@ namespace jank::runtime
       return o;
     }
 
+    /* TODO: Port visit_object: stackable. */
     return visit_object(
       [&](auto const typed_o) -> object_ref {
         using T = typename jtl::decay_t<decltype(typed_o)>::value_type;
@@ -850,6 +875,7 @@ namespace jank::runtime
       return o;
     }
 
+    /* TODO: Port visit_object: stackable. */
     return visit_object(
       [&](auto const typed_o) -> object_ref {
         using T = typename jtl::decay_t<decltype(typed_o)>::value_type;
@@ -869,6 +895,7 @@ namespace jank::runtime
 
   object_ref empty(object_ref const o)
   {
+    /* TODO: Port visit_object: collection_like. */
     return visit_object(
       [=](auto const typed_o) -> object_ref {
         using T = typename jtl::decay_t<decltype(typed_o)>::value_type;
@@ -945,6 +972,7 @@ namespace jank::runtime
       return 0;
     }
 
+    /* TODO: Port visit_object: countable, seqable. */
     return visit_object(
       [&](auto const typed_s) -> usize {
         using T = typename jtl::decay_t<decltype(typed_s)>::value_type;
@@ -1059,6 +1087,7 @@ namespace jank::runtime
 
   object_ref chunk_first(object_ref const o)
   {
+    /* TODO: Port visit_object: chunkable. */
     return visit_object(
       [=](auto const typed_o) -> object_ref {
         using T = typename jtl::decay_t<decltype(typed_o)>::value_type;
@@ -1076,6 +1105,7 @@ namespace jank::runtime
 
   object_ref chunk_next(object_ref const o)
   {
+    /* TODO: Port visit_object: chunkable. */
     return visit_object(
       [=](auto const typed_o) -> object_ref {
         using T = typename jtl::decay_t<decltype(typed_o)>::value_type;
@@ -1093,6 +1123,7 @@ namespace jank::runtime
 
   object_ref chunk_rest(object_ref const o)
   {
+    /* TODO: Port visit_object: chunkable. */
     return visit_object(
       [=](auto const typed_o) -> object_ref {
         using T = typename jtl::decay_t<decltype(typed_o)>::value_type;
@@ -1120,6 +1151,7 @@ namespace jank::runtime
 
   bool is_chunked_seq(object_ref const o)
   {
+    /* TODO: Port visit_object: chunkable. */
     return visit_object(
       [=](auto const typed_o) -> bool {
         using T = typename jtl::decay_t<decltype(typed_o)>::value_type;

--- a/compiler+runtime/src/cpp/jank/runtime/obj/chunked_cons.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/chunked_cons.cpp
@@ -42,6 +42,7 @@ namespace jank::runtime::obj
 
   object_ref chunked_cons::first() const
   {
+    /* TODO: Port visit_object: chunk_like. */
     return visit_object(
       [&](auto const typed_head) -> object_ref {
         using T = typename decltype(typed_head)::value_type;
@@ -61,6 +62,7 @@ namespace jank::runtime::obj
 
   object_ref chunked_cons::next() const
   {
+    /* TODO: Port visit_object: chunk_like. */
     return visit_object(
       [&](auto const typed_head) -> object_ref {
         using T = typename decltype(typed_head)::value_type;
@@ -89,6 +91,7 @@ namespace jank::runtime::obj
       return {};
     }
 
+    /* TODO: Port visit_object: sequenceable. */
     return visit_object(
       [&](auto const typed_tail) -> chunked_cons_ref {
         using T = typename jtl::decay_t<decltype(typed_tail)>::value_type;
@@ -109,6 +112,7 @@ namespace jank::runtime::obj
 
   chunked_cons_ref chunked_cons::next_in_place()
   {
+    /* TODO: Port visit_object: chunk_like. */
     return visit_object(
       [&](auto const typed_head) -> chunked_cons_ref {
         using T = typename decltype(typed_head)::value_type;
@@ -132,6 +136,7 @@ namespace jank::runtime::obj
 
   object_ref chunked_cons::chunked_first() const
   {
+    /* TODO: Port visit_object: chunk_like. */
     return visit_object(
       [&](auto const typed_head) -> object_ref {
         using T = typename decltype(typed_head)::value_type;

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_list.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_list.cpp
@@ -48,6 +48,7 @@ namespace jank::runtime::obj
       return make_box<persistent_list>();
     }
 
+    /* TODO: Port visit_object: sequenceable. */
     return visit_object(
       [](auto const typed_s) -> persistent_list_ref {
         using T = typename decltype(typed_s)::value_type;

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_sorted_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_sorted_map.cpp
@@ -38,6 +38,7 @@ namespace jank::runtime::obj
 
   persistent_sorted_map_ref persistent_sorted_map::create_from_seq(object_ref const seq)
   {
+    /* TODO: Port visit_object: seqable. */
     return make_box<persistent_sorted_map>(visit_object(
       [](auto const typed_seq) -> persistent_sorted_map::value_type {
         using T = typename jtl::decay_t<decltype(typed_seq)>::value_type;

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_vector.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_vector.cpp
@@ -48,6 +48,7 @@ namespace jank::runtime::obj
       return make_box<persistent_vector>();
     }
 
+    /* TODO: Port visit_object: seqable. */
     return visit_object(
       [](auto const typed_s) -> persistent_vector_ref {
         using T = typename decltype(typed_s)::value_type;


### PR DESCRIPTION
```
visit_object
  sequenceable: 13
  seqable: 10
  metadatable: 6
  not using all objects: 5
  chunk_like: 4
  chunkable: 4
  sequential: 4
  associatively_writable: 4
  associatively_writable_in_place: 3
  countable: 3
  nameable: 3
  all types: 2 (equal, hash)
  collection_like: 2
  indexable: 2
  stackable: 2
  transientable: 2
  sequenceable_in_place: 1
  persistentable: 1
  conjable: 1
  conjable_in_place: 1
  derefable: 1
  realizable: 1
```