### PR TITLE
Add a print-cflags command for external build compatibility

### DIFF
--- a/compiler+runtime/include/cpp/jank/aot/processor.hpp
+++ b/compiler+runtime/include/cpp/jank/aot/processor.hpp
@@ -6,6 +6,9 @@
 
 namespace jank::aot
 {
+  jtl::result<std::vector<char const *>, error_ref> build_compiler_args();
+  std::vector<char const *> build_linker_args();
+
   struct processor
   {
     jtl::result<void, error_ref> build_executable(jtl::immutable_string const &module) const;

--- a/compiler+runtime/include/cpp/jank/util/cli.hpp
+++ b/compiler+runtime/include/cpp/jank/util/cli.hpp
@@ -14,6 +14,7 @@ namespace jank::util::cli
     run_main,
     check_health,
     print_binary_version,
+    print_cflags,
   };
 
   enum class compilation_target : u8

--- a/compiler+runtime/src/cpp/jank/aot/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/aot/processor.cpp
@@ -154,7 +154,7 @@ int main(int argc, const char** argv)
     return main_file_path;
   }
 
-  static jtl::result<std::vector<char const *>, error_ref> build_compiler_args()
+  jtl::result<std::vector<char const *>, error_ref> build_compiler_args()
   {
     std::vector<char const *> compiler_args{};
 
@@ -283,6 +283,50 @@ int main(int argc, const char** argv)
     return compiler_args;
   }
 
