### PR TITLE
Enable `clojure.string-test.split-lines`

### DIFF
--- a/compiler+runtime/src/cpp/clojure/string_native.cpp
+++ b/compiler+runtime/src/cpp/clojure/string_native.cpp
@@ -400,17 +400,21 @@ namespace clojure::string_native
       std::sregex_token_iterator iter(search_str.begin(), search_str.end(), regex, -1);
       std::sregex_token_iterator const end;
 
-      for(auto peek(iter); iter != end; ++iter)
+      for(; iter != end; ++iter)
       {
-        auto const substr(iter->str());
+        vec.push_back(make_box<obj::persistent_string>(iter->str()));
+      }
 
-        if(++peek == end && substr.empty())
+      /* Discard all trailing empty strings to match java.lang.String/split behavior. */
+      auto n(vec.size());
+      for(; n > 0; --n)
+      {
+        if(!expect_object<obj::persistent_string>(vec[n - 1])->data.empty())
         {
           break;
         }
-
-        vec.push_back(make_box<obj::persistent_string>(substr));
       }
+      vec.take(n);
     }
 
     return make_box<obj::persistent_vector>(vec.persistent());

--- a/compiler+runtime/src/cpp/clojure/string_native.cpp
+++ b/compiler+runtime/src/cpp/clojure/string_native.cpp
@@ -395,17 +395,32 @@ namespace clojure::string_native
 
   obj::persistent_vector_ref split(jtl::immutable_string const &s, obj::re_pattern_ref const re)
   {
-    auto const regex(re->regex);
-
-    std::string const search_str{ s.c_str() };
-
     detail::native_transient_vector vec;
-    std::sregex_token_iterator iter(search_str.begin(), search_str.end(), regex, -1);
-    std::sregex_token_iterator const end;
 
-    for(; iter != end; ++iter)
+    if(s.empty())
     {
-      vec.push_back(make_box<obj::persistent_string>(iter->str()));
+      vec.push_back(make_box<obj::persistent_string>(s));
+    }
+    else
+    {
+      auto const regex(re->regex);
+
+      std::string const search_str{ s.c_str() };
+
+      std::sregex_token_iterator iter(search_str.begin(), search_str.end(), regex, -1);
+      std::sregex_token_iterator const end;
+
+      for(auto peek(iter); iter != end; ++iter)
+      {
+        auto const substr(iter->str());
+
+        if(++peek == end && substr.empty())
+        {
+          break;
+        }
+
+        vec.push_back(make_box<obj::persistent_string>(substr));
+      }
     }
 
     return make_box<obj::persistent_vector>(vec.persistent());

--- a/compiler+runtime/src/cpp/jank/analyze/cpp_util.cpp
+++ b/compiler+runtime/src/cpp/jank/analyze/cpp_util.cpp
@@ -691,6 +691,12 @@ namespace jank::analyze::cpp_util
             resolve_scope("jank.runtime.obj.persistent_hash_map_ref").expect_ok()) };
           return type;
         }
+      case jank::runtime::object_type::re_pattern:
+        {
+          static auto const type{ Cpp::GetTypeFromScope(
+            resolve_scope("jank.runtime.obj.re_pattern_ref").expect_ok()) };
+          return type;
+        }
       case jank::runtime::object_type::var:
         return var_type();
       default:

--- a/compiler+runtime/src/jank/clojure/string.jank
+++ b/compiler+runtime/src/jank/clojure/string.jank
@@ -175,7 +175,7 @@
 (defn split-lines
   "Splits s on \\n or \\r\\n. Trailing empty lines are not returned."
   [s]
-  (cpp/clojure.string_native.split s (cpp/jank.runtime.re_pattern "\\r?\\n")))
+  (cpp/clojure.string_native.split s #"\r?\n"))
 
 (defn trim
   "Removes whitespace from both ends of string."

--- a/compiler+runtime/src/jank/clojure/string.jank
+++ b/compiler+runtime/src/jank/clojure/string.jank
@@ -175,7 +175,7 @@
 (defn split-lines
   "Splits s on \\n or \\r\\n. Trailing empty lines are not returned."
   [s]
-  (cpp/clojure.string_native.split s #"\r?\n"))
+  (cpp/clojure.string_native.split s (cpp/jank.runtime.re_pattern "\\r?\\n")))
 
 (defn trim
   "Removes whitespace from both ends of string."

--- a/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
+++ b/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
@@ -235,6 +235,7 @@
     clojure.string-test.lower-case
     clojure.string-test.replace
     clojure.string-test.reverse
+    clojure.string-test.split-lines
     clojure.string-test.starts-with-qmark
     clojure.string-test.upper-case
   ])


### PR DESCRIPTION
Depends on https://github.com/jank-lang/clojure-test-suite/pull/948 for tests to pass.

```clojure
% ./pass-test 
warning: 'sleep' already referred to #'clojure.core/sleep in namespace 'clojure.core-test.portability' but has been replaced by #'clojure.core-test.portability/sleep

Testing clojure.string-test.split-lines

Ran 1 tests containing 15 assertions.
0 failures, 0 errors.
:clojure-test-suite-successful
```