### PR TITLE
Improve nREPL server usability

### DIFF
--- a/compiler+runtime/include/cpp/jank/runtime/behavior/derefable.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/behavior/derefable.hpp
@@ -1,9 +1,0 @@
-#pragma once
-
-namespace jank::runtime::behavior
-{
-  template <typename T>
-  concept derefable = requires(T * const t) {
-    { t->deref() } -> std::convertible_to<object_ref>;
-  };
-}

--- a/compiler+runtime/include/cpp/jank/runtime/obj/atom.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/atom.hpp
@@ -14,14 +14,15 @@ namespace jank::runtime::obj
   {
     static constexpr object_type obj_type{ object_type::atom };
     static constexpr object_behavior obj_behaviors{ object_behavior::compare
-                                                    | object_behavior::ref_like };
+                                                    | object_behavior::ref_like
+                                                    | object_behavior::deref };
     static constexpr bool pointer_free{ false };
 
     atom();
     atom(object_ref const o);
 
-    /* behavior::derefable */
-    object_ref deref() const;
+    /* behavior::deref */
+    object_ref deref() override;
 
     /* behavior::metadatable */
     object_ref with_meta(object_ref const m);

--- a/compiler+runtime/include/cpp/jank/runtime/obj/delay.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/delay.hpp
@@ -11,14 +11,14 @@ namespace jank::runtime::obj
   struct delay : object
   {
     static constexpr object_type obj_type{ object_type::delay };
-    static constexpr object_behavior obj_behaviors{ object_behavior::none };
+    static constexpr object_behavior obj_behaviors{ object_behavior::deref };
     static constexpr bool pointer_free{ false };
 
     delay();
     delay(object_ref const fn);
 
-    /* behavior::derefable */
-    object_ref deref();
+    /* behavior::deref */
+    object_ref deref() override;
 
     /* behavior::realizable */
     bool is_realized() const;

--- a/compiler+runtime/include/cpp/jank/runtime/obj/future.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/future.hpp
@@ -20,13 +20,13 @@ namespace jank::runtime::obj
   struct future : object
   {
     static constexpr object_type obj_type{ object_type::future };
-    static constexpr object_behavior obj_behaviors{ object_behavior::none };
+    static constexpr object_behavior obj_behaviors{ object_behavior::deref };
     static constexpr bool pointer_free{ false };
 
     future();
 
-    /* behavior::derefable */
-    object_ref deref();
+    /* behavior::deref */
+    object_ref deref() override;
 
     /* behavior::realizable */
     bool is_realized() const;

--- a/compiler+runtime/include/cpp/jank/runtime/obj/promise.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/promise.hpp
@@ -19,13 +19,14 @@ namespace jank::runtime::obj
   struct promise : object
   {
     static constexpr object_type obj_type{ object_type::promise };
-    static constexpr object_behavior obj_behaviors{ object_behavior::call };
+    static constexpr object_behavior obj_behaviors{ object_behavior::call
+                                                    | object_behavior::deref };
     static constexpr bool pointer_free{ false };
 
     promise();
 
-    /* behavior::derefable */
-    object_ref deref();
+    /* behavior::deref */
+    object_ref deref() override;
 
     /* behavior::realizable */
     bool is_realized() const;

--- a/compiler+runtime/include/cpp/jank/runtime/obj/reduced.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/reduced.hpp
@@ -9,13 +9,13 @@ namespace jank::runtime::obj
   struct reduced : object
   {
     static constexpr object_type obj_type{ object_type::reduced };
-    static constexpr object_behavior obj_behaviors{ object_behavior::none };
+    static constexpr object_behavior obj_behaviors{ object_behavior::deref };
     static constexpr bool pointer_free{ false };
 
     reduced(object_ref const o);
 
-    /* behavior::derefable */
-    object_ref deref() const;
+    /* behavior::deref */
+    object_ref deref() override;
 
     /*** XXX: Everything here is immutable after initialization. ***/
     object_ref val{};

--- a/compiler+runtime/include/cpp/jank/runtime/obj/volatile.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/volatile.hpp
@@ -9,13 +9,13 @@ namespace jank::runtime::obj
   struct volatile_ : object
   {
     static constexpr object_type obj_type{ object_type::volatile_ };
-    static constexpr object_behavior obj_behaviors{ object_behavior::none };
+    static constexpr object_behavior obj_behaviors{ object_behavior::deref };
     static constexpr bool pointer_free{ false };
 
     volatile_(object_ref const o);
 
-    /* behavior::derefable */
-    object_ref deref() const;
+    /* behavior::deref */
+    object_ref deref() override;
 
     object_ref reset(object_ref const o);
 

--- a/compiler+runtime/include/cpp/jank/runtime/object.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/object.hpp
@@ -311,12 +311,12 @@ namespace jank::runtime
     sequence_like = 1 << 7,
     sequence_like_in_place = 1 << 8,
     indexable = 1 << 9,
+    deref = 1 << 10,
     //associatively_writable,
     //chunkable,
     //collection_like,
     //conjable,
     //countable,
-    //derefable,
     //map_like,
     //metadatable,
     //nameable,
@@ -541,6 +541,9 @@ namespace jank::runtime
      * This enables some checks at the beginning of the member function to be elided when
      * compared to next(), such as bounds or emptiness checks. */
     virtual object_ref next_in_place();
+
+    /* behavior::deref */
+    virtual object_ref deref();
 
     object_type type{};
     object_behavior behaviors{ object_behavior::none };

--- a/compiler+runtime/include/cpp/jank/runtime/oref.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/oref.hpp
@@ -1126,6 +1126,25 @@ namespace jank::runtime
       }
     }
 
+    /* behavior::deref */
+    object_ref deref() const
+    {
+      if(detail::is_tagged_small_int(data))
+      {
+        obj::small_integer i{ detail::as_integer(data) };
+        return i.deref();
+      }
+      else if(detail::is_tagged_small_real(data))
+      {
+        obj::small_real i{ detail::as_real(data) };
+        return i.deref();
+      }
+      else
+      {
+        return ptr()->deref();
+      }
+    }
+
     value_type *raw() const
     {
       return data;
@@ -1744,6 +1763,17 @@ namespace jank::runtime
       return static_cast<T *>(data)->nth(index, fallback);
     }
 
+    /* behavior::deref */
+    object_ref deref() const
+    {
+      if(is_nil())
+      {
+        return const_cast<obj::nil &>(_jank_nil).deref();
+      }
+
+      return static_cast<T *>(data)->deref();
+    }
+
     void *raw() const
     {
       return data;
@@ -2103,6 +2133,13 @@ namespace jank::runtime
       return i.nth(index, fallback);
     }
 
+    /* behavior::deref */
+    object_ref deref() const
+    {
+      obj::small_integer i{ data };
+      return i.deref();
+    }
+
     i32 raw() const
     {
       return data;
@@ -2453,6 +2490,13 @@ namespace jank::runtime
     {
       obj::small_real const i{ data };
       return i.nth(index, fallback);
+    }
+
+    /* behavior::deref */
+    object_ref deref() const
+    {
+      obj::small_real i{ data };
+      return i.deref();
     }
 
     f64 raw() const
@@ -2811,6 +2855,12 @@ namespace jank::runtime
     object_ref nth(object_ref const, object_ref const fallback) const
     {
       return fallback;
+    }
+
+    /* behavior::deref */
+    object_ref deref() const
+    {
+      return const_cast<obj::nil &>(_jank_nil).deref();
     }
 
     value_type *raw() const

--- a/compiler+runtime/include/cpp/jank/runtime/var.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/var.hpp
@@ -20,7 +20,8 @@ namespace jank::runtime
   struct var : object
   {
     static constexpr object_type obj_type{ object_type::var };
-    static constexpr object_behavior obj_behaviors{ object_behavior::call };
+    static constexpr object_behavior obj_behaviors{ object_behavior::call
+                                                    | object_behavior::deref };
     static constexpr bool pointer_free{ false };
 
     var() = delete;
@@ -122,8 +123,8 @@ namespace jank::runtime
                     object_ref const a10,
                     object_ref const more) const override;
 
-    /* behavior::derefable */
-    object_ref deref() const;
+    /* behavior::deref */
+    object_ref deref() override;
 
     /* behavior::metadatable */
     var_ref with_meta(object_ref m);

--- a/compiler+runtime/src/cpp/jank/runtime/core.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core.cpp
@@ -11,7 +11,6 @@
 #include <jank/runtime/core.hpp>
 #include <jank/runtime/visit.hpp>
 #include <jank/runtime/behavior/nameable.hpp>
-#include <jank/runtime/behavior/derefable.hpp>
 #include <jank/runtime/behavior/ref_like.hpp>
 #include <jank/runtime/behavior/realizable.hpp>
 #include <jank/runtime/core/call.hpp>
@@ -645,22 +644,7 @@ namespace jank::runtime
 
   object_ref deref(object_ref const o)
   {
-    /* TODO: Port visit_object: derefable. */
-    return visit_object(
-      [=](auto const typed_o) -> object_ref {
-        using T = typename jtl::decay_t<decltype(typed_o)>::value_type;
-
-        if constexpr(behavior::derefable<T>)
-        {
-          return typed_o->deref();
-        }
-        else
-        {
-          throw std::runtime_error{ util::format("Objects of type `{}` are not dereferenceable.",
-                                                 object_type_str(typed_o.get_type())) };
-        }
-      },
-      o);
+    return o.deref();
   }
 
   bool is_realized(object_ref const o)

--- a/compiler+runtime/src/cpp/jank/runtime/obj/atom.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/atom.cpp
@@ -19,7 +19,7 @@ namespace jank::runtime::obj
   {
   }
 
-  object_ref atom::deref() const
+  object_ref atom::deref()
   {
     return val.load();
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/multi_function.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/multi_function.cpp
@@ -164,7 +164,7 @@ namespace jank::runtime::obj
   {
     std::lock_guard<std::recursive_mutex> const lock{ mutex };
 
-    if(is_preferred(deref(hierarchy), y, x))
+    if(is_preferred(hierarchy.deref(), y, x))
     {
       throw std::runtime_error{ util::format(
         "The `prefer-method` operation on multimethod `{}` cannot prefer `{}` over `{}` because "
@@ -221,7 +221,7 @@ namespace jank::runtime::obj
     static object_ref const isa{
       __rt_ctx->intern_var("clojure.core", "isa?").expect_ok()->deref()
     };
-    return truthy(isa.call(deref(hierarchy), x, y));
+    return truthy(isa.call(hierarchy.deref(), x, y));
   }
 
   bool multi_function::is_dominant(object_ref const hierarchy,
@@ -246,7 +246,7 @@ namespace jank::runtime::obj
 
   object_ref multi_function::get_method(object_ref const dispatch_val) const
   {
-    if(cached_hierarchy != deref(hierarchy))
+    if(cached_hierarchy != hierarchy.deref())
     {
       const_cast<multi_function *>(this)->reset_cache();
     }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/reduced.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/reduced.cpp
@@ -10,7 +10,7 @@ namespace jank::runtime::obj
     jank_debug_assert(val.is_some());
   }
 
-  object_ref reduced::deref() const
+  object_ref reduced::deref()
   {
     return val;
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/volatile.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/volatile.cpp
@@ -9,7 +9,7 @@ namespace jank::runtime::obj
   {
   }
 
-  object_ref volatile_::deref() const
+  object_ref volatile_::deref()
   {
     return val;
   }

--- a/compiler+runtime/src/cpp/jank/runtime/object.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/object.cpp
@@ -305,6 +305,13 @@ namespace jank::runtime
     return next();
   }
 
+  object_ref object::deref()
+  {
+    throw error::runtime_unsupported_behavior(type,
+                                              "deref",
+                                              object_source(runtime::detail::untagged(this)));
+  }
+
   bool very_equal_to::operator()(object_ref const lhs, object_ref const rhs) const noexcept
   {
     if(lhs.get_type() != rhs.get_type())

--- a/compiler+runtime/src/cpp/jank/runtime/var.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/var.cpp
@@ -86,7 +86,7 @@ namespace jank::runtime
 
   bool var::is_bound() const
   {
-    return const_cast<var*>(this)->deref().get_type() != object_type::var_unbound_root;
+    return const_cast<var *>(this)->deref().get_type() != object_type::var_unbound_root;
   }
 
   object_ref var::get_root() const
@@ -164,22 +164,22 @@ namespace jank::runtime
 
   object_ref var::call() const
   {
-    return const_cast<var*>(this)->deref().call();
+    return const_cast<var *>(this)->deref().call();
   }
 
   object_ref var::call(object_ref const a1) const
   {
-    return const_cast<var*>(this)->deref().call(a1);
+    return const_cast<var *>(this)->deref().call(a1);
   }
 
   object_ref var::call(object_ref const a1, object_ref const a2) const
   {
-    return const_cast<var*>(this)->deref().call(a1, a2);
+    return const_cast<var *>(this)->deref().call(a1, a2);
   }
 
   object_ref var::call(object_ref const a1, object_ref const a2, object_ref const a3) const
   {
-    return const_cast<var*>(this)->deref().call(a1, a2, a3);
+    return const_cast<var *>(this)->deref().call(a1, a2, a3);
   }
 
   object_ref var::call(object_ref const a1,
@@ -187,7 +187,7 @@ namespace jank::runtime
                        object_ref const a3,
                        object_ref const a4) const
   {
-    return const_cast<var*>(this)->deref().call(a1, a2, a3, a4);
+    return const_cast<var *>(this)->deref().call(a1, a2, a3, a4);
   }
 
   object_ref var::call(object_ref const a1,
@@ -196,7 +196,7 @@ namespace jank::runtime
                        object_ref const a4,
                        object_ref const a5) const
   {
-    return const_cast<var*>(this)->deref().call(a1, a2, a3, a4, a5);
+    return const_cast<var *>(this)->deref().call(a1, a2, a3, a4, a5);
   }
 
   object_ref var::call(object_ref const a1,
@@ -206,7 +206,7 @@ namespace jank::runtime
                        object_ref const a5,
                        object_ref const a6) const
   {
-    return const_cast<var*>(this)->deref().call(a1, a2, a3, a4, a5, a6);
+    return const_cast<var *>(this)->deref().call(a1, a2, a3, a4, a5, a6);
   }
 
   object_ref var::call(object_ref const a1,
@@ -217,7 +217,7 @@ namespace jank::runtime
                        object_ref const a6,
                        object_ref const a7) const
   {
-    return const_cast<var*>(this)->deref().call(a1, a2, a3, a4, a5, a6, a7);
+    return const_cast<var *>(this)->deref().call(a1, a2, a3, a4, a5, a6, a7);
   }
 
   object_ref var::call(object_ref const a1,
@@ -229,7 +229,7 @@ namespace jank::runtime
                        object_ref const a7,
                        object_ref const a8) const
   {
-    return const_cast<var*>(this)->deref().call(a1, a2, a3, a4, a5, a6, a7, a8);
+    return const_cast<var *>(this)->deref().call(a1, a2, a3, a4, a5, a6, a7, a8);
   }
 
   object_ref var::call(object_ref const a1,
@@ -242,7 +242,7 @@ namespace jank::runtime
                        object_ref const a8,
                        object_ref const a9) const
   {
-    return const_cast<var*>(this)->deref().call(a1, a2, a3, a4, a5, a6, a7, a8, a9);
+    return const_cast<var *>(this)->deref().call(a1, a2, a3, a4, a5, a6, a7, a8, a9);
   }
 
   object_ref var::call(object_ref const a1,
@@ -256,7 +256,7 @@ namespace jank::runtime
                        object_ref const a9,
                        object_ref const a10) const
   {
-    return const_cast<var*>(this)->deref().call(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10);
+    return const_cast<var *>(this)->deref().call(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10);
   }
 
   object_ref var::call(object_ref const a1,
@@ -271,7 +271,7 @@ namespace jank::runtime
                        object_ref const a10,
                        object_ref const more) const
   {
-    return const_cast<var*>(this)->deref().call(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, more);
+    return const_cast<var *>(this)->deref().call(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, more);
   }
 
   object_ref var::deref()

--- a/compiler+runtime/src/cpp/jank/runtime/var.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/var.cpp
@@ -86,7 +86,7 @@ namespace jank::runtime
 
   bool var::is_bound() const
   {
-    return deref().get_type() != object_type::var_unbound_root;
+    return const_cast<var*>(this)->deref().get_type() != object_type::var_unbound_root;
   }
 
   object_ref var::get_root() const
@@ -164,22 +164,22 @@ namespace jank::runtime
 
   object_ref var::call() const
   {
-    return deref().call();
+    return const_cast<var*>(this)->deref().call();
   }
 
   object_ref var::call(object_ref const a1) const
   {
-    return deref().call(a1);
+    return const_cast<var*>(this)->deref().call(a1);
   }
 
   object_ref var::call(object_ref const a1, object_ref const a2) const
   {
-    return deref().call(a1, a2);
+    return const_cast<var*>(this)->deref().call(a1, a2);
   }
 
   object_ref var::call(object_ref const a1, object_ref const a2, object_ref const a3) const
   {
-    return deref().call(a1, a2, a3);
+    return const_cast<var*>(this)->deref().call(a1, a2, a3);
   }
 
   object_ref var::call(object_ref const a1,
@@ -187,7 +187,7 @@ namespace jank::runtime
                        object_ref const a3,
                        object_ref const a4) const
   {
-    return deref().call(a1, a2, a3, a4);
+    return const_cast<var*>(this)->deref().call(a1, a2, a3, a4);
   }
 
   object_ref var::call(object_ref const a1,
@@ -196,7 +196,7 @@ namespace jank::runtime
                        object_ref const a4,
                        object_ref const a5) const
   {
-    return deref().call(a1, a2, a3, a4, a5);
+    return const_cast<var*>(this)->deref().call(a1, a2, a3, a4, a5);
   }
 
   object_ref var::call(object_ref const a1,
@@ -206,7 +206,7 @@ namespace jank::runtime
                        object_ref const a5,
                        object_ref const a6) const
   {
-    return deref().call(a1, a2, a3, a4, a5, a6);
+    return const_cast<var*>(this)->deref().call(a1, a2, a3, a4, a5, a6);
   }
 
   object_ref var::call(object_ref const a1,
@@ -217,7 +217,7 @@ namespace jank::runtime
                        object_ref const a6,
                        object_ref const a7) const
   {
-    return deref().call(a1, a2, a3, a4, a5, a6, a7);
+    return const_cast<var*>(this)->deref().call(a1, a2, a3, a4, a5, a6, a7);
   }
 
   object_ref var::call(object_ref const a1,
@@ -229,7 +229,7 @@ namespace jank::runtime
                        object_ref const a7,
                        object_ref const a8) const
   {
-    return deref().call(a1, a2, a3, a4, a5, a6, a7, a8);
+    return const_cast<var*>(this)->deref().call(a1, a2, a3, a4, a5, a6, a7, a8);
   }
 
   object_ref var::call(object_ref const a1,
@@ -242,7 +242,7 @@ namespace jank::runtime
                        object_ref const a8,
                        object_ref const a9) const
   {
-    return deref().call(a1, a2, a3, a4, a5, a6, a7, a8, a9);
+    return const_cast<var*>(this)->deref().call(a1, a2, a3, a4, a5, a6, a7, a8, a9);
   }
 
   object_ref var::call(object_ref const a1,
@@ -256,7 +256,7 @@ namespace jank::runtime
                        object_ref const a9,
                        object_ref const a10) const
   {
-    return deref().call(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10);
+    return const_cast<var*>(this)->deref().call(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10);
   }
 
   object_ref var::call(object_ref const a1,
@@ -271,10 +271,10 @@ namespace jank::runtime
                        object_ref const a10,
                        object_ref const more) const
   {
-    return deref().call(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, more);
+    return const_cast<var*>(this)->deref().call(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, more);
   }
 
-  object_ref var::deref() const
+  object_ref var::deref()
   {
     auto const binding(get_thread_binding());
     if(binding.is_some())

--- a/compiler+runtime/src/cpp/jank/terminal_repl_client.cpp
+++ b/compiler+runtime/src/cpp/jank/terminal_repl_client.cpp
@@ -250,7 +250,7 @@ namespace jank::terminal_repl
     auto const repl_main{
       __rt_ctx->intern_var("jank.nrepl.server.core", "background-main").expect_ok()
     };
-    repl_main.call();
+    auto const repl_ready{ repl_main.call() };
 
     __rt_ctx->in_ns_var->deref().call(make_box<obj::symbol>("user"));
     __rt_ctx->intern_var("clojure.core", "refer")
@@ -294,8 +294,7 @@ namespace jank::terminal_repl
 
     /* We want to wait until the nREPL server is completely initialized, so we'll block on
      * its promise. */
-    auto const repl_ready{ __rt_ctx->intern_var("jank.nrepl.server.core", "ready?").expect_ok() };
-    repl_ready->deref();
+    repl_ready.deref();
 
     while(true)
     {

--- a/compiler+runtime/src/cpp/jank/terminal_repl_client.cpp
+++ b/compiler+runtime/src/cpp/jank/terminal_repl_client.cpp
@@ -244,6 +244,9 @@ namespace jank::terminal_repl
       __rt_ctx->load_module("jank.nrepl.server.core", module::origin::latest).expect_ok();
     }
 
+    /* This will start the nREPL server on a background thread. Meanwhile, we'll set up
+     * some stuff for this thread and then we'll later block on an nREPL promise to ensure
+     * that it's completely running before we prompt the user. */
     auto const repl_main{
       __rt_ctx->intern_var("jank.nrepl.server.core", "background-main").expect_ok()
     };
@@ -288,6 +291,11 @@ namespace jank::terminal_repl
       std::make_pair(second_res_var, jank_nil),
       std::make_pair(third_res_var, jank_nil),
       std::make_pair(error_var, jank_nil)) };
+
+    /* We want to wait until the nREPL server is completely initialized, so we'll block on
+     * its promise. */
+    auto const repl_ready{ __rt_ctx->intern_var("jank.nrepl.server.core", "ready?").expect_ok() };
+    repl_ready->deref();
 
     while(true)
     {

--- a/compiler+runtime/src/jank/clojure/data.jank
+++ b/compiler+runtime/src/jank/clojure/data.jank
@@ -1,0 +1,89 @@
+;   Copyright (c) Rich Hickey. All rights reserved.
+;   The use and distribution terms for this software are covered by the
+;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;   which can be found in the file epl-v10.html at the root of this distribution.
+;   By using this software in any fashion, you are agreeing to be bound by
+;   the terms of this license.
+;   You must not remove this notice, or any other, from this software.
+
+(ns ^{:author "Stuart Halloway",
+    :doc "Non-core data functions."}
+  clojure.data
+  (:require [clojure.set :as set]))
+
+(declare diff)
+
+(defn- atom-diff
+  "Internal helper for diff."
+  [a b]
+  (if (= a b) [nil nil a] [a b nil]))
+
+;; for big things a sparse vector class would be better
+(defn- vectorize
+  "Convert an associative-by-numeric-index collection into
+   an equivalent vector, with nil for any missing keys"
+  [m]
+  (when (seq m)
+    (reduce
+     (fn [result [k v]] (assoc result k v))
+     (vec (repeat (apply max (keys m))  nil))
+     m)))
+
+(defn- diff-associative-key
+  "Diff associative things a and b, comparing only the key k."
+  [a b k]
+  (let [va (get a k)
+        vb (get b k)
+        [a* b* ab] (diff va vb)
+        in-a (contains? a k)
+        in-b (contains? b k)
+        same (and in-a in-b
+                  (or (not (nil? ab))
+                      (and (nil? va) (nil? vb))))]
+    [(when (and in-a (or (not (nil? a*)) (not same))) {k a*})
+     (when (and in-b (or (not (nil? b*)) (not same))) {k b*})
+     (when same {k ab})
+     ]))
+
+(defn- diff-associative
+  "Diff associative things a and b, comparing only keys in ks."
+  [a b ks]
+  (reduce
+   (fn [diff1 diff2]
+     (doall (map merge diff1 diff2)))
+   [nil nil nil]
+   (map
+    (partial diff-associative-key a b)
+    ks)))
+
+(defn- diff-sequential
+  [a b]
+  (vec (map vectorize (diff-associative
+                       (if (vector? a) a (vec a))
+                       (if (vector? b) b (vec b))
+                       (range (max (count a) (count b)))))))
+
+(defn- equality-partition [o]
+  :atom)
+
+(defn- diff-similar [lhs rhs]
+  (atom-diff lhs rhs))
+
+(defn diff
+  "Recursively compares a and b, returning a tuple of
+  [things-only-in-a things-only-in-b things-in-both].
+  Comparison rules:
+
+  * For equal a and b, return [nil nil a].
+  * Maps are subdiffed where keys match and values differ.
+  * Sets are never subdiffed.
+  * All sequential things are treated as associative collections
+    by their indexes, with results returned as vectors.
+  * Everything else (including strings!) is treated as
+    an atom and compared for equality."
+  [a b]
+  (if (= a b)
+    [nil nil a]
+    (if (= (equality-partition a) (equality-partition b))
+      (diff-similar a b)
+      (atom-diff a b))))

--- a/compiler+runtime/src/jank/clojure/pprint.jank
+++ b/compiler+runtime/src/jank/clojure/pprint.jank
@@ -1,0 +1,7 @@
+(ns clojure.pprint)
+
+(defn pprint [o]
+  (prn o))
+
+(defn write [o & kw-args]
+  (pr o))

--- a/compiler+runtime/src/jank/jank/nrepl/server/core.jank
+++ b/compiler+runtime/src/jank/jank/nrepl/server/core.jank
@@ -97,5 +97,9 @@
       (let [client* (accept server*)]
         (future (handle-client client*))))))
 
-(defn background-main [& args]
-  (future (apply -main args)))
+(defn background-main
+  "Starts the nREPL server as a background thread. Returns a promise which will be delivered
+   the server is running."
+  [& args]
+  (future (apply -main args))
+  *ready?)

--- a/compiler+runtime/src/jank/jank/nrepl/server/core.jank
+++ b/compiler+runtime/src/jank/jank/nrepl/server/core.jank
@@ -12,6 +12,7 @@
             [jank.nrepl.server.handler.lookup]))
 
 (def *verbose (atom false))
+(def *ready? (promise))
 
 (defn log [& args]
   (when @*verbose
@@ -91,6 +92,7 @@
     ;; format to assist with setting up a REPL via jack-in.
     (println "nREPL server started on port" (str (.get_port server))
              "on host 127.0.0.1 -" (.get_endpoint server))
+    (deliver *ready? true)
     (while true
       (let [client* (accept server*)]
         (future (handle-client client*))))))

--- a/gdb/jank.py
+++ b/gdb/jank.py
@@ -2,6 +2,10 @@ import re
 import gdb
 from itertools import count
 
+# Ignore GC bits.
+handle SIGPWR nostop noprint
+handle SIGXCPU nostop noprint
+
 def jank_address(oref):
     data_ptr = oref["data"].format_string(raw=True)
     return re.search("(0x[0-9a-fA-F]+)", data_ptr).group(1)


### PR DESCRIPTION
* Port `deref` to object behavior
* Return a promise from nREPL `background-main`, to denote when the server is ready
* Wait for the nREPL server to be up before processing any terminal REPL client inputs
* Add stubs for `clojure.pprint` and `clojure.data`, since Conjure wanted to use them