### PR TITLE
Enable `clojure.core-test.int`

### DIFF
--- a/compiler+runtime/src/cpp/jank/codegen/cpp_processor.cpp
+++ b/compiler+runtime/src/cpp/jank/codegen/cpp_processor.cpp
@@ -176,7 +176,7 @@ namespace jank::codegen
         }
         else if(runtime::detail::is_tagged_small_int(ptr))
         {
-          fmt_str = util::format("{}{ {} }",
+          fmt_str = util::format("{}{ static_cast<jtl::i32>({}) }",
                                  get_qualified_type_name(type),
                                  runtime::detail::as_integer(ptr));
         }

--- a/compiler+runtime/src/cpp/jank/codegen/cpp_processor.cpp
+++ b/compiler+runtime/src/cpp/jank/codegen/cpp_processor.cpp
@@ -176,9 +176,16 @@ namespace jank::codegen
         }
         else if(runtime::detail::is_tagged_small_int(ptr))
         {
-          fmt_str = util::format("{}{ static_cast<jtl::i32>({}) }",
-                                 get_qualified_type_name(type),
-                                 runtime::detail::as_integer(ptr));
+          auto const i(runtime::detail::as_integer(ptr));
+          if(i == std::numeric_limits<i32>::min())
+          {
+            fmt_str
+              = util::format("{}{ static_cast<jtl::i32>({}) }", get_qualified_type_name(type), i);
+          }
+          else
+          {
+            fmt_str = util::format("{}{ {} }", get_qualified_type_name(type), i);
+          }
         }
         else if(runtime::detail::is_tagged_small_real(ptr))
         {

--- a/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
+++ b/compiler+runtime/test/bash/clojure-test-suite/src/jank_test/run_clojure_test_suite.cljc
@@ -88,7 +88,7 @@
     clojure.core-test.identical-qmark
     clojure.core-test.ifn-qmark
     clojure.core-test.inc
-    ; clojure.core-test.int ; FIXME: Codegen bug.
+    clojure.core-test.int
     clojure.core-test.int-qmark
     clojure.core-test.integer-qmark
     clojure.core-test.interleave


### PR DESCRIPTION
Resolves the following codegen error:

```cpp
In file included from <<< inputs >>>:1:
/home/chris/repos/jank/compiler+runtime/src/jank/clojure/core.jank:3495:16: error: call to constructor of 'jank::runtime::obj::small_integer_ref' (aka 'oref<small_integer>') is ambiguous
 3495 | auto const v89(jank::runtime::obj::small_integer_ref{ -2147483648 });
      |                ^                                    ~~~~~~~~~~~~~~~
/home/chris/repos/jank/compiler+runtime/include/cpp/jank/runtime/oref.hpp:1557:5: note: candidate constructor
 1557 |     oref(i32 const data) noexcept
      |     ^
/home/chris/repos/jank/compiler+runtime/include/cpp/jank/runtime/oref.hpp:1562:5: note: candidate constructor
 1562 |     oref(i64 const data) noexcept
      |     ^
```