### PR TITLE
Enable strip & linker garbage collection for AOT

### DIFF
--- a/compiler+runtime/src/cpp/jank/aot/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/aot/processor.cpp
@@ -299,6 +299,8 @@ int main(int argc, const char** argv)
       {
         linker_args.push_back(strdup(lib));
       }
+
+      linker_args.push_back(strdup("-Wl,--gc-sections"));
     }
     else
     {

--- a/compiler+runtime/src/cpp/jank/aot/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/aot/processor.cpp
@@ -300,7 +300,14 @@ int main(int argc, const char** argv)
         linker_args.push_back(strdup(lib));
       }
 
-      linker_args.push_back(strdup("-Wl,--gc-sections"));
+      if constexpr(jtl::current_platform == jtl::platform::macos_like)
+      {
+        linker_args.push_back(strdup("-Wl,-dead_strip"));
+      }
+      else
+      {
+        linker_args.push_back(strdup("-Wl,--gc-sections"));
+      }
     }
     else
     {

--- a/compiler+runtime/src/cpp/jank/aot/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/aot/processor.cpp
@@ -248,8 +248,15 @@ int main(int argc, const char** argv)
       compiler_args.emplace_back(strdup(framework.c_str()));
     }
 
-    /* We always enable debug info. Users can later strip the binary, if they want. */
-    compiler_args.push_back(strdup("-g"));
+    /* Either include debug symbols or strip everything from the final executable. */
+    if(util::cli::opts.debug)
+    {
+      compiler_args.push_back(strdup("-g"));
+    }
+    else
+    {
+      compiler_args.emplace_back(strdup("-Wl,--strip-all"));
+    }
 
     compiler_args.push_back(strdup("-std=c++20"));
     compiler_args.push_back(strdup("-Wno-c23-extensions"));


### PR DESCRIPTION
I don't see any downside to this, and it gives a modest size reduction for statically linked binaries. Sort of like a poor man's LTO. Normally you would combine with `-fdata-sections -ffunction-sections` but I didn't see any change with those flags.

Here are the results for a jank hello world program:

|       | -O2  | -O2 -s | -O2 -s & upx --best |
|-------|------|--------|--------------|
| main  | 8.4M | 6.6M   | 1.9M         |
| w/ PR | 7.4M | 5.9M   | 1.4M         |

(`-s` was added via `JANK_EXTRA_FLAGS`)