### PR TITLE
WIP POC arrays

### DIFF
--- a/compiler+runtime/CMakeLists.txt
+++ b/compiler+runtime/CMakeLists.txt
@@ -580,6 +580,7 @@ add_library(
   src/cpp/jank/runtime/obj/uuid.cpp
   src/cpp/jank/runtime/obj/inst.cpp
   src/cpp/jank/runtime/obj/opaque_box.cpp
+  src/cpp/jank/runtime/obj/array.cpp
   src/cpp/jank/runtime/obj/character.cpp
   src/cpp/jank/runtime/obj/big_integer.cpp
   src/cpp/jank/runtime/obj/big_decimal.cpp

--- a/compiler+runtime/include/cpp/jank/runtime/obj/array.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/array.hpp
@@ -1,0 +1,182 @@
+#pragma once
+
+#include <jtl/option.hpp>
+#include <jtl/primitive.hpp>
+
+#include <jank/runtime/object.hpp>
+#include <jank/runtime/core/make_box.hpp>
+#include <jank/runtime/obj/opaque_box.hpp>
+
+namespace jank::runtime::obj
+{
+  enum class element_type : u8
+  {
+    boolean,
+    character,
+    f32,
+    f64,
+    i16,
+    i32,
+    i64,
+    object,
+    u8,
+  };
+
+  using array_box_ref = oref<struct array_box>;
+
+  template <typename T>
+  struct array : object
+  {
+    static constexpr object_type obj_type{ object_type::array_box };
+    static constexpr object_behavior obj_behaviors{ object_behavior::get };
+    static constexpr bool pointer_free{ false };
+
+    array(element_type const etype, usize const size)
+      : object{ obj_type, obj_behaviors }
+      , etype{ etype }
+      , size{ size }
+      , data{ new(UseGC) T[size] }
+    {
+    }
+
+    array(element_type const etype, usize const size, T init_value)
+      : object{ obj_type, obj_behaviors }
+      , etype{ etype }
+      , size{ size }
+      , data{ new(UseGC) T[size] }
+    {
+      for(usize i{}; i < size; ++i)
+      {
+        data[i] = init_value;
+      }
+    }
+
+    T &operator[](std::size_t const i)
+    {
+      if(i > size)
+      {
+        throw std::runtime_error{ "boom" };
+      }
+      return data[i];
+    }
+
+    T operator[](std::size_t const i) const
+    {
+      if(i > size)
+      {
+        throw std::runtime_error{ "boom" };
+      }
+      return data[i];
+    }
+
+    T at(std::size_t i) const
+    {
+      if(i > size)
+      {
+        throw std::runtime_error{ "boom" };
+      }
+      return data[i];
+    }
+
+    /* behavior::get */
+    using object::get;
+
+    object_ref get(object_ref const key) const override
+    {
+      auto const n(static_cast<usize>(key.to_integer()));
+      return make_box(operator[](n));
+    }
+
+    object_ref get(object_ref const key, object_ref const fallback)
+    {
+      auto const n(static_cast<usize>(key.to_integer()));
+      if(n > size)
+      {
+        return fallback;
+      }
+      return make_box(operator[](n));
+    }
+
+    bool contains(object_ref const key) const override
+    {
+      auto const n(static_cast<usize>(key.to_integer()));
+      return n < size;
+    }
+
+    array_box_ref into_object()
+    {
+      return reinterpret_cast<array_box *>(this);
+    }
+
+    element_type etype;
+    usize size;
+    jtl::immutable_string canonical_type{};
+    jtl::ptr<T> data{};
+  };
+
+  template <typename T>
+  using array_ref = oref<struct array<T>>;
+
+  using bool_array_ref = array_ref<bool>;
+  using char_array_ref = array_ref<char>;
+  using f32_array_ref = array_ref<f32>;
+  using f64_array_ref = array_ref<f64>;
+  using i16_array_ref = array_ref<i16>;
+  using i32_array_ref = array_ref<i32>;
+  using i64_array_ref = array_ref<i64>;
+  using object_array_ref = array_ref<object_ref>;
+  using u8_array_ref = array_ref<u8>;
+
+  struct array_box : object
+  {
+    static constexpr object_type obj_type{ object_type::array_box };
+    static constexpr object_behavior obj_behaviors{ object_behavior::get };
+    static constexpr bool pointer_free{ false };
+
+    object_ref operator[](std::size_t const i) const;
+
+    array<bool> *booleans();
+    array<char> *chars();
+    array<f32> *floats();
+    array<f64> *doubles();
+    array<i16> *shorts();
+    array<i32> *ints();
+    array<i64> *longs();
+    array<object_ref> *objects();
+    array<u8> *bytes();
+
+    /* behavior::countable */
+    usize count() const;
+
+    /* behavior::get */
+    using object::get;
+    object_ref get(object_ref const key) const override;
+    object_ref get(object_ref const key, object_ref const fallback) const override;
+    bool contains(object_ref const key) const override;
+
+    element_type etype;
+    usize size;
+    jtl::immutable_string canonical_type{};
+    jtl::ptr<void> data{};
+  };
+
+  element_type get_element_type(object_ref const o);
+
+  bool_array_ref boolean_array(u64 const size);
+  bool_array_ref boolean_array(u64 const size, bool const init);
+  char_array_ref char_array(u64 const size);
+  char_array_ref char_array(u64 const size, char const init);
+  f32_array_ref float_array(u64 const size);
+  f32_array_ref float_array(u64 const size, f32 const init);
+  f64_array_ref double_array(u64 const size);
+  f64_array_ref double_array(u64 const size, f64 const init);
+  i16_array_ref short_array(u64 const size);
+  i16_array_ref short_array(u64 const size, i16 const init);
+  i32_array_ref int_array(u64 const size);
+  i32_array_ref int_array(u64 const size, i32 const init);
+  i64_array_ref long_array(u64 const size);
+  i64_array_ref long_array(u64 const size, i64 const init);
+  object_array_ref object_array(u64 const size);
+  u8_array_ref byte_array(u64 const size);
+  u8_array_ref byte_array(u64 const size, u8 const init);
+}

--- a/compiler+runtime/include/cpp/jank/runtime/object.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/object.hpp
@@ -102,6 +102,7 @@ namespace jank::runtime
     inst,
 
     opaque_box,
+    array_box,
 
     reader_conditional,
   };
