### PR TITLE
Update folly, remove ::close workarounds, handle excpt.h

### DIFF
--- a/compiler+runtime/include/cpp/jank/runtime/obj/exception_info.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/exception_info.hpp
@@ -1,8 +1,13 @@
 #pragma once
 
-/* Windows defines this and it becomes an issue in unity builds. */
-#ifdef exception_info
-  #undef exception_info
+/* MSYS2's excpt.h is included transitively and defines exception_info
+ * as a macro, which conflicts with our class. Undefine it here to
+ * prevent the macro from leaking. */
+#ifdef __MINGW64__
+  #include <excpt.h>
+  #ifdef exception_info
+    #undef exception_info
+  #endif
 #endif
 
 #include <memory>

--- a/compiler+runtime/src/cpp/jank/aot/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/aot/processor.cpp
@@ -2,6 +2,8 @@
 #include <vector>
 #include <cstdlib>
 
+#include <unistd.h>
+
 #include <jtl/result.hpp>
 #include <jtl/string_builder.hpp>
 
@@ -146,7 +148,7 @@ int main(int argc, const char** argv)
     std::string main_file_path{ (tmp_dir / "jank-main-XXXXXX").string() };
 
     auto const fd{ mkstemp(main_file_path.data()) };
-    ::close(fd);
+    close(fd);
 
     std::ofstream out(main_file_path);
     out << sb.release();

--- a/compiler+runtime/src/cpp/jank/environment/check_health.cpp
+++ b/compiler+runtime/src/cpp/jank/environment/check_health.cpp
@@ -1,6 +1,8 @@
 #include <filesystem>
 #include <fstream>
 
+#include <unistd.h>
+
 #include <llvm/TargetParser/Host.h>
 #include <llvm/Support/Program.h>
 
@@ -340,7 +342,7 @@ namespace jank::environment
         auto const tmp{ std::filesystem::temp_directory_path() };
         std::string path_tmp{ (tmp / "jank-aot-XXXXXX").string() };
         int const fd{ mkstemp(path_tmp.data()) };
-        ::close(fd);
+        close(fd);
         std::filesystem::remove(path_tmp);
         std::filesystem::create_directories(path_tmp);
 

--- a/compiler+runtime/src/cpp/jank/runtime/module/loader.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/module/loader.cpp
@@ -141,7 +141,7 @@ namespace jank::runtime::module
       CloseHandle(fd->hMapping);
       CloseHandle(fd->hFile);
 #else
-      ::close(*fd);
+      close(*fd);
 #endif
       fd.reset();
     }

--- a/compiler+runtime/src/cpp/jank/terminal_repl_client.cpp
+++ b/compiler+runtime/src/cpp/jank/terminal_repl_client.cpp
@@ -4,6 +4,8 @@
 #include <set>
 #include <string>
 
+#include <unistd.h>
+
 #include <isocline.h>
 
 #include <jtl/terminal.hpp>
@@ -279,7 +281,7 @@ namespace jank::terminal_repl
     auto const tmp{ std::filesystem::temp_directory_path() };
     std::string path_tmp{ (tmp / "jank-repl-XXXXXX").string() };
     int const fd{ mkstemp(path_tmp.data()) };
-    ::close(fd);
+    close(fd);
 
     auto const first_res_var{ __rt_ctx->find_var("clojure.core", "*1") };
     auto const second_res_var{ __rt_ctx->find_var("clojure.core", "*2") };

--- a/compiler+runtime/src/cpp/jank/util/clang.cpp
+++ b/compiler+runtime/src/cpp/jank/util/clang.cpp
@@ -1,6 +1,8 @@
 #include <filesystem>
 #include <fstream>
 
+#include <unistd.h>
+
 #include <clang/Basic/Diagnostic.h>
 #include <clang/Basic/DiagnosticIDs.h>
 #include <clang/Basic/DiagnosticOptions.h>
@@ -31,7 +33,7 @@ namespace jank::util
     auto const tmp{ std::filesystem::temp_directory_path() };
     std::string path_tmp{ (tmp / "jank-clang-XXXXXX").string() };
     int const fd{ mkstemp(path_tmp.data()) };
