### PR TITLE
Add ld script parser to fix some linkage issues on glibc-based Linux systems

### DIFF
--- a/compiler+runtime/CMakeLists.txt
+++ b/compiler+runtime/CMakeLists.txt
@@ -741,6 +741,7 @@ add_library(
   src/cpp/jank/runtime/context_dynamic.cpp
   src/cpp/jank/runtime/ns_dynamic.cpp
   src/cpp/jank/jit/object_dynamic.cpp
+  src/cpp/jank/jit/parse_ld_script.cpp
   src/cpp/jank/jit/processor_dynamic.cpp
   src/cpp/jank/codegen/api_dynamic.cpp
 )
@@ -977,6 +978,7 @@ if(jank_test)
     test/cpp/jank/runtime/obj/integer_range.cpp
     test/cpp/jank/runtime/obj/repeat.cpp
     test/cpp/jank/jit/processor.cpp
+    test/cpp/jank/jit/parse_ld_script.cpp
     test/cpp/jank/analyze/cpp_util.cpp
   )
   add_executable(jank::test_exe ALIAS jank_test_exe)

--- a/compiler+runtime/include/cpp/jank/jit/parse_ld_script.hpp
+++ b/compiler+runtime/include/cpp/jank/jit/parse_ld_script.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <jtl/immutable_string.hpp>
+#include <jtl/option.hpp>
+
+namespace jank::jit
+{
+  bool is_object_file(jtl::immutable_string const &path);
+  jtl::option<jtl::immutable_string> parse_ld_script(jtl::immutable_string const &path);
+}

--- a/compiler+runtime/include/cpp/jank/jit/parse_ld_script.hpp
+++ b/compiler+runtime/include/cpp/jank/jit/parse_ld_script.hpp
@@ -5,6 +5,6 @@
 
 namespace jank::jit
 {
-  bool is_object_file(jtl::immutable_string const &path);
+  bool is_elf_file(jtl::immutable_string const &path);
   jtl::option<jtl::immutable_string> parse_ld_script(jtl::immutable_string const &path);
 }