+  std::vector<char const *> build_linker_args()
+  {
+    std::vector<char const *> linker_args{};
+
+    if(util::cli::opts.target_runtime == util::cli::compilation_runtime::static_)
+    {
+      for(auto const &lib : { "-ljank-static-runtime", "-lm", "-lz", "-lzstd" })
+      {
+        linker_args.push_back(strdup(lib));
+      }
+    }
+    else
+    {
+      for(auto const &lib :
+          { "-ljank-dynamic-runtime", "-lLLVM", "-lclang-cpp", "-lcrypto", "-lm", "-lz", "-lzstd" })
+      {
+        linker_args.push_back(strdup(lib));
+      }
+    }
+
+#if defined(__MINGW64__)
+    linker_args.push_back(strdup("-lpthread"));
+#endif
+
+    for(auto const &library_dir : util::cli::opts.library_dirs)
+    {
+      linker_args.push_back(strdup(util::format("-Wl,-rpath,{}", library_dir).c_str()));
+    }
+
+    for(auto const &lib : util::cli::opts.libs)
+    {
+      linker_args.push_back(strdup(util::format("-l{}", lib).c_str()));
+    }
+
+    /* On non-macOS platforms, explicitly link libstdc++.
+     * macOS uses libc++ implicitly via Clang. */
+    if constexpr(jtl::current_platform != jtl::platform::macos_like)
+    {
+      linker_args.push_back(strdup("-lstdc++"));
+    }
+
+    return linker_args;
+  }
+
   jtl::result<void, error_ref>
   processor::build_executable(jtl::immutable_string const &module) const
   {
@@ -355,42 +399,8 @@ int main(int argc, const char** argv)
     compiler_args.push_back(strdup("c++"));
     compiler_args.push_back(strdup(entrypoint_path.c_str()));
 
-    if(util::cli::opts.target_runtime == util::cli::compilation_runtime::static_)
-    {
-      for(auto const &lib : { "-ljank-static-runtime", "-lm", "-lz", "-lzstd" })
-      {
-        compiler_args.push_back(strdup(lib));
-      }
-    }
-    else
-    {
-      for(auto const &lib :
-          { "-ljank-dynamic-runtime", "-lLLVM", "-lclang-cpp", "-lcrypto", "-lm", "-lz", "-lzstd" })
-      {
-        compiler_args.push_back(strdup(lib));
-      }
-    }
-
-#if defined(__MINGW64__)
-    compiler_args.push_back(strdup("-lpthread"));
-#endif
-
-    for(auto const &library_dir : util::cli::opts.library_dirs)
-    {
-      compiler_args.push_back(strdup(util::format("-Wl,-rpath,{}", library_dir).c_str()));
-    }
-
-    for(auto const &lib : util::cli::opts.libs)
-    {
-      compiler_args.push_back(strdup(util::format("-l{}", lib).c_str()));
-    }
-
-    /* On non-macOS platforms, explicitly link libstdc++.
-     * macOS uses libc++ implicitly via Clang. */
-    if constexpr(jtl::current_platform != jtl::platform::macos_like)
-    {
-      compiler_args.push_back(strdup("-lstdc++"));
-    }
+    auto const linker_args = build_linker_args();
+    std::ranges::copy(linker_args, std::back_inserter(compiler_args));
 
     /* Required because of `strdup` usage and need to manually free the memory.
      * Clang expects C strings that we own. */

--- a/compiler+runtime/src/cpp/jank/aot/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/aot/processor.cpp
@@ -399,7 +399,7 @@ int main(int argc, const char** argv)
     compiler_args.push_back(strdup("c++"));
     compiler_args.push_back(strdup(entrypoint_path.c_str()));
 
-    auto const linker_args = build_linker_args();
+    auto const linker_args{ build_linker_args() };
     std::ranges::copy(linker_args, std::back_inserter(compiler_args));
 
     /* Required because of `strdup` usage and need to manually free the memory.

--- a/compiler+runtime/src/cpp/jank/util/cli.cpp
+++ b/compiler+runtime/src/cpp/jank/util/cli.cpp
@@ -113,6 +113,8 @@ COMMANDS
                               -main.
   check-health                Provide a status report on the jank installation.
   print-binary-version        Print the current binary version to stdout and exit.
+  print-cflags                Print the Clang flags for AOT compilation of C++ source code
+                              to stdout and exit.
 
 OPTIONS
   -h,     --help              Print this help message and exit.
@@ -228,6 +230,7 @@ OPTIONS
       {       "compile-module",       command::compile_module },
       {         "check-health",         command::check_health },
       { "print-binary-version", command::print_binary_version },
+      {         "print-cflags",         command::print_cflags },
     };
 
     options_scratchpad scratch;

--- a/compiler+runtime/src/cpp/main.cpp
+++ b/compiler+runtime/src/cpp/main.cpp
@@ -412,7 +412,7 @@ int main(int const argc, char const **argv)
       else if(util::cli::opts.command == util::cli::command::print_cflags)
       {
         auto const compiler_args_res{ aot::build_compiler_args() };
-        std::vector<char const *> const compiler_args{ jtl::move(compiler_args_res.expect_ok()) };
+        auto const &compiler_args{ compiler_args_res.expect_ok() };
         for(auto const arg : compiler_args)
         {
           util::print("{} ", arg);

--- a/compiler+runtime/src/cpp/main.cpp
+++ b/compiler+runtime/src/cpp/main.cpp
@@ -404,9 +404,24 @@ int main(int const argc, char const **argv)
       {
         return jank::environment::check_health() ? 0 : 1;
       }
-      if(util::cli::opts.command == util::cli::command::print_binary_version)
+      else if(util::cli::opts.command == util::cli::command::print_binary_version)
       {
         util::println("{}", util::binary_version());
+        return 0;
+      }
+      else if(util::cli::opts.command == util::cli::command::print_cflags)
+      {
+        auto const compiler_args_res{ aot::build_compiler_args() };
+        std::vector<char const *> const compiler_args{ jtl::move(compiler_args_res.expect_ok()) };
+        for(auto const arg : compiler_args)
+        {
+          util::print("{} ", arg);
+        }
+        for(auto const arg : aot::build_linker_args())
+        {
+          util::print("{} ", arg);
+        }
+        util::println("");
         return 0;
       }
 
@@ -485,6 +500,7 @@ int main(int const argc, char const **argv)
           break;
         case util::cli::command::check_health:
         case util::cli::command::print_binary_version:
+        case util::cli::command::print_cflags:
           break;
       }
       return 0;


### PR DESCRIPTION
Tested by `clang++ hello.cpp $(jank print-cflags)`, where hello.cpp is from `jank compile-module --output-target cpp` with a placeholder main method (since `jank compile` won't output a C++ file).

Towards `zig cc` AOT compilation.