-    ::close(fd);
+    close(fd);
     auto const proc_code{ llvm::sys::ExecuteAndWait(path.string(),
                                                     { path.string(), "--version" },
                                                     std::nullopt,

--- a/compiler+runtime/src/cpp/main.cpp
+++ b/compiler+runtime/src/cpp/main.cpp
@@ -3,6 +3,8 @@
 #include <fstream>
 #include <optional>
 
+#include <unistd.h>
+
 #include <isocline.h>
 
 #include <CppInterOp/Compatibility.h>

--- a/compiler+runtime/src/jank/jank/nrepl/server/capture.jank
+++ b/compiler+runtime/src/jank/jank/nrepl/server/capture.jank
@@ -1,7 +1,7 @@
 (ns jank.nrepl.server.capture
   (:include "cstdio"
-            "filesystem")
-  (:require [jank.nrepl.server.util :refer [close dup dup2 unlink]]))
+            "filesystem"
+            "unistd.h"))
 
 (def temp-file-template
   (str (.string (cpp/std.filesystem.temp_directory_path)) "/" "jank-nrepl-XXXXXX"))
@@ -21,15 +21,15 @@
   [fp*]
   (let [fp                  (cpp/unbox (:* FILE) fp*)
         fd                  (cpp/fileno fp)
-        bak-fd              (dup fd)
+        bak-fd              (cpp/dup fd)
         [temp-name temp-fd] (make-temp-file)]
     ;; First flush the stream to ensure any data from before we start capturing
     ;; is written.
     (cpp/fflush fp)
 
     ;; Redirect the stream to a temporary file which we can later read back.
-    (dup2 temp-fd fd)
-    (close temp-fd)
+    (cpp/dup2 temp-fd fd)
+    (cpp/close temp-fd)
 
     ;; Return a handle of what we've changed so that we can revert it later.
     {:fp*       fp*
@@ -47,16 +47,16 @@
     (cpp/fflush fp)
 
     ;; Bring it all back to its original state.
-    (dup2 bak-fd fd)
-    (close bak-fd)
-    (close temp-fd)))
+    (cpp/dup2 bak-fd fd)
+    (cpp/close bak-fd)
+    (cpp/close temp-fd)))
 
 (defn- readback
   "Read back the data which was captured by the handle. The data is deleted, so
   this can only be called once."
   [{:keys [temp-name]}]
   (let [s (slurp temp-name)]
-    (unlink temp-name)
+    (cpp/unlink temp-name)
     s))
 
 (defn with-capture

--- a/compiler+runtime/src/jank/jank/nrepl/server/util.jank
+++ b/compiler+runtime/src/jank/jank/nrepl/server/util.jank
@@ -9,18 +9,3 @@
               (str (subs x 0 n) "…")
               x))]
     (postwalk inner form)))
-
-(defmacro def-unistd
-  "Defines a macro FNAME that expands to a call to the corresponding
-  POSIX `unistd` function, using a portability symbol on Windows."
-  [fname]
-  `(defmacro ~fname [& args#]
-     (let [f# (if (= cpp/jtl.current_platform cpp/jtl.platform.windows_like)
-                (symbol "cpp" (str "folly.portability.unistd." ~(name fname)))
-                (symbol "cpp" ~(name fname)))]
-       `(~f# ~@args#))))
-;; Create cross platform POSIX unistd bindings
-(def-unistd close)
-(def-unistd dup)
-(def-unistd dup2)
-(def-unistd unlink)


### PR DESCRIPTION
Hi, could you please consider this patch to prevent Folly's `unistd` compatibility namespace from being promoted to the global namespace? It resolves #962.

MSYS2 provides a `unistd.h` API that conflicts with Folly's compatibility API when transitively included. The fix allows the MSYS2 API to be used directly, avoiding these conflicts.

The patch also improves the existing `exception_info` macro workaround by explicitly including MSYS2's `excpt.h` before undefining the macro, making it independent of transitive include order.

The Folly submodule currently points to my fork until https://github.com/jank-lang/folly/pull/3 is merged upstream, after which we'll switch to the upstream commit here before merging.

Thanks!