--- a/compiler+runtime/src/cpp/jank/jit/parse_ld_script.cpp
+++ b/compiler+runtime/src/cpp/jank/jit/parse_ld_script.cpp
@@ -11,12 +11,10 @@ namespace jank::jit
 {
   namespace
   {
-    /* Half-open [begin, end) byte range, within the (comment-stripped) script text, spanning
-     * the contents inside the outermost parentheses of a GROUP(...) or INPUT(...) directive. */
     struct directive_range
     {
-      std::size_t begin;
-      std::size_t end;
+      usize begin{};
+      usize end{};
     };
 
     bool is_identifier_character(char const c) noexcept
@@ -32,7 +30,7 @@ namespace jank::jit
     }
 
     bool matches_directive(std::string_view const source,
-                           std::size_t const position,
+                           usize const position,
                            std::string_view const directive) noexcept
     {
       if(position + directive.size() > source.size()
@@ -42,7 +40,7 @@ namespace jank::jit
       }
 
       /* Require word boundaries around the directive name so we don't match a substring of a
-       * longer identifier (e.g. some hypothetical `MY_GROUP` symbol). */
+       * longer identifier. */
       auto const has_identifier_before{ position > 0
                                         && is_identifier_character(source[position - 1]) };
       auto const directive_end{ position + directive.size() };
@@ -51,17 +49,13 @@ namespace jank::jit
       return !has_identifier_before && !has_identifier_after;
     }
 
-    /* Strips C-style block comments, which ld scripts (including the "GNU ld script" header
-     * comment glibc adds) may contain, before we try to find directives. We don't need to
-     * handle ld's line comments (# ...) since glibc's generated scripts don't use them, and
-     * skipping that keeps this simpler. */
     std::string strip_comments(std::string_view const source)
     {
       std::string result;
       result.reserve(source.size());
 
       bool in_comment{ false };
-      for(std::size_t i{}; i < source.size(); ++i)
+      for(usize i{}; i < source.size(); ++i)
       {
         if(in_comment)
         {
@@ -89,17 +83,15 @@ namespace jank::jit
     jtl::option<directive_range> find_input_directive(std::string_view const source)
     {
       /* We only care about the first top-level GROUP(...) or INPUT(...) we find. Real-world
-       * ld scripts (e.g. glibc's libm.so) only ever contain one, and this keeps us from having
-       * to build a full ld script grammar for directives we don't need (OUTPUT_FORMAT,
-       * SEARCH_DIR, etc). */
+       * ld scripts only ever contain one. I'm not going to write a full robust parser. */
       static std::array<std::string_view, 2> const directives{ "GROUP", "INPUT" };
-      std::size_t parenthesis_depth{};
+      usize parenthesis_depth{};
 
-      for(std::size_t i{}; i < source.size(); ++i)
+      for(usize i{}; i < source.size(); ++i)
       {
         /* Only look for directives when we're not already nested inside some other
-         * parenthesized construct, so we don't, say, match "INPUT" appearing as an argument
-         * to another directive. */
+         * parenthesized construct. This way we don't match "INPUT" appearing as an argument
+         * to another directive, for example. */
         if(parenthesis_depth == 0)
         {
           for(auto const directive : directives)
@@ -119,8 +111,8 @@ namespace jank::jit
               continue;
             }
 
-            /* Track nested parentheses (e.g. from AS_NEEDED(...) inside GROUP(...)) so we find
-             * the matching close paren for the directive itself, not an inner one. */
+            /* Track nested parentheses so we find the matching close paren for the
+             * directive itself, not an inner one. */
             auto depth{ 1u };
             for(auto close_paren{ open_paren + 1 }; close_paren < source.size(); ++close_paren)
             {
@@ -137,6 +129,7 @@ namespace jank::jit
                 }
               }
             }
+
             /* Unbalanced parentheses; treat this as an unparsable script. */
             return none;
           }
@@ -156,11 +149,9 @@ namespace jank::jit
     }
 
     /* Reads a single token from `source[position, end)`, advancing `position` past it. Handles
-     * both quoted tokens (ld scripts may quote paths containing special characters) and bare
-     * tokens delimited by whitespace/commas/parens. Returns an empty string at `end` or when
-     * the caller calls this pointed at a delimiter (which it filters out before calling). */
-    std::string
-    read_token(std::string_view const source, std::size_t &position, std::size_t const end)
+     * both quoted tokens and bare tokens delimited by whitespace/commas/parens.
+     * Returns an empty string at `end`. */
+    std::string read_token(std::string_view const source, usize &position, usize const end)
     {
       if(position >= end)
       {
@@ -217,47 +208,35 @@ namespace jank::jit
     }
   }
 
-  /* Distinguishes a real object/shared-library file from a textual GNU ld linker script (the
-   * form glibc ships some "shared libraries" as, e.g. libm.so, in order to pull in a GROUP of
-   * several actual .so files). LLVM's JIT dynamic loader can only load real ELF/Mach-O/PE
-   * binaries, so we peek at the file's leading bytes to detect one before handing it off.
-   *
-   * We check for every format jank might plausibly encounter across its supported platforms
-   * (Linux, macOS, and Windows), even though only one is relevant on any given build, since
-   * this is cheap and keeps the check self-contained and easy to extend. */
   bool is_object_file(jtl::immutable_string const &path)
   {
     std::array<unsigned char, 4> magic{};
     std::ifstream file{ path.c_str(), std::ios::binary };
     if(!file.read(reinterpret_cast<char *>(magic.data()), magic.size()))
     {
-      /* Files shorter than 4 bytes, or otherwise unreadable, can't be a real object file. Ld
-       * scripts are always longer than this, so it's safe to report false here rather than
-       * treating this as "unknown". */
+      /* Files shorter than 4 bytes, or otherwise unreadable, can't be a real object file. */
       return false;
     }
 
-    if(magic == std::array<unsigned char, 4>{ 0x7f, 'E', 'L', 'F' } /* ELF (Linux). */
-       || magic == std::array<unsigned char, 4>{ 0xfe, 0xed, 0xfa, 0xce }
+    if(/* ELF (Linux). */
+       magic == std::array<unsigned char, 4>{ 0x7f, 'E', 'L', 'F' }
+
        /* Mach-O 32-bit, big-endian. */
-       || magic == std::array<unsigned char, 4>{ 0xce, 0xfa, 0xed, 0xfe }
+       || magic == std::array<unsigned char, 4>{ 0xfe, 0xed, 0xfa, 0xce }
        /* Mach-O 32-bit, little-endian. */
-       || magic == std::array<unsigned char, 4>{ 0xfe, 0xed, 0xfa, 0xcf }
+       || magic == std::array<unsigned char, 4>{ 0xce, 0xfa, 0xed, 0xfe }
        /* Mach-O 64-bit, big-endian. */
-       || magic == std::array<unsigned char, 4>{ 0xcf, 0xfa, 0xed, 0xfe }
+       || magic == std::array<unsigned char, 4>{ 0xfe, 0xed, 0xfa, 0xcf }
        /* Mach-O 64-bit, little-endian (macOS). */
-       || magic == std::array<unsigned char, 4>{ 0xca, 0xfe, 0xba, 0xbe }
+       || magic == std::array<unsigned char, 4>{ 0xcf, 0xfa, 0xed, 0xfe }
        /* Mach-O fat/universal binary, big-endian. */
-       || magic == std::array<unsigned char, 4>{ 0xbe, 0xba, 0xfe, 0xca }
+       || magic == std::array<unsigned char, 4>{ 0xca, 0xfe, 0xba, 0xbe }
        /* Mach-O fat/universal binary, little-endian. */
-       || magic == std::array<unsigned char, 4>{ 0xca, 0xfe, 0xba, 0xbf }
+       || magic == std::array<unsigned char, 4>{ 0xbe, 0xba, 0xfe, 0xca }
        /* Mach-O fat/universal binary, 64-bit, big-endian. */
-       || magic
-         == std::array<unsigned char, 4>{
-           0xbf,
-           0xba,
-           0xfe,
-           0xca } /* Mach-O fat/universal binary, 64-bit, little-endian. */)
+       || magic == std::array<unsigned char, 4>{ 0xca, 0xfe, 0xba, 0xbf }
+       /* Mach-O fat/universal binary, 64-bit, little-endian. */
+       || magic == std::array<unsigned char, 4>{ 0xbf, 0xba, 0xfe, 0xca })
     {
       return true;
     }
@@ -269,18 +248,15 @@ namespace jank::jit
   }
 
   /* Attempts to parse `path` as a GNU ld linker script and extract the real shared library it
-   * points at. glibc, on many Linux systems (notably Nix), ships some "shared libraries" (e.g.
-   * libm.so) as text scripts like:
+   * points at. glibc, on many Linux systems, ships some "shared libraries" as text scripts like:
    *
    *   GROUP ( /path/to/libm.so.6 AS_NEEDED ( /path/to/libmvec.so.1 ) )
    *
-   * Here, libm.so.6 is the library we actually want to load; libmvec.so.1 is only pulled in
-   * if something in the binary actually needs symbols from it (that's what AS_NEEDED means to
-   * the real `ld`). We don't do the "does anything need this" analysis ourselves, so we prefer
-   * the first library that's *not* wrapped in AS_NEEDED, since that's the one the script
-   * considers unconditionally required. If every path is wrapped in AS_NEEDED, we fall back to
-   * the very first one we saw, on the assumption that it's more likely to be useful than
-   * loading nothing at all. */
+   * Here, libm.so.6 is the library we actually want to load. libmvec.so.1 is only pulled in
+   * if something in the binary actually needs symbols from it. We don't do the
+   * "does anything need this" analysis ourselves, so we prefer the first library that's
+   * not wrapped in AS_NEEDED. If every path is wrapped in AS_NEEDED, we fall back to
+   * the very first one we saw. That's more likely to be useful than loading nothing at all. */
   jtl::option<jtl::immutable_string> parse_ld_script(jtl::immutable_string const &path)
   {
     auto const contents{ read_file(path) };
@@ -297,10 +273,10 @@ namespace jank::jit
     }
 
     auto const range{ directive.unwrap() };
-    std::size_t position{ range.begin };
+    usize position{ range.begin };
     /* How many nested AS_NEEDED(...) wrappers we're currently inside of, while scanning the
      * directive's argument list. */
-    std::size_t as_needed_depth{};
+    usize as_needed_depth{};
     bool found_path{};
     bool found_required_path{};
     std::string first_path;

--- a/compiler+runtime/src/cpp/jank/jit/parse_ld_script.cpp
+++ b/compiler+runtime/src/cpp/jank/jit/parse_ld_script.cpp
@@ -1,0 +1,312 @@
+#include <jank/jit/parse_ld_script.hpp>
+
+#include <array>
+#include <cctype>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <string_view>
+
+namespace jank::jit
+{
+  namespace
+  {
+    struct directive_range
+    {
+      std::size_t begin;
+      std::size_t end;
+    };
+
+    bool is_identifier_character(char const c) noexcept
+    {
+      auto const unsigned_c{ static_cast<unsigned char>(c) };
+      return std::isalnum(unsigned_c) != 0 || c == '_';
+    }
+
+    bool is_separator(char const c) noexcept
+    {
+      auto const unsigned_c{ static_cast<unsigned char>(c) };
+      return std::isspace(unsigned_c) != 0 || c == ',';
+    }
+
+    bool matches_directive(std::string_view const source,
+                           std::size_t const position,
+                           std::string_view const directive) noexcept
+    {
+      if(position + directive.size() > source.size()
+         || source.compare(position, directive.size(), directive) != 0)
+      {
+        return false;
+      }
+
+      auto const has_identifier_before{ position > 0
+                                        && is_identifier_character(source[position - 1]) };
+      auto const directive_end{ position + directive.size() };
+      auto const has_identifier_after{ directive_end < source.size()
+                                       && is_identifier_character(source[directive_end]) };
+      return !has_identifier_before && !has_identifier_after;
+    }
+
+    std::string strip_comments(std::string_view const source)
+    {
+      std::string result;
+      result.reserve(source.size());
+
+      bool in_comment{ false };
+      for(std::size_t i{}; i < source.size(); ++i)
+      {
+        if(in_comment)
+        {
+          if(source[i] == '*' && i + 1 < source.size() && source[i + 1] == '/')
+          {
+            in_comment = false;
+            ++i;
+          }
+          continue;
+        }
+
+        if(source[i] == '/' && i + 1 < source.size() && source[i + 1] == '*')
+        {
+          in_comment = true;
+          ++i;
+          continue;
+        }
+
+        result.push_back(source[i]);
+      }
+
+      return result;
+    }
+
+    jtl::option<directive_range> find_input_directive(std::string_view const source)
+    {
+      static std::array<std::string_view, 2> const directives{ "GROUP", "INPUT" };
+      std::size_t parenthesis_depth{};
+
+      for(std::size_t i{}; i < source.size(); ++i)
+      {
+        if(parenthesis_depth == 0)
+        {
+          for(auto const directive : directives)
+          {
+            if(!matches_directive(source, i, directive))
+            {
+              continue;
+            }
+
+            auto open_paren{ i + directive.size() };
+            while(open_paren < source.size() && is_separator(source[open_paren]))
+            {
+              ++open_paren;
+            }
+            if(open_paren >= source.size() || source[open_paren] != '(')
+            {
+              continue;
+            }
+
+            auto depth{ 1u };
+            for(auto close_paren{ open_paren + 1 }; close_paren < source.size(); ++close_paren)
+            {
+              if(source[close_paren] == '(')
+              {
+                ++depth;
+              }
+              else if(source[close_paren] == ')')
+              {
+                --depth;
+                if(depth == 0)
+                {
+                  return directive_range{ open_paren + 1, close_paren };
+                }
+              }
+            }
+            return none;
+          }
+        }
+
+        if(source[i] == '(')
+        {
+          ++parenthesis_depth;
+        }
+        else if(source[i] == ')' && parenthesis_depth > 0)
+        {
+          --parenthesis_depth;
+        }
+      }
+
+      return none;
+    }
+
+    std::string
+    read_token(std::string_view const source, std::size_t &position, std::size_t const end)
+    {
+      if(position >= end)
+      {
+        return {};
+      }
+
+      if(source[position] == '"' || source[position] == '\'')
+      {
+        auto const quote{ source[position++] };
+        std::string token;
+        while(position < end && source[position] != quote)
+        {
+          if(source[position] == '\\' && position + 1 < end)
+          {
+            token.push_back(source[position + 1]);
+            position += 2;
+          }
+          else
+          {
+            token.push_back(source[position++]);
+          }
+        }
+        if(position < end)
+        {
+          ++position;
+        }
+        return token;
+      }
+
+      auto const begin{ position };
+      while(position < end && !is_separator(source[position]) && source[position] != '('
+            && source[position] != ')')
+      {
+        ++position;
+      }
+      return std::string{ source.substr(begin, position - begin) };
+    }
+
+    jtl::option<std::string> read_file(jtl::immutable_string const &path)
+    {
+      std::ifstream file{ path.c_str(), std::ios::binary };
+      if(!file)
+      {
+        return none;
+      }
+
+      std::string contents{ std::istreambuf_iterator<char>{ file },
+                            std::istreambuf_iterator<char>{} };
+      if(file.bad())
+      {
+        return none;
+      }
+      return contents;
+    }
+  }
+
+  bool is_object_file(jtl::immutable_string const &path)
+  {
+    std::array<unsigned char, 4> magic{};
+    std::ifstream file{ path.c_str(), std::ios::binary };
+    if(!file.read(reinterpret_cast<char *>(magic.data()), magic.size()))
+    {
+      return false;
+    }
+
+    if(magic == std::array<unsigned char, 4>{ 0x7f, 'E', 'L', 'F' }
+       || magic == std::array<unsigned char, 4>{ 0xfe, 0xed, 0xfa, 0xce }
+       || magic == std::array<unsigned char, 4>{ 0xce, 0xfa, 0xed, 0xfe }
+       || magic == std::array<unsigned char, 4>{ 0xfe, 0xed, 0xfa, 0xcf }
+       || magic == std::array<unsigned char, 4>{ 0xcf, 0xfa, 0xed, 0xfe }
+       || magic == std::array<unsigned char, 4>{ 0xca, 0xfe, 0xba, 0xbe }
+       || magic == std::array<unsigned char, 4>{ 0xbe, 0xba, 0xfe, 0xca }
+       || magic == std::array<unsigned char, 4>{ 0xca, 0xfe, 0xba, 0xbf }
+       || magic == std::array<unsigned char, 4>{ 0xbf, 0xba, 0xfe, 0xca })
+    {
+      return true;
+    }
+
+    return magic[0] == 'M' && magic[1] == 'Z';
+  }
+
+  jtl::option<jtl::immutable_string> parse_ld_script(jtl::immutable_string const &path)
+  {
+    auto const contents{ read_file(path) };
+    if(contents.is_none())
+    {
+      return none;
+    }
+
+    auto const script{ strip_comments(contents.unwrap()) };
+    auto const directive{ find_input_directive(script) };
+    if(directive.is_none())
+    {
+      return none;
+    }
+
+    auto const range{ directive.unwrap() };
+    std::size_t position{ range.begin };
+    std::size_t as_needed_depth{};
+    bool found_path{};
+    bool found_required_path{};
+    std::string first_path;
+    std::string first_required_path;
+
+    while(position < range.end)
+    {
+      if(is_separator(script[position]))
+      {
+        ++position;
+        continue;
+      }
+
+      if(script[position] == '(')
+      {
+        ++position;
+        continue;
+      }
+
+      if(script[position] == ')')
+      {
+        if(as_needed_depth > 0)
+        {
+          --as_needed_depth;
+        }
+        ++position;
+        continue;
+      }
+
+      auto token{ read_token(script, position, range.end) };
+      if(token.empty())
+      {
+        continue;
+      }
+
+      if(token == "AS_NEEDED")
+      {
+        while(position < range.end && is_separator(script[position]))
+        {
+          ++position;
+        }
+        if(position < range.end && script[position] == '(')
+        {
+          ++as_needed_depth;
+          ++position;
+        }
+        continue;
+      }
+
+      if(!found_path)
+      {
+        first_path = token;
+        found_path = true;
+      }
+      if(as_needed_depth == 0 && !found_required_path)
+      {
+        first_required_path = token;
+        found_required_path = true;
+      }
+    }
+
+    if(found_required_path)
+    {
+      return jtl::immutable_string{ first_required_path };
+    }
+    if(found_path)
+    {
+      return jtl::immutable_string{ first_path };
+    }
+    return none;
+  }
+}

--- a/compiler+runtime/src/cpp/jank/jit/parse_ld_script.cpp
+++ b/compiler+runtime/src/cpp/jank/jit/parse_ld_script.cpp
@@ -208,7 +208,7 @@ namespace jank::jit
     }
   }
 