@@ -265,6 +266,8 @@ namespace jank::runtime
 
       case object_type::opaque_box:
         return "opaque_box";
+      case object_type::array_box:
+        return "array_box";
 
       case object_type::reader_conditional:
         return "reader_conditional";

--- a/compiler+runtime/include/cpp/jank/runtime/visit.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/visit.hpp
@@ -64,6 +64,7 @@
 #include <jank/runtime/obj/uuid.hpp>
 #include <jank/runtime/obj/inst.hpp>
 #include <jank/runtime/obj/opaque_box.hpp>
+#include <jank/runtime/obj/array.hpp>
 #include <jank/runtime/obj/reader_conditional.hpp>
 #include <jank/runtime/ns.hpp>
 #include <jank/runtime/var.hpp>
@@ -242,6 +243,8 @@ namespace jank::runtime
         return fn(expect_object<obj::inst>(erased), std::forward<Args>(args)...);
       case object_type::opaque_box:
         return fn(expect_object<obj::opaque_box>(erased), std::forward<Args>(args)...);
+      case object_type::array_box:
+        return fn(expect_object<obj::array_box>(erased), std::forward<Args>(args)...);
       case object_type::reader_conditional:
         return fn(expect_object<obj::reader_conditional>(erased), std::forward<Args>(args)...);
       default:

