### PR TITLE
Fix AOT compilation with `-l:foo` flags

### DIFF
--- a/compiler+runtime/include/cpp/jank/aot/processor.hpp
+++ b/compiler+runtime/include/cpp/jank/aot/processor.hpp
@@ -7,7 +7,7 @@
 namespace jank::aot
 {
   jtl::result<std::vector<char const *>, error_ref> build_compiler_args();
-  std::vector<char const *> build_linker_args();
+  jtl::result<std::vector<char const *>, error_ref> build_linker_args();
 
   struct processor
   {

--- a/compiler+runtime/include/cpp/jank/jit/processor.hpp
+++ b/compiler+runtime/include/cpp/jank/jit/processor.hpp
@@ -41,6 +41,14 @@ namespace jank::runtime::obj
 
 namespace jank::jit
 {
+  struct resolved_lib
+  {
+    /* The resolved lib name/path. */
+    jtl::immutable_string lib;
+    /* Whether or not the resolved lib is a static lib. */
+    bool is_static{};
+  };
+
   struct processor
   {
     processor(jtl::immutable_string const &binary_version);
@@ -64,9 +72,14 @@ namespace jank::jit
     jtl::string_result<void> remove_symbol(jtl::immutable_string const &name) const;
     jtl::string_result<void *> find_symbol(jtl::immutable_string const &name) const;
 
+    static native_vector<std::filesystem::path> build_library_dirs();
+    static jtl::result<native_vector<resolved_lib>, jtl::immutable_string>
+    resolve_libs(native_vector<jtl::immutable_string> const &libs);
     jtl::result<void, jtl::immutable_string>
     load_libs(native_vector<jtl::immutable_string> const &libs) const;
-    jtl::option<jtl::immutable_string> find_lib(jtl::immutable_string const &lib) const;
+    static jtl::option<jtl::immutable_string>
+    find_lib(native_vector<std::filesystem::path> const &library_dirs,
+             jtl::immutable_string const &lib);
 
     /*** XXX: Everything here is immutable after initialization. ***/
     /*** XXX: Calls through the interpreter and LLVM JIT runtime are thread-safe. ***/

--- a/compiler+runtime/src/cpp/jank/aot/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/aot/processor.cpp
@@ -8,6 +8,7 @@
 #include <jank/error/aot.hpp>
 #include <jank/error/system.hpp>
 #include <jank/aot/processor.hpp>
+#include <jank/jit/processor.hpp>
 #include <jank/runtime/context.hpp>
 #include <jank/runtime/module/loader.hpp>
 #include <jank/util/cli.hpp>
@@ -289,7 +290,7 @@ int main(int argc, const char** argv)
     return compiler_args;
   }
 
-  std::vector<char const *> build_linker_args()
+  jtl::result<std::vector<char const *>, error_ref> build_linker_args()
   {
     std::vector<char const *> linker_args{};
 
@@ -318,9 +319,29 @@ int main(int argc, const char** argv)
       linker_args.push_back(strdup(util::format("-Wl,-rpath,{}", library_dir).c_str()));
     }
 
-    for(auto const &lib : util::cli::opts.libs)
+    /* Resolve the libs first, since jank supports its own `-l:foo` syntax (to force
+     * static lib selection) which Clang doesn't understand. Once resolved, static libs
+     * are passed to Clang as paths, while dynamic libs keep the usual `-l<name>` form. */
+    auto const resolved_libs{ jit::processor::resolve_libs(util::cli::opts.libs) };
+    if(resolved_libs.is_err())
     {
-      linker_args.push_back(strdup(util::format("-l{}", lib).c_str()));
+      return error::aot_internal_failure(resolved_libs.expect_err());
+    }
+
+    {
+      auto const &libs{ util::cli::opts.libs };
+      auto const &resolved{ resolved_libs.expect_ok() };
+      for(usize i{}; i < resolved.size(); ++i)
+      {
+        if(resolved[i].is_static)
+        {
+          linker_args.push_back(strdup(resolved[i].lib.c_str()));
+        }
+        else
+        {
+          linker_args.push_back(strdup(util::format("-l{}", libs[i]).c_str()));
+        }
+      }
     }
 
     /* On non-macOS platforms, explicitly link libstdc++.
@@ -405,8 +426,19 @@ int main(int argc, const char** argv)
     compiler_args.push_back(strdup("c++"));
     compiler_args.push_back(strdup(entrypoint_path.c_str()));
 
-    auto const linker_args{ build_linker_args() };
-    std::ranges::copy(linker_args, std::back_inserter(compiler_args));
+    /* Reset Clang's forced language back to file-extension-based detection. Otherwise,
+     * the `-x c++` above would cause any subsequent bare filename argument (such as a
+     * resolved static lib path from `build_linker_args`) to be treated as C++ source
+     * instead of being linked as a library. */
+    compiler_args.push_back(strdup("-x"));
+    compiler_args.push_back(strdup("none"));
+
+    auto const linker_args_res{ build_linker_args() };
+    if(linker_args_res.is_err())
+    {
+      return linker_args_res.expect_err();
+    }
+    std::ranges::copy(linker_args_res.expect_ok(), std::back_inserter(compiler_args));
 
     /* Required because of `strdup` usage and need to manually free the memory.
      * Clang expects C strings that we own. */

--- a/compiler+runtime/src/cpp/jank/jit/processor_dynamic.cpp
+++ b/compiler+runtime/src/cpp/jank/jit/processor_dynamic.cpp
@@ -95,9 +95,9 @@ namespace jank::jit
     std::exit(gen_crash_diag ? 70 : 1);
   }
 
-  processor::processor(jtl::immutable_string const &binary_version)
+  native_vector<std::filesystem::path> processor::build_library_dirs()
   {
-    profile::timer const timer{ "jit ctor" };
+    native_vector<std::filesystem::path> library_dirs;
 
     for(auto const &library_dir : util::cli::opts.library_dirs)
     {
@@ -105,6 +105,29 @@ namespace jank::jit
     }
 
     library_dirs.emplace_back(util::multi_arch_lib_path().c_str());
+
+    /* JANK_JIT_FLAGS come from how jank was configured with CMake. Any `-L` flags in
+     * there need to be included in the library search paths too. */
+    {
+      std::stringstream flags{ JANK_JIT_FLAGS };
+      std::string flag;
+      while(std::getline(flags, flag, ' '))
+      {
+        if(flag.starts_with("-L"))
+        {
+          library_dirs.emplace_back(flag.substr(2));
+        }
+      }
+    }
+
+    return library_dirs;
+  }
+
+  processor::processor(jtl::immutable_string const &binary_version)
+  {
+    profile::timer const timer{ "jit ctor" };
+
+    library_dirs = build_library_dirs();
 
     /* When we AOT compile the jank compiler/runtime, we keep track of the compiler
      * flags used so we can use the same set during JIT compilation. Here we parse these
@@ -177,11 +200,6 @@ namespace jank::jit
       while(std::getline(flags, flag, ' '))
       {
         args.emplace_back(strdup(flag.c_str()));
-
-        if(flag.starts_with("-L"))
-        {
-          library_dirs.emplace_back(flag.substr(2));
-        }
       }
     }
 
@@ -678,7 +696,9 @@ namespace jank::jit
     return err(util::format("Failed to find symbol: '{}'", name));
   }
 
-  jtl::option<jtl::immutable_string> processor::find_lib(jtl::immutable_string const &lib) const
+  jtl::option<jtl::immutable_string>
+  processor::find_lib(native_vector<std::filesystem::path> const &library_dirs,
+                      jtl::immutable_string const &lib)
   {
     std::filesystem::path const lib_path{ lib.c_str() };
     if(lib_path.is_absolute())
@@ -726,26 +746,23 @@ namespace jank::jit
     return none;
   }
 
-  jtl::result<void, jtl::immutable_string>
-  processor::load_libs(native_vector<jtl::immutable_string> const &libs) const
+  jtl::result<native_vector<resolved_lib>, jtl::immutable_string>
+  processor::resolve_libs(native_vector<jtl::immutable_string> const &libs)
   {
+    auto const library_dirs{ build_library_dirs() };
+    native_vector<resolved_lib> resolved;
+    resolved.reserve(libs.size());
+
     for(auto const &lib : libs)
     {
       /* Try finding the lib literally, in case it contains a file name or a path.
        * Example: -llibfoo.a or -l./libfoo.so or -l/path/to/libfoo.a */
       {
-        auto const result{ processor::find_lib(lib) };
+        auto const result{ processor::find_lib(library_dirs, lib) };
         if(result.is_some())
         {
           auto const &found_lib{ result.unwrap() };
-          if(is_static_lib(found_lib))
-          {
-            load_static_library(found_lib);
-          }
-          else
-          {
-            load_dynamic_library(found_lib);
-          }
+          resolved.emplace_back(found_lib, is_static_lib(found_lib));
           continue;
         }
       }
@@ -755,7 +772,7 @@ namespace jank::jit
        * Example: -l:foo or -l:libfoo.a or -l:./libfoo.so or -l:/path/to/libfoo.a */
       if(lib.starts_with(':'))
       {
-        auto result{ processor::find_lib(lib.substr(1)) };
+        auto result{ processor::find_lib(library_dirs, lib.substr(1)) };
         if(result.is_some())
         {
           if(!is_static_lib(result.unwrap()))
@@ -764,12 +781,12 @@ namespace jank::jit
               util::format("Failed to find static library '{}'. This library is not static.",
                            lib.substr(1)));
           }
-          load_static_library(result.unwrap());
+          resolved.emplace_back(result.unwrap(), true);
           continue;
         }
 
         auto const &stat{ static_lib_name(lib.substr(1)) };
-        result = processor::find_lib(stat);
+        result = processor::find_lib(library_dirs, stat);
         if(result.is_none())
         {
           return err(util::format("Failed to find static library '{}'.", lib.substr(1)));
@@ -782,7 +799,7 @@ namespace jank::jit
               util::format("Failed to find static library '{}'. This library is not static.",
                            lib.substr(1)));
           }
-          load_static_library(result.unwrap());
+          resolved.emplace_back(result.unwrap(), true);
         }
       }
       /* Otherwise, just try to find the lib as first a dynamic lib and then a static lib.
@@ -791,24 +808,48 @@ namespace jank::jit
       else
       {
         auto const &shared{ shared_lib_name(lib) };
-        auto result{ processor::find_lib(shared) };
+        auto result{ processor::find_lib(library_dirs, shared) };
         if(result.is_none())
         {
           auto const &stat{ static_lib_name(lib) };
-          result = processor::find_lib(stat);
+          result = processor::find_lib(library_dirs, stat);
           if(result.is_none())
           {
             return err(util::format("Failed to find library '{}'.", lib));
           }
           else
           {
-            load_static_library(result.unwrap());
+            resolved.emplace_back(result.unwrap(), true);
           }
         }
         else
         {
-          load_dynamic_library(result.unwrap());
+          resolved.emplace_back(result.unwrap(), false);
         }
+      }
+    }
+
+    return ok(jtl::move(resolved));
+  }
+
+  jtl::result<void, jtl::immutable_string>
+  processor::load_libs(native_vector<jtl::immutable_string> const &libs) const
+  {
+    auto result{ resolve_libs(libs) };
+    if(result.is_err())
+    {
+      return err(result.expect_err());
+    }
+
+    for(auto const &lib : result.expect_ok())
+    {
+      if(lib.is_static)
+      {
+        load_static_library(lib.lib);
+      }
+      else
+      {
+        load_dynamic_library(lib.lib);
       }
     }
 

--- a/compiler+runtime/src/cpp/main.cpp
+++ b/compiler+runtime/src/cpp/main.cpp
@@ -258,7 +258,9 @@ int main(int const argc, char const **argv)
         {
           util::print("{} ", arg);
         }
-        for(auto const arg : aot::build_linker_args())
+        auto const linker_args_res{ aot::build_linker_args() };
+        auto const &linker_args{ linker_args_res.expect_ok() };
+        for(auto const arg : linker_args)
         {
           util::print("{} ", arg);
         }


### PR DESCRIPTION
We were only resolving these libs for loading into the JIT runtime, but we just passed them through to the AOT compilation as is. This worked most of the time, but not for `-l:foo` flags. Also, for static libs, we should be more explicit by just specifying the actual `.a` file, to ensure that we get the same behavior across JIT and AOT.