-  bool is_object_file(jtl::immutable_string const &path)
+  bool is_elf_file(jtl::immutable_string const &path)
   {
     std::array<unsigned char, 4> magic{};
     std::ifstream file{ path.c_str(), std::ios::binary };
@@ -218,33 +218,7 @@ namespace jank::jit
       return false;
     }
 
-    if(/* ELF (Linux). */
-       magic == std::array<unsigned char, 4>{ 0x7f, 'E', 'L', 'F' }
-
-       /* Mach-O 32-bit, big-endian. */
-       || magic == std::array<unsigned char, 4>{ 0xfe, 0xed, 0xfa, 0xce }
-       /* Mach-O 32-bit, little-endian. */
-       || magic == std::array<unsigned char, 4>{ 0xce, 0xfa, 0xed, 0xfe }
-       /* Mach-O 64-bit, big-endian. */
-       || magic == std::array<unsigned char, 4>{ 0xfe, 0xed, 0xfa, 0xcf }
-       /* Mach-O 64-bit, little-endian (macOS). */
-       || magic == std::array<unsigned char, 4>{ 0xcf, 0xfa, 0xed, 0xfe }
-       /* Mach-O fat/universal binary, big-endian. */
-       || magic == std::array<unsigned char, 4>{ 0xca, 0xfe, 0xba, 0xbe }
-       /* Mach-O fat/universal binary, little-endian. */
-       || magic == std::array<unsigned char, 4>{ 0xbe, 0xba, 0xfe, 0xca }
-       /* Mach-O fat/universal binary, 64-bit, big-endian. */
-       || magic == std::array<unsigned char, 4>{ 0xca, 0xfe, 0xba, 0xbf }
-       /* Mach-O fat/universal binary, 64-bit, little-endian. */
-       || magic == std::array<unsigned char, 4>{ 0xbf, 0xba, 0xfe, 0xca })
-    {
-      return true;
-    }
-
-    /* PE/COFF (Windows DLLs) start with the "MZ" DOS header magic; we don't need to look any
-     * further into the PE header, since only the first two bytes are needed to disambiguate
-     * this from a text-based ld script. */
-    return magic[0] == 'M' && magic[1] == 'Z';
+    return magic == std::array<unsigned char, 4>{ 0x7f, 'E', 'L', 'F' };
   }
 
   /* Attempts to parse `path` as a GNU ld linker script and extract the real shared library it

--- a/compiler+runtime/src/cpp/jank/jit/parse_ld_script.cpp
+++ b/compiler+runtime/src/cpp/jank/jit/parse_ld_script.cpp
@@ -11,6 +11,8 @@ namespace jank::jit
 {
   namespace
   {
+    /* Half-open [begin, end) byte range, within the (comment-stripped) script text, spanning
+     * the contents inside the outermost parentheses of a GROUP(...) or INPUT(...) directive. */
     struct directive_range
     {
       std::size_t begin;
@@ -39,6 +41,8 @@ namespace jank::jit
         return false;
       }
 