--- a/compiler+runtime/src/cpp/jank/runtime/obj/array.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/array.cpp
@@ -1,0 +1,247 @@
+#include <jank/runtime/obj/array.hpp>
+
+#include <jank/runtime/core/make_box.hpp>
+#include <jank/runtime/rtti.hpp>
+
+namespace jank::runtime::obj
+{
+  array<bool> *array_box::booleans()
+  {
+    if(etype != element_type::boolean)
+    {
+      throw std::runtime_error{ "boom" };
+    }
+
+    return reinterpret_cast<array<bool> *>(this);
+  }
+
+  array<char> *array_box::chars()
+  {
+    if(etype != element_type::character)
+    {
+      throw std::runtime_error{ "boom" };
+    }
+
+    return reinterpret_cast<array<char> *>(this);
+  }
+
+  array<f32> *array_box::floats()
+  {
+    if(etype != element_type::f32)
+    {
+      throw std::runtime_error{ "boom" };
+    }
+
+    return reinterpret_cast<array<f32> *>(this);
+  }
+
+  array<f64> *array_box::doubles()
+  {
+    if(etype != element_type::f64)
+    {
+      throw std::runtime_error{ "boom" };
+    }
+
+    return reinterpret_cast<array<f64> *>(this);
+  }
+
+  array<i16> *array_box::shorts()
+  {
+    if(etype != element_type::i16)
+    {
+      throw std::runtime_error{ "boom" };
+    }
+
+    return reinterpret_cast<array<i16> *>(this);
+  }
+
+  array<i32> *array_box::ints()
+  {
+    if(etype != element_type::i32)
+    {
+      throw std::runtime_error{ "boom" };
+    }
+
+    return reinterpret_cast<array<i32> *>(this);
+  }
+
+  array<i64> *array_box::longs()
+  {
+    if(etype != element_type::i64)
+    {
+      throw std::runtime_error{ "boom" };
+    }
+
+    return reinterpret_cast<array<i64> *>(this);
+  }
+
+  array<object_ref> *array_box::objects()
+  {
+    if(etype != element_type::object)
+    {
+      throw std::runtime_error{ "boom" };
+    }
+
+    return reinterpret_cast<array<object_ref> *>(this);
+  }
+
+  array<u8> *array_box::bytes()
+  {
+    if(etype != element_type::u8)
+    {
+      throw std::runtime_error{ "boom" };
+    }
+
+    return reinterpret_cast<array<u8> *>(this);
+  }
+
+  object_ref array_box::operator[](std::size_t const i) const
+  {
+    if(i > size)
+    {
+      throw std::runtime_error{ "boom" };
+    }
+
+    switch(etype)
+    {
+      case element_type::boolean:
+        return make_box(reinterpret_cast<array<bool> const *>(this)->data[i]);
+      case element_type::character:
+        return make_box(reinterpret_cast<array<char> const *>(this)->data[i]);
+      case element_type::f32:
+        return make_box(reinterpret_cast<array<f32> const *>(this)->data[i]);
+      case element_type::f64:
+        return make_box(reinterpret_cast<array<f64> const *>(this)->data[i]);
+      case element_type::i16:
+        return make_box(reinterpret_cast<array<i16> const *>(this)->data[i]);
+      case element_type::i32:
+        return make_box(reinterpret_cast<array<i32> const *>(this)->data[i]);
+      case element_type::i64:
+        return make_box(reinterpret_cast<array<i64> const *>(this)->data[i]);
+      case element_type::object:
+        return reinterpret_cast<array<object_ref> const *>(this)->data[i];
+      case element_type::u8:
+        return make_box(reinterpret_cast<array<u8> const *>(this)->data[i]);
+      default:
+        return make_box<opaque_box>(data /*.data + (i * element_size)*/, canonical_type);
+    }
+  }
+
+  /* behavior::countable */
+  usize array_box::count() const
+  {
+    return size;
+  }
+
+  object_ref array_box::get(object_ref const key) const
+  {
+    auto const n(static_cast<usize>(key.to_integer()));
+    return operator[](n);
+  }
+
+  object_ref array_box::get(object_ref const key, object_ref const fallback) const
+  {
+    auto const n(static_cast<usize>(key.to_integer()));
+    if(n > size)
+    {
+      return fallback;
+    }
+    return operator[](n);
+  }
+
+  bool array_box::contains(object_ref const key) const
+  {
+    auto const n(static_cast<usize>(key.to_integer()));
+    return n < size;
+  }
+
+  element_type get_element_type(object_ref const o)
+  {
+    return try_object<obj::array_box>(o)->etype;
+  }
+
+  bool_array_ref boolean_array(u64 const size)
+  {
+    return make_box<array<bool>>(element_type::boolean, size);
+  }
+
+  bool_array_ref boolean_array(u64 const size, bool const init_value)
+  {
+    return make_box<array<bool>>(element_type::boolean, size, init_value);
+  }
+
+  char_array_ref char_array(u64 const size)
+  {
+    return make_box<array<char>>(element_type::character, size);
+  }
+
+  char_array_ref char_array(u64 const size, char const init)
+  {
+    return make_box<array<char>>(element_type::character, size, init);
+  }
+
+  f32_array_ref float_array(u64 const size)
+  {
+    return make_box<array<f32>>(element_type::f32, size);
+  }
+
+  f32_array_ref float_array(u64 const size, f32 const init)
+  {
+    return make_box<array<f32>>(element_type::f32, size, init);
+  }
+
+  f64_array_ref double_array(u64 const size)
+  {
+    return make_box<array<f64>>(element_type::f64, size);
+  }
+
+  f64_array_ref double_array(u64 const size, f64 const init)
+  {
+    return make_box<array<f64>>(element_type::f64, size, init);
+  }
+
+  i16_array_ref short_array(u64 const size)
+  {
+    return make_box<array<i16>>(element_type::i16, size);
+  }
+
+  i16_array_ref short_array(u64 const size, i16 const init)
+  {
+    return make_box<array<i16>>(element_type::i16, size, init);
+  }
+
+  i32_array_ref int_array(u64 const size)
+  {
+    return make_box<array<i32>>(element_type::i32, size);
+  }
+
+  i32_array_ref int_array(u64 const size, i32 const init)
+  {
+    return make_box<array<i32>>(element_type::i32, size, init);
+  }
+
+  i64_array_ref long_array(u64 const size)
+  {
+    return make_box<array<i64>>(element_type::i64, size);
+  }
+
+  i64_array_ref long_array(u64 const size, i64 const init)
+  {
+    return make_box<array<i64>>(element_type::i64, size, init);
+  }
+
+  object_array_ref object_array(u64 const size)
+  {
+    return make_box<array<object_ref>>(element_type::object, size);
+  }
+
+  u8_array_ref byte_array(u64 const size)
+  {
+    return make_box<array<u8>>(element_type::u8, size);
+  }
+
+  u8_array_ref byte_array(u64 const size, u8 const init)
+  {
+    return make_box<array<u8>>(element_type::u8, size, init);
+  }
+}

