### PR TITLE
Add a `lein debug` helper alias

### DIFF
--- a/lein-jank/src/leiningen/jank.clj
+++ b/lein-jank/src/leiningen/jank.clj
@@ -29,8 +29,10 @@
   (find-deprecated-flags project)
   (when (:verbose opts)
     (reset! ljc/verbose? true))
+  (when (:debug opts)
+    (ljc/verify-executable! ljc/debug-tool))
   (let [project (ljc/native-build project opts)
-        prefix  (when (:debug opts) ["gdb" "--args"])
+        prefix  (when (:debug opts) ljc/debug-tool)
         cp-str  (ljc/build-module-path project)]
     (ljc/shell-out! project cp-str prefix cmd jank-args prog-args)))
 

--- a/lein-jank/src/leiningen/jank.clj
+++ b/lein-jank/src/leiningen/jank.clj
@@ -35,7 +35,8 @@
     (ljc/shell-out! project cp-str prefix cmd jank-args prog-args)))
 
 (def run-cli-options
-  [["-m" "--main NAMESPACE" "override main namespace"]])
+  [["-m" "--main NAMESPACE" "override main namespace"]
+   ["-d" "--debug" "run in the debugger"]])
 
 (defn run!
   "Run your project, starting at the :main entrypoint.
@@ -56,21 +57,13 @@ Calls the -main function in the given namespace."
 (defn debug!
   "Run your project under the debugger, starting at the :main entrypoint.
 
-This assumes that `gdb` is on your system path.
-
 USAGE: lein debug [--] [ARGS...]
 (see lein run)
 
 USAGE: lein debug -m/--main NAMESPACE [--] [ARGS...]
 (see lein run)"
   [project & args]
-  (ljc/verify-executable! ["gdb"])
-  (let [cli-options (into ljc/standard-options run-cli-options)
-        [opts args] (ljc/parse-opts #'run! args cli-options)
-        opts        (assoc opts :debug true)]
-    (if-let [main (or (:main opts) (:main project))]
-      (dispatch-jank project opts "run-main" [main] args)
-      (lmain/warn "No :main entrypoint for project."))))
+  (apply run! project (conj args "--debug")))
 
 (defn repl!
   "Start a terminal REPL and nREPL server in your :main ns, or the user ns if no

--- a/lein-jank/src/leiningen/jank.clj
+++ b/lein-jank/src/leiningen/jank.clj
@@ -29,9 +29,10 @@
   (find-deprecated-flags project)
   (when (:verbose opts)
     (reset! ljc/verbose? true))
-  (let [project     (ljc/native-build project opts)
-        cp-str      (ljc/build-module-path project)]
-    (ljc/shell-out! project cp-str cmd jank-args prog-args)))
+  (let [project (ljc/native-build project opts)
+        prefix  (when (:debug opts) ["gdb" "--args"])
+        cp-str  (ljc/build-module-path project)]
+    (ljc/shell-out! project cp-str prefix cmd jank-args prog-args)))
 
 (def run-cli-options
   [["-m" "--main NAMESPACE" "override main namespace"]])
@@ -48,6 +49,25 @@ Calls the -main function in the given namespace."
   [project & args]
   (let [cli-options (into ljc/standard-options run-cli-options)
         [opts args] (ljc/parse-opts #'run! args cli-options)]
+    (if-let [main (or (:main opts) (:main project))]
+      (dispatch-jank project opts "run-main" [main] args)
+      (lmain/warn "No :main entrypoint for project."))))
+
+(defn debug!
+  "Run your project under the debugger, starting at the :main entrypoint.
+
+This assumes that `gdb` is on your system path.
+
+USAGE: lein debug [--] [ARGS...]
+(see lein run)
+
+USAGE: lein debug -m/--main NAMESPACE [--] [ARGS...]
+(see lein run)"
+  [project & args]
+  (ljc/verify-executable! ["gdb"])
+  (let [cli-options (into ljc/standard-options run-cli-options)
+        [opts args] (ljc/parse-opts #'run! args cli-options)
+        opts        (assoc opts :debug true)]
     (if-let [main (or (:main opts) (:main project))]
       (dispatch-jank project opts "run-main" [main] args)
       (lmain/warn "No :main entrypoint for project."))))
@@ -124,6 +144,7 @@ namespaces or files."
     (dispatch-jank project opts "check-health" [] args)))
 
 (def subtask-kw->var {:run #'run!
+                      :debug #'debug!
                       :repl #'repl!
                       :compile #'compile!
                       :compile-module #'compile-module!
@@ -157,6 +178,9 @@ namespaces or files."
   {:jank     {:name (:name project)}
    :aliases  {"run" ^{:doc "Run your project, starting at the main entrypoint."}
               ["jank" "run"]
+
+              "debug" ^{:doc "Run your project under the debugger, starting at the :main entrypoint."}
+              ["jank" "debug"]
 
               "repl" ^{:doc "Start a terminal REPL in your :main or user ns."}
               ["jank" "repl"]

--- a/lein-jank/src/leiningen/jank/core.clj
+++ b/lein-jank/src/leiningen/jank/core.clj
@@ -15,6 +15,11 @@
   [["-v" "--verbose" "Enable verbose output"]
    [nil  "--disable-sandbox" "Disable jank-build sandboxing"]])
 
+(def debug-tool
+  (if (contains? #{"mac os x" "darwin"} (string/lower-case (System/getProperty "os.name")))
+    ["lldb" "--"]
+    ["gdb" "--args"]))
+
 (defn parse-opts
   "Process the args using the given clojure.tools.cli option-specs. If given
   invalid arguments, print and exit. Otherwise, returns a vector of the parsed

--- a/lein-jank/src/leiningen/jank/core.clj
+++ b/lein-jank/src/leiningen/jank/core.clj
@@ -115,12 +115,11 @@
 
     (lmain/warn (str "Unknown flag " flag))))
 
-(defn verify-jank!
-  "Verify that we can run the jank executable, or crash with the
-  reason we cannot."
-  []
+(defn verify-executable!
+  "Verify that we can run the executable, or crash with the reason we cannot."
+  [args]
   (try
-    (util/sh {} ["jank"])
+    (util/sh {} args)
     (catch Exception e
       ;; Will print a nice message on failure like "Cannot run program
       ;; 'jank': ..."
@@ -131,9 +130,10 @@
                   (build-declarative-flag flag value))
                 (:jank project))))
 
-(defn shell-out! [project classpath command compiler-args runtime-args]
-  (verify-jank!)
-  (let [args (concat ["jank" command "--module-path" classpath]
+(defn shell-out! [project classpath prefix command compiler-args runtime-args]
+  (verify-executable! ["jank"])
+  (let [args (concat prefix
+                     ["jank" command "--module-path" classpath]
                      ; The normal build dir would be <target dir>/_cache, but we want
                      ; to nest one level deeper, so that files from this project don't
                      ; interfere with files from the dependencies. So we specify our


### PR DESCRIPTION
This helper drops you into gdb with all the proper jank arguments for your project.

I'm not sure what the implications are for Windows/MacOS, but at least for now it will just say that gdb is not available. Maybe since we ship with LLVM we can use a bundled lldb? Not sure.

Alternatively this could be an argument to `lein run` like `lein run --debug`, but this seems more discoverable.