+      /* Require word boundaries around the directive name so we don't match a substring of a
+       * longer identifier (e.g. some hypothetical `MY_GROUP` symbol). */
       auto const has_identifier_before{ position > 0
                                         && is_identifier_character(source[position - 1]) };
       auto const directive_end{ position + directive.size() };
@@ -47,6 +51,10 @@ namespace jank::jit
       return !has_identifier_before && !has_identifier_after;
     }
 
+    /* Strips C-style block comments, which ld scripts (including the "GNU ld script" header
+     * comment glibc adds) may contain, before we try to find directives. We don't need to
+     * handle ld's line comments (# ...) since glibc's generated scripts don't use them, and
+     * skipping that keeps this simpler. */
     std::string strip_comments(std::string_view const source)
     {
       std::string result;
@@ -80,11 +88,18 @@ namespace jank::jit
 
     jtl::option<directive_range> find_input_directive(std::string_view const source)
     {
+      /* We only care about the first top-level GROUP(...) or INPUT(...) we find. Real-world
+       * ld scripts (e.g. glibc's libm.so) only ever contain one, and this keeps us from having
+       * to build a full ld script grammar for directives we don't need (OUTPUT_FORMAT,
+       * SEARCH_DIR, etc). */
       static std::array<std::string_view, 2> const directives{ "GROUP", "INPUT" };
       std::size_t parenthesis_depth{};
 
       for(std::size_t i{}; i < source.size(); ++i)
       {
+        /* Only look for directives when we're not already nested inside some other
+         * parenthesized construct, so we don't, say, match "INPUT" appearing as an argument
+         * to another directive. */
         if(parenthesis_depth == 0)
         {
           for(auto const directive : directives)
@@ -104,6 +119,8 @@ namespace jank::jit
               continue;
             }
 
+            /* Track nested parentheses (e.g. from AS_NEEDED(...) inside GROUP(...)) so we find
+             * the matching close paren for the directive itself, not an inner one. */
             auto depth{ 1u };
             for(auto close_paren{ open_paren + 1 }; close_paren < source.size(); ++close_paren)
             {
@@ -120,6 +137,7 @@ namespace jank::jit
                 }
               }
             }
+            /* Unbalanced parentheses; treat this as an unparsable script. */
             return none;
           }
         }