--- a/compiler+runtime/src/jank/clojure/core.jank
+++ b/compiler+runtime/src/jank/clojure/core.jank
@@ -6622,80 +6622,63 @@
 (defn float-array
   "Creates an array of floats"
   ([size-or-seq]
-  ;;  (. clojure.lang.Numbers float_array size-or-seq)
-   (throw "TODO: port float-array"))
+   (cpp/jank.runtime.obj.float_array size-or-seq))
   ([size init-val-or-seq]
-  ;;  (. clojure.lang.Numbers float_array size init-val-or-seq)
-   (throw "TODO: port float-array") ))
+   (cpp/jank.runtime.obj.float_array size init-val-or-seq)))
 
 (defn boolean-array
   "Creates an array of booleans"
   ([size-or-seq]
-  ;;  (. clojure.lang.Numbers boolean_array size-or-seq)
-   (throw "TODO: port boolean-array"))
+   (cpp/jank.runtime.obj.boolean_array size-or-seq))
   ([size init-val-or-seq]
-  ;;  (. clojure.lang.Numbers boolean_array size init-val-or-seq)
-   (throw "TODO: port boolean-array")))
+   (cpp/jank.runtime.obj.boolean_array size init-val-or-seq)))
 
 (defn byte-array
   "Creates an array of bytes"
   ([size-or-seq]
-  ;;  (. clojure.lang.Numbers byte_array size-or-seq)
-   (throw "TODO: port byte-array"))
+   (cpp/jank.runtime.obj.byte_array size-or-seq))
   ([size init-val-or-seq]
-  ;;  (. clojure.lang.Numbers byte_array size init-val-or-seq)
-   (throw "TODO: port byte-array")))
+   (cpp/jank.runtime.obj.byte_array size init-val-or-seq)))
 
 (defn char-array
   "Creates an array of chars"
   ([size-or-seq]
-  ;;  (. clojure.lang.Numbers char_array size-or-seq)
-   (throw "TODO: port char-array"))
+   (cpp/jank.runtime.obj.char_array size-or-seq))
   ([size init-val-or-seq]
-  ;;  (. clojure.lang.Numbers char_array size init-val-or-seq)
-   (throw "TODO: port char-array")))
+   (cpp/jank.runtime.obj.char_array size init-val-or-seq)))
 
 (defn short-array
   "Creates an array of shorts"
   ([size-or-seq]
-  ;;  (. clojure.lang.Numbers short_array size-or-seq)
-   (throw "TODO: port short-array"))
+   (cpp/jank.runtime.obj.short_array size-or-seq))
   ([size init-val-or-seq]
-  ;;  (. clojure.lang.Numbers short_array size init-val-or-seq)
-   (throw "TODO: port short-array")))
+   (cpp/jank.runtime.obj.short_array size init-val-or-seq)))
 
 (defn double-array
   "Creates an array of doubles"
   ([size-or-seq]
-  ;;  (. clojure.lang.Numbers double_array size-or-seq)
-   (throw "TODO: port double-array"))
+   (cpp/jank.runtime.obj.double_array size-or-seq))
   ([size init-val-or-seq]
-  ;;  (. clojure.lang.Numbers double_array size init-val-or-seq)
-   (throw "TODO: port double-array")))
+   (cpp/jank.runtime.obj.double_array size init-val-or-seq)))
 
 (defn object-array
   "Creates an array of objects"
   ([size-or-seq]
-  ;;  (. clojure.lang.RT object_array size-or-seq)
-   (throw "TODO: port object-array")))
+   (cpp/jank.runtime.obj.object_array size-or-seq)))
 
 (defn int-array
   "Creates an array of ints"
   ([size-or-seq]
-  ;;  (. clojure.lang.Numbers int_array size-or-seq)
-   (throw "TODO: port int-array"))
+   (cpp/jank.runtime.obj.int_array size-or-seq))
   ([size init-val-or-seq]
-  ;;  (. clojure.lang.Numbers int_array size init-val-or-seq)
-   (throw "TODO: port int-array")))
+   (cpp/jank.runtime.obj.int_array size init-val-or-seq)))
 
 (defn long-array
   "Creates an array of longs"
   ([size-or-seq]
-  ;;  (. clojure.lang.Numbers long_array size-or-seq)
-   (throw "TODO: port long-array"))
+   (cpp/jank.runtime.obj.long_array size-or-seq))
   ([size init-val-or-seq]
-  ;;  (. clojure.lang.Numbers long_array size init-val-or-seq)
-   (throw "TODO: port long-array")))
+   (cpp/jank.runtime.obj.long_array size init-val-or-seq)))
 
 ;; definline doesn't work without eval
 
@@ -6750,10 +6733,12 @@
 (defn bytes?
   "Return true if x is a byte array"
   [x]
-  ;; (if (nil? x)
-  ;;   false
-  ;;   (-> x class .getComponentType (= Byte/TYPE)))
-  (throw "TODO: port bytes?"))
+  (if (nil? x)
+    false
+    (and (cpp/== (.get_type x)
+                 cpp/jank.runtime.object_type.array_box)
+         (cpp/== (cpp/jank.runtime.obj.get_element_type x)
+                 cpp/jank.runtime.obj.element_type.u8))))
 
 (defn seque
   "Creates a queued seq on another (presumably lazy) seq s. The queued


### PR DESCRIPTION
I played around with some ideas for how we could get the best of both worlds for arrays in jank:

The following is currently working:
```clojure
user=> (get (byte-array 10 2) 0) ;; support clojure functions
2
user=> (bytes? (byte-array 10 2)) ;; supports element predicates
true
user=> (bytes? (double-array 10 2.0)) ;; supports element predicates
false
user=> (let [x (cpp/jank.runtime.obj.boolean_array 10)] ;; we can update boolean-array to support inlining to avoid doing the interop
[(cpp/aget (cpp/* x) 0) ;; support raw unboxed read
 (aset (cpp/* x) 0 true) ;; support raw unboxed write
 (cpp/aget (cpp/* x) 0) 
 (count x)  ;; converts to boxed object
 x
 (get x 0)])
[false true true 10 #object [array_box 0x7f6f5b20ed20] true]
```
We can also support unboxing the array via `booleans/bytes/chars/shorts/floats/ints/doubles/longs` so any object can get cast into a `array<T>`.