@@ -137,6 +155,10 @@ namespace jank::jit
       return none;
     }
 
+    /* Reads a single token from `source[position, end)`, advancing `position` past it. Handles
+     * both quoted tokens (ld scripts may quote paths containing special characters) and bare
+     * tokens delimited by whitespace/commas/parens. Returns an empty string at `end` or when
+     * the caller calls this pointed at a delimiter (which it filters out before calling). */
     std::string
     read_token(std::string_view const source, std::size_t &position, std::size_t const end)
     {
@@ -195,31 +217,70 @@ namespace jank::jit
     }
   }
 
+  /* Distinguishes a real object/shared-library file from a textual GNU ld linker script (the
+   * form glibc ships some "shared libraries" as, e.g. libm.so, in order to pull in a GROUP of
+   * several actual .so files). LLVM's JIT dynamic loader can only load real ELF/Mach-O/PE
+   * binaries, so we peek at the file's leading bytes to detect one before handing it off.
+   *
+   * We check for every format jank might plausibly encounter across its supported platforms
+   * (Linux, macOS, and Windows), even though only one is relevant on any given build, since
+   * this is cheap and keeps the check self-contained and easy to extend. */
   bool is_object_file(jtl::immutable_string const &path)
   {
     std::array<unsigned char, 4> magic{};
     std::ifstream file{ path.c_str(), std::ios::binary };
     if(!file.read(reinterpret_cast<char *>(magic.data()), magic.size()))
     {
+      /* Files shorter than 4 bytes, or otherwise unreadable, can't be a real object file. Ld
+       * scripts are always longer than this, so it's safe to report false here rather than
+       * treating this as "unknown". */
       return false;
     }
 
-    if(magic == std::array<unsigned char, 4>{ 0x7f, 'E', 'L', 'F' }
+    if(magic == std::array<unsigned char, 4>{ 0x7f, 'E', 'L', 'F' } /* ELF (Linux). */
        || magic == std::array<unsigned char, 4>{ 0xfe, 0xed, 0xfa, 0xce }
+       /* Mach-O 32-bit, big-endian. */
        || magic == std::array<unsigned char, 4>{ 0xce, 0xfa, 0xed, 0xfe }
+       /* Mach-O 32-bit, little-endian. */
        || magic == std::array<unsigned char, 4>{ 0xfe, 0xed, 0xfa, 0xcf }
+       /* Mach-O 64-bit, big-endian. */
        || magic == std::array<unsigned char, 4>{ 0xcf, 0xfa, 0xed, 0xfe }
+       /* Mach-O 64-bit, little-endian (macOS). */
        || magic == std::array<unsigned char, 4>{ 0xca, 0xfe, 0xba, 0xbe }
+       /* Mach-O fat/universal binary, big-endian. */
        || magic == std::array<unsigned char, 4>{ 0xbe, 0xba, 0xfe, 0xca }
+       /* Mach-O fat/universal binary, little-endian. */
        || magic == std::array<unsigned char, 4>{ 0xca, 0xfe, 0xba, 0xbf }
-       || magic == std::array<unsigned char, 4>{ 0xbf, 0xba, 0xfe, 0xca })
+       /* Mach-O fat/universal binary, 64-bit, big-endian. */
+       || magic
+         == std::array<unsigned char, 4>{
+           0xbf,
+           0xba,
+           0xfe,
+           0xca } /* Mach-O fat/universal binary, 64-bit, little-endian. */)
     {
       return true;
     }
 
+    /* PE/COFF (Windows DLLs) start with the "MZ" DOS header magic; we don't need to look any
+     * further into the PE header, since only the first two bytes are needed to disambiguate
+     * this from a text-based ld script. */
     return magic[0] == 'M' && magic[1] == 'Z';
   }
 
+  /* Attempts to parse `path` as a GNU ld linker script and extract the real shared library it
+   * points at. glibc, on many Linux systems (notably Nix), ships some "shared libraries" (e.g.
+   * libm.so) as text scripts like:
+   *
+   *   GROUP ( /path/to/libm.so.6 AS_NEEDED ( /path/to/libmvec.so.1 ) )
+   *
+   * Here, libm.so.6 is the library we actually want to load; libmvec.so.1 is only pulled in
+   * if something in the binary actually needs symbols from it (that's what AS_NEEDED means to
+   * the real `ld`). We don't do the "does anything need this" analysis ourselves, so we prefer
+   * the first library that's *not* wrapped in AS_NEEDED, since that's the one the script
+   * considers unconditionally required. If every path is wrapped in AS_NEEDED, we fall back to
+   * the very first one we saw, on the assumption that it's more likely to be useful than
+   * loading nothing at all. */
   jtl::option<jtl::immutable_string> parse_ld_script(jtl::immutable_string const &path)
   {
     auto const contents{ read_file(path) };
@@ -237,6 +298,8 @@ namespace jank::jit
 
     auto const range{ directive.unwrap() };
     std::size_t position{ range.begin };
+    /* How many nested AS_NEEDED(...) wrappers we're currently inside of, while scanning the
+     * directive's argument list. */
     std::size_t as_needed_depth{};
     bool found_path{};
     bool found_required_path{};

--- a/compiler+runtime/src/cpp/jank/jit/parse_ld_script.cpp
+++ b/compiler+runtime/src/cpp/jank/jit/parse_ld_script.cpp
@@ -17,13 +17,13 @@ namespace jank::jit
       usize end{};
     };
 
-    bool is_identifier_character(char const c) noexcept
+    bool is_identifier_character(char const c)
     {
       auto const unsigned_c{ static_cast<unsigned char>(c) };
       return std::isalnum(unsigned_c) != 0 || c == '_';
     }
 
-    bool is_separator(char const c) noexcept
+    bool is_separator(char const c)
     {
       auto const unsigned_c{ static_cast<unsigned char>(c) };
       return std::isspace(unsigned_c) != 0 || c == ',';
@@ -31,7 +31,7 @@ namespace jank::jit
 
     bool matches_directive(std::string_view const source,
                            usize const position,
-                           std::string_view const directive) noexcept
+                           std::string_view const directive)
     {
       if(position + directive.size() > source.size()
          || source.compare(position, directive.size(), directive) != 0)

--- a/compiler+runtime/src/cpp/jank/jit/processor_dynamic.cpp
+++ b/compiler+runtime/src/cpp/jank/jit/processor_dynamic.cpp
@@ -1,4 +1,3 @@
-#include <dlfcn.h>
 #include <cstdlib>
 #include <filesystem>
 
@@ -41,6 +40,10 @@
 #include <jank/error/system.hpp>
 #include <jank/error/runtime.hpp>
 #include <jank/error/codegen.hpp>
+
+#ifdef JANK_MACOS_LIKE
+  #include <dlfcn.h>
+#endif
 
 namespace jank::jit
 {

--- a/compiler+runtime/src/cpp/jank/jit/processor_dynamic.cpp
+++ b/compiler+runtime/src/cpp/jank/jit/processor_dynamic.cpp
@@ -810,35 +810,38 @@ namespace jank::jit
                                    jtl::immutable_string const &path,
                                    usize const depth)
     {
-      if(!is_object_file(path))
+      if constexpr(jtl::current_platform == jtl::platform::linux_like)
       {
-        if(auto const resolved{ parse_ld_script(path) }; resolved.is_some())
+        if(!is_elf_file(path))
         {
-          if(depth >= max_ld_script_depth)
+          if(auto const resolved{ parse_ld_script(path) }; resolved.is_some())
           {
-            throw std::runtime_error{ util::format(
-              "Exceeded the maximum GNU ld script nesting depth while loading `{}`.",
-              path) };
-          }
+            if(depth >= max_ld_script_depth)
+            {
+              throw std::runtime_error{ util::format(
+                "Exceeded the maximum GNU ld script nesting depth while loading `{}`.",
+                path) };
+            }
 
-          auto const script_path{ std::filesystem::path{ path.c_str() } };
-          auto resolved_path{ std::filesystem::path{ resolved.unwrap().c_str() } };
-          if(resolved_path.is_relative())
-          {
-            resolved_path = script_path.parent_path() / resolved_path;
-          }
-          resolved_path = resolved_path.lexically_normal();
+            auto const script_path{ std::filesystem::path{ path.c_str() } };
+            auto resolved_path{ std::filesystem::path{ resolved.unwrap().c_str() } };
+            if(resolved_path.is_relative())
+            {
+              resolved_path = script_path.parent_path() / resolved_path;
+            }
+            resolved_path = resolved_path.lexically_normal();
 
-          if(resolved_path == script_path.lexically_normal())
-          {
-            throw std::runtime_error{ util::format("This GNU ld script `{}` refers to itself.",
-                                                   path) };
-          }
+            if(resolved_path == script_path.lexically_normal())
+            {
+              throw std::runtime_error{ util::format("This GNU ld script `{}` refers to itself.",
+                                                     path) };
+            }
 
-          load_dynamic_library_impl(prc,
-                                    jtl::immutable_string{ resolved_path.string() },
-                                    depth + 1);
-          return;
+            load_dynamic_library_impl(prc,
+                                      jtl::immutable_string{ resolved_path.string() },
+                                      depth + 1);
+            return;
+          }
         }
       }
 

--- a/compiler+runtime/src/cpp/jank/jit/processor_dynamic.cpp
+++ b/compiler+runtime/src/cpp/jank/jit/processor_dynamic.cpp
@@ -716,13 +716,12 @@ namespace jank::jit
      * of that into jank, but a simpler way is to just try to open the lib via `dlopen`, which
      * will handle all of this for us. If it opens, we clearly found it and we can just
      * return the lib name as is. This short-circuits the rest of the searching machinery. */
-    if constexpr(jtl::current_platform == jtl::platform::macos_like)
+#ifdef JANK_MACOS_LIKE
+    if(::dlopen(lib.c_str(), RTLD_LAZY | RTLD_GLOBAL))
     {
-      if(::dlopen(lib.c_str(), RTLD_LAZY | RTLD_GLOBAL))
-      {
-        return lib;
-      }
+      return lib;
     }
+#endif
 
     return none;
   }

--- a/compiler+runtime/src/cpp/jank/jit/processor_dynamic.cpp
+++ b/compiler+runtime/src/cpp/jank/jit/processor_dynamic.cpp
@@ -23,6 +23,7 @@
 #include <CppInterOp/CppInterOp.h>
 
 #include <jank/jit/object.hpp>
+#include <jank/jit/parse_ld_script.hpp>
 #include <jank/jit/processor.hpp>
 #include <jank/util/make_array.hpp>
 #include <jank/util/environment.hpp>
@@ -797,9 +798,53 @@ namespace jank::jit
     return ok();
   }
 
+  namespace
+  {
+    constexpr usize max_ld_script_depth{ 8 };
+
+    void load_dynamic_library_impl(processor const &prc,
+                                   jtl::immutable_string const &path,
+                                   usize const depth)
+    {
+      if(!is_object_file(path))
+      {
+        if(auto const resolved{ parse_ld_script(path) }; resolved.is_some())
+        {
+          if(depth >= max_ld_script_depth)
+          {
+            throw std::runtime_error{ util::format(
+              "Exceeded the maximum GNU ld script nesting depth while loading '{}'.",
+              path) };
+          }
+
+          auto const script_path{ std::filesystem::path{ path.c_str() } };
+          auto resolved_path{ std::filesystem::path{ resolved.unwrap().c_str() } };
+          if(resolved_path.is_relative())
+          {
+            resolved_path = script_path.parent_path() / resolved_path;
+          }
+          resolved_path = resolved_path.lexically_normal();
+
+          if(resolved_path == script_path.lexically_normal())
+          {
+            throw std::runtime_error{ util::format("GNU ld script '{}' refers to itself.", path) };
+          }
+
+          load_dynamic_library_impl(prc,
+                                    jtl::immutable_string{ resolved_path.string() },
+                                    depth + 1);
+          return;
+        }
+      }
+
+      llvm::cantFail(
+        static_cast<clang::Interpreter &>(*prc.interpreter).LoadDynamicLibrary(path.data()));
+    }
+  }
+
   void processor::load_dynamic_library(jtl::immutable_string const &path) const
   {
-    llvm::cantFail(static_cast<clang::Interpreter &>(*interpreter).LoadDynamicLibrary(path.data()));
+    load_dynamic_library_impl(*this, path, 0);
   }
 
   void processor::load_static_library(jtl::immutable_string const &path) const

--- a/compiler+runtime/src/cpp/jank/jit/processor_dynamic.cpp
+++ b/compiler+runtime/src/cpp/jank/jit/processor_dynamic.cpp
@@ -1,3 +1,7 @@
+#include <dlfcn.h>
+#include <cstdlib>
+#include <filesystem>
+
 #include <clang/AST/Type.h>
 #include <clang/Basic/Diagnostic.h>
 #include <clang/Frontend/CompilerInstance.h>
@@ -15,9 +19,6 @@
 #include <llvm/Object/SymbolSize.h>
 #include <llvm/IRReader/IRReader.h>
 #include <llvm/Support/Signals.h>
-
-#include <cstdlib>
-#include <filesystem>
 
 #include <CppInterOp/Compatibility.h>
 #include <CppInterOp/CppInterOp.h>
@@ -703,6 +704,20 @@ namespace jank::jit
       if(std::filesystem::is_regular_file(lib_abs_path.c_str()))
       {
         return lib_abs_path;
+      }
+    }
+
+    /* On macOS, since Big Sur, dylib files aren't just stored on the filesystem. So, if we
+     * want to load libz.dylib, we can't just look for it normally. Instead, there's a whole
+     * dyld shared cache, a new .tbd file format, and custom linker support. We could add all
+     * of that into jank, but a simpler way is to just try to open the lib via `dlopen`, which
+     * will handle all of this for us. If it opens, we clearly found it and we can just
+     * return the lib name as is. This short-circuits the rest of the searching machinery. */
+    if constexpr(jtl::current_platform == jtl::platform::macos_like)
+    {
+      if(::dlopen(lib.c_str(), RTLD_LAZY | RTLD_GLOBAL))
+      {
+        return lib;
       }
     }
 

--- a/compiler+runtime/src/cpp/jank/jit/processor_dynamic.cpp
+++ b/compiler+runtime/src/cpp/jank/jit/processor_dynamic.cpp
@@ -802,6 +802,10 @@ namespace jank::jit
   {
     constexpr usize max_ld_script_depth{ 8 };
 
+    /* On Linux, shared libraries (.so files) can actually be text files which are ld scripts
+     * teling the linker which libs to bring in. The LLVM JIT doesn't handle these, so we do
+     * our own handling here. This is recursive, since the referenced .so in a ld script
+     * may be a ld script itself. We don't want to get stuck in a loop with this, though. */
     void load_dynamic_library_impl(processor const &prc,
                                    jtl::immutable_string const &path,
                                    usize const depth)
@@ -813,7 +817,7 @@ namespace jank::jit
           if(depth >= max_ld_script_depth)
           {
             throw std::runtime_error{ util::format(
-              "Exceeded the maximum GNU ld script nesting depth while loading '{}'.",
+              "Exceeded the maximum GNU ld script nesting depth while loading `{}`.",
               path) };
           }
 
@@ -827,7 +831,8 @@ namespace jank::jit
 
           if(resolved_path == script_path.lexically_normal())
           {
-            throw std::runtime_error{ util::format("GNU ld script '{}' refers to itself.", path) };
+            throw std::runtime_error{ util::format("This GNU ld script `{}` refers to itself.",
+                                                   path) };
           }
 
           load_dynamic_library_impl(prc,

--- a/compiler+runtime/test/cpp/jank/jit/parse_ld_script.cpp
+++ b/compiler+runtime/test/cpp/jank/jit/parse_ld_script.cpp
@@ -47,7 +47,7 @@ namespace jank::jit
                                    "OUTPUT_FORMAT(elf64-x86-64)\n"
                                    "GROUP ( /lib/libm.so.6 AS_NEEDED ( /lib/libmvec.so.1 ) )\n" };
 
-      CHECK_FALSE(is_object_file(path_string(script.path)));
+      CHECK_FALSE(is_elf_file(path_string(script.path)));
       auto const result{ parse_ld_script(path_string(script.path)) };
       REQUIRE(result.is_some());
       CHECK(result.unwrap() == "/lib/libm.so.6");
@@ -82,13 +82,13 @@ namespace jank::jit
       CHECK(result.unwrap() == "/lib/librequired.so");
     }
 
-    TEST_CASE("recognizes object files")
+    TEST_CASE("recognizes ELF files")
     {
       temporary_file const object{ std::string{ "\x7f"
                                                 "ELF"
                                                 "binary contents" } };
 
-      CHECK(is_object_file(path_string(object.path)));
+      CHECK(is_elf_file(path_string(object.path)));
       CHECK(parse_ld_script(path_string(object.path)).is_none());
     }
   }

--- a/compiler+runtime/test/cpp/jank/jit/parse_ld_script.cpp
+++ b/compiler+runtime/test/cpp/jank/jit/parse_ld_script.cpp
@@ -1,0 +1,95 @@
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include <jank/jit/parse_ld_script.hpp>
+
+/* This must go last; doctest and glog both define CHECK and family. */
+#include <doctest/doctest.h>
+
+namespace jank::jit
+{
+  namespace
+  {
+    struct temporary_file
+    {
+      explicit temporary_file(std::string const &contents)
+        : path{ std::filesystem::temp_directory_path()
+                / ("jank-ld-script-test-"
+                   + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count())) }
+      {
+        std::ofstream file{ path, std::ios::binary };
+        REQUIRE(file.good());
+        file << contents;
+      }
+
+      ~temporary_file()
+      {
+        std::error_code error;
+        std::filesystem::remove(path, error);
+      }
+
+      std::filesystem::path path;
+    };
+
+    jtl::immutable_string path_string(std::filesystem::path const &path)
+    {
+      return path.string();
+    }
+  }
+
+  TEST_SUITE("jit ld script")
+  {
+    TEST_CASE("parses GROUP and selects the required library")
+    {
+      temporary_file const script{ "/* GNU ld script */\n"
+                                   "OUTPUT_FORMAT(elf64-x86-64)\n"
+                                   "GROUP ( /lib/libm.so.6 AS_NEEDED ( /lib/libmvec.so.1 ) )\n" };
+
+      CHECK_FALSE(is_object_file(path_string(script.path)));
+      auto const result{ parse_ld_script(path_string(script.path)) };
+      REQUIRE(result.is_some());
+      CHECK(result.unwrap() == "/lib/libm.so.6");
+    }
+
+    TEST_CASE("parses INPUT")
+    {
+      temporary_file const script{ "INPUT ( libexample.so )\n" };
+
+      auto const result{ parse_ld_script(path_string(script.path)) };
+      REQUIRE(result.is_some());
+      CHECK(result.unwrap() == "libexample.so");
+    }
+
+    TEST_CASE("falls back to an AS_NEEDED library")
+    {
+      temporary_file const script{ "GROUP ( AS_NEEDED ( /lib/liboptional.so ) )\n" };
+
+      auto const result{ parse_ld_script(path_string(script.path)) };
+      REQUIRE(result.is_some());
+      CHECK(result.unwrap() == "/lib/liboptional.so");
+    }
+
+    TEST_CASE("prefers a required library over an earlier AS_NEEDED library")
+    {
+      temporary_file const script{
+        "GROUP ( AS_NEEDED ( /lib/liboptional.so ) /lib/librequired.so )\n"
+      };
+
+      auto const result{ parse_ld_script(path_string(script.path)) };
+      REQUIRE(result.is_some());
+      CHECK(result.unwrap() == "/lib/librequired.so");
+    }
+
+    TEST_CASE("recognizes object files")
+    {
+      temporary_file const object{ std::string{ "\x7f"
+                                                "ELF"
+                                                "binary contents" } };
+
+      CHECK(is_object_file(path_string(object.path)));
+      CHECK(parse_ld_script(path_string(object.path)).is_none());
+    }
+  }
+}

--- a/lein-jank-template/project.clj
+++ b/lein-jank-template/project.clj
@@ -1,4 +1,4 @@
-(defproject org.jank-lang/lein-template.jank "2026.09-6"
+(defproject org.jank-lang/lein-template.jank "2026.09-7"
   :license {:name "MPL 2.0"
             :url "https://www.mozilla.org/en-US/MPL/2.0/"}
   :eval-in-leiningen true)

--- a/lein-jank-template/resources/leiningen/new/jank/project.clj
+++ b/lein-jank-template/resources/leiningen/new/jank/project.clj
@@ -2,7 +2,7 @@
   :license {:name "MPL 2.0"
             :url "https://www.mozilla.org/en-US/MPL/2.0/"}
   :dependencies []
-  :plugins [[org.jank-lang/lein-jank "2026.09-6"]]
+  :plugins [[org.jank-lang/lein-jank "2026.09-7"]]
   :middleware [leiningen.jank/middleware]
   :main {{namespace}}
   :profiles {:base {:jank {:target-dir "target/debug"

--- a/lein-jank/project.clj
+++ b/lein-jank/project.clj
@@ -1,4 +1,4 @@
-(defproject org.jank-lang/lein-jank "2026.09-6"
+(defproject org.jank-lang/lein-jank "2026.09-7"
   :description "Build your jank projects using Leiningen."
   :url "https://jank-lang.org/"
   :license {:name "MPL 2.0"

--- a/lein-jank/src/jank_build/core.clj
+++ b/lein-jank/src/jank_build/core.clj
@@ -24,8 +24,7 @@
 (def default-build-opts
   {:target-dir         "target"
    :optimization-level 3
-   ;; TODO: enable when jank can link to .a files via -L and -l flags.
-   :static?            false})
+   :static?            true})
 
 (defn has-build-file?
   "Returns true if the given directory or jar file has a `jank-build.bb` file in


### PR DESCRIPTION
As we found on stream this week, sometimes a `.so` file is not a binary and is instead a text file containing an ld script. Zig has its own parser for this, as does LLVM. Here, we add our own, with just enough functionality to pull out the next `.so` file to try. This works recursively, up to a certain limit. With this fix, I can now link every example in the jank commons repo on my NixOS machine.

Also, I found that macOS doesn't store system dylibs on the filesystem anymore either, since Big Sur. So we can't just happily plug along looking for libz.dylib on the -L paths... a workaround has been implemented.