### PR TITLE
Send exception_info via nrepl

### DIFF
--- a/compiler+runtime/include/cpp/jank/error/report.hpp
+++ b/compiler+runtime/include/cpp/jank/error/report.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
 #include <jank/error.hpp>
+#include <jtl/immutable_string.hpp>
 
 namespace jank::error
 {
-  void report(error_ref e);
-  void warn(jtl::immutable_string const &);
+  jtl::immutable_string report(error_ref e);
+  jtl::immutable_string warn(jtl::immutable_string const &);
 }

--- a/compiler+runtime/include/cpp/jank/evaluate.hpp
+++ b/compiler+runtime/include/cpp/jank/evaluate.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <jank/runtime/object.hpp>
+#include <jank/read/source.hpp>
 
 namespace jank::runtime::obj
 {
@@ -102,4 +103,6 @@ namespace jank::evaluate
   runtime::object_ref eval(analyze::expr::cpp_unbox_ref);
   runtime::object_ref eval(analyze::expr::cpp_new_ref);
   runtime::object_ref eval(analyze::expr::cpp_delete_ref);
+
+  bool safe_eval(jtl::immutable_string const &code, read::source_position const &p);
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/exception_info.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/exception_info.hpp
@@ -12,7 +12,9 @@
 
 #include <memory>
 
+#include <jank/error.hpp>
 #include <jank/runtime/object.hpp>
+#include <jtl/option.hpp>
 
 /* NOLINTNEXTLINE(modernize-concat-nested-namespaces): Not doable, due to the inline. */
 namespace cpptrace
@@ -35,8 +37,10 @@ namespace jank::runtime::obj
     static constexpr bool pointer_free{ false };
 
     exception_info(jtl::immutable_string const &message, object_ref const data);
+    exception_info(error_ref error);
 
     /* behavior::object_like */
+    jtl::immutable_string to_string() const override;
     jtl::immutable_string to_code_string() const override;
 
     void resolve();
@@ -48,5 +52,6 @@ namespace jank::runtime::obj
     exception_info_ref cause;
     std::unique_ptr<cpptrace::raw_trace> raw_trace;
     std::unique_ptr<cpptrace::stacktrace> resolved_trace;
+    jtl::option<error_ref> error;
   };
 }

--- a/compiler+runtime/src/cpp/jank/error/report.cpp
+++ b/compiler+runtime/src/cpp/jank/error/report.cpp
@@ -5,12 +5,11 @@
 
 namespace jank::error
 {
-  void warn(jtl::immutable_string const &msg)
+  jtl::immutable_string warn(jtl::immutable_string const &msg)
   {
-    util::println(stderr,
-                  "{}warning:{} {}",
-                  jtl::terminal::text_style::yellow,
-                  jtl::terminal::text_style::reset,
-                  msg);
+    return util::format("{}warning:{} {}\n",
+                        jtl::terminal::text_style::yellow,
+                        jtl::terminal::text_style::reset,
+                        msg);
   }
 }

--- a/compiler+runtime/src/cpp/jank/error/report_dynamic.cpp
+++ b/compiler+runtime/src/cpp/jank/error/report_dynamic.cpp
@@ -3,6 +3,7 @@
 
 #include <boost/algorithm/string/replace.hpp>
 
+#include <jtl/string_builder.hpp>
 #include <jtl/terminal.hpp>
 #include <jtl/utf8.hpp>
 
@@ -764,19 +765,20 @@ namespace jank::error
     return ui::highlight_cpp(source);
   }
 
-  void report(error_ref const e)
+  jtl::immutable_string report(error_ref const e)
   {
+    jtl::string_builder sb;
     plan const p{ e };
 
     auto const terminal_width{ jtl::terminal::get_size().width };
     auto const max_width{ std::min(terminal_width, 100ull) };
 
-    util::println(stderr, "{}", header(kind_str(e->kind), max_width));
-    util::println(stderr,
-                  "{}error:{} {}\n",
-                  text_style::bold | text_style::red,
-                  text_style::reset,
-                  e->message);
+    util::format_to(sb, "{}\n", header(kind_str(e->kind), max_width));
+    util::format_to(sb,
+                    "{}error:{} {}\n\n",
+                    text_style::bold | text_style::red,
+                    text_style::reset,
+                    e->message);
 
     /* TODO: Context. */
     //auto context{ vbox(
@@ -797,47 +799,47 @@ namespace jank::error
 
     for(usize i{}; i < p.snippets.size(); ++i)
     {
-      util::println(stderr,
-                    "{}",
-                    code_snippet(p.snippets[i], max_width, i == p.snippets.size() - 1));
+      util::format_to(sb,
+                      "{}\n",
+                      code_snippet(p.snippets[i], max_width, i == p.snippets.size() - 1));
     }
     if(p.snippets.empty())
     {
-      util::println(stderr,
-                    "https://book.jank-lang.org/reference/error/{}.html",
-                    kind_str(e->kind));
+      util::format_to(sb,
+                      "https://book.jank-lang.org/reference/error/{}.html\n",
+                      kind_str(e->kind));
     }
     else
     {
-      util::println(stderr, "{}", documentation_box(e, max_width));
+      util::format_to(sb, "{}\n", documentation_box(e, max_width));
     }
 
     if(!e->candidates.empty())
     {
       auto const show_count{ std::min(e->candidates.size(),
                                       static_cast<size_t>(util::cli::opts.max_error_candidates)) };
-      util::println(stderr,
-                    "  Candidates considered (showing {} of {}):\n",
-                    show_count,
-                    e->candidates.size());
+      util::format_to(sb,
+                      "  Candidates considered (showing {} of {}):\n\n",
+                      show_count,
+                      e->candidates.size());
       for(size_t i{}; i < show_count; ++i)
       {
         auto const &c{ e->candidates[i] };
 
         if(c.viable)
         {
-          util::print(stderr, "  {}✓{}", text_style::green, text_style::reset);
+          util::format_to(sb, "  {}✓{}", text_style::green, text_style::reset);
         }
         else
         {
-          util::print(stderr, "  {}✗{}", text_style::red, text_style::reset);
+          util::format_to(sb, "  {}✗{}", text_style::red, text_style::reset);
         }
-        util::print(stderr, " {}", format_and_highlight_cpp(c.signature, "    "));
-        util::println(stderr,
-                      "{}╰─ declared at {}{}",
-                      text_style::bright_black,
-                      shorten_path(c.source),
-                      text_style::reset);
+        util::format_to(sb, " {}", format_and_highlight_cpp(c.signature, "    "));
+        util::format_to(sb,
+                        "{}╰─ declared at {}{}\n",
+                        text_style::bright_black,
+                        shorten_path(c.source),
+                        text_style::reset);
 
         native_vector<native_vector<jtl::immutable_string>> rows;
         for(auto const &a : c.arguments)
@@ -870,28 +872,30 @@ namespace jank::error
         }
 
         auto const column_padding{ determine_column_padding(rows, 1) };
-        util::print(stderr, "{}", render_columns("    ", rows, column_padding));
+        util::format_to(sb, "{}", render_columns("    ", rows, column_padding));
 
-        util::println(stderr,
-                      "    {}──────────────────────────────────────────────────────────{}",
-                      text_style::bright_black,
-                      text_style::reset);
-        util::println(stderr, "    {}{}", (c.viable ? "Viable: " : "Not viable: "), c.reason);
+        util::format_to(sb,
+                        "    {}──────────────────────────────────────────────────────────{}\n",
+                        text_style::bright_black,
+                        text_style::reset);
+        util::format_to(sb, "    {}{}\n", (c.viable ? "Viable: " : "Not viable: "), c.reason);
         if(!c.clang_reason.empty())
         {
-          util::println(stderr,
-                        "    {}╰─ {}{}",
-                        text_style::bright_black,
-                        c.clang_reason,
-                        text_style::reset);
+          util::format_to(sb,
+                          "    {}╰─ {}{}\n",
+                          text_style::bright_black,
+                          c.clang_reason,
+                          text_style::reset);
         }
-        util::println(stderr, "");
+        util::format_to(sb, "\n");
       }
     }
 
     if(e->cause)
     {
-      report(e->cause.as_ref());
+      sb.push_back(report(e->cause.as_ref()));
     }
+
+    return sb.release();
   }
 }

--- a/compiler+runtime/src/cpp/jank/error/report_dynamic.cpp
+++ b/compiler+runtime/src/cpp/jank/error/report_dynamic.cpp
@@ -771,8 +771,9 @@ namespace jank::error
     auto const terminal_width{ jtl::terminal::get_size().width };
     auto const max_width{ std::min(terminal_width, 100ull) };
 
-    util::println("{}", header(kind_str(e->kind), max_width));
-    util::println("{}error:{} {}\n",
+    util::println(stderr, "{}", header(kind_str(e->kind), max_width));
+    util::println(stderr,
+                  "{}error:{} {}\n",
                   text_style::bold | text_style::red,
                   text_style::reset,
                   e->message);
@@ -796,22 +797,27 @@ namespace jank::error
 
     for(usize i{}; i < p.snippets.size(); ++i)
     {
-      util::println("{}", code_snippet(p.snippets[i], max_width, i == p.snippets.size() - 1));
+      util::println(stderr,
+                    "{}",
+                    code_snippet(p.snippets[i], max_width, i == p.snippets.size() - 1));
     }
     if(p.snippets.empty())
     {
-      util::println("https://book.jank-lang.org/reference/error/{}.html", kind_str(e->kind));
+      util::println(stderr,
+                    "https://book.jank-lang.org/reference/error/{}.html",
+                    kind_str(e->kind));
     }
     else
     {
-      util::println("{}", documentation_box(e, max_width));
+      util::println(stderr, "{}", documentation_box(e, max_width));
     }
 
     if(!e->candidates.empty())
     {
       auto const show_count{ std::min(e->candidates.size(),
                                       static_cast<size_t>(util::cli::opts.max_error_candidates)) };
-      util::println("  Candidates considered (showing {} of {}):\n",
+      util::println(stderr,
+                    "  Candidates considered (showing {} of {}):\n",
                     show_count,
                     e->candidates.size());
       for(size_t i{}; i < show_count; ++i)
@@ -820,14 +826,15 @@ namespace jank::error
 
         if(c.viable)
         {
-          util::print("  {}✓{}", text_style::green, text_style::reset);
+          util::print(stderr, "  {}✓{}", text_style::green, text_style::reset);
         }
         else
         {
-          util::print("  {}✗{}", text_style::red, text_style::reset);
+          util::print(stderr, "  {}✗{}", text_style::red, text_style::reset);
         }
-        util::print(" {}", format_and_highlight_cpp(c.signature, "    "));
-        util::println("{}╰─ declared at {}{}",
+        util::print(stderr, " {}", format_and_highlight_cpp(c.signature, "    "));
+        util::println(stderr,
+                      "{}╰─ declared at {}{}",
                       text_style::bright_black,
                       shorten_path(c.source),
                       text_style::reset);
@@ -863,20 +870,22 @@ namespace jank::error
         }
 
         auto const column_padding{ determine_column_padding(rows, 1) };
-        util::print("{}", render_columns("    ", rows, column_padding));
+        util::print(stderr, "{}", render_columns("    ", rows, column_padding));
 
-        util::println("    {}──────────────────────────────────────────────────────────{}",
+        util::println(stderr,
+                      "    {}──────────────────────────────────────────────────────────{}",
                       text_style::bright_black,
                       text_style::reset);
-        util::println("    {}{}", (c.viable ? "Viable: " : "Not viable: "), c.reason);
+        util::println(stderr, "    {}{}", (c.viable ? "Viable: " : "Not viable: "), c.reason);
         if(!c.clang_reason.empty())
         {
-          util::println("    {}╰─ {}{}",
+          util::println(stderr,
+                        "    {}╰─ {}{}",
                         text_style::bright_black,
                         c.clang_reason,
                         text_style::reset);
         }
-        util::println("");
+        util::println(stderr, "");
       }
     }
 

--- a/compiler+runtime/src/cpp/jank/error/report_static.cpp
+++ b/compiler+runtime/src/cpp/jank/error/report_static.cpp
@@ -5,12 +5,11 @@
 
 namespace jank::error
 {
-  void report(error_ref const e)
+  jtl::immutable_string report(error_ref const e)
   {
-    util::println(stderr,
-                  "{}error:{} {}",
-                  jtl::terminal::text_style::red,
-                  jtl::terminal::text_style::reset,
-                  e->message);
+    return util::format("{}error:{} {}\n",
+                        jtl::terminal::text_style::red,
+                        jtl::terminal::text_style::reset,
+                        e->message);
   }
 }

--- a/compiler+runtime/src/cpp/jank/evaluate.cpp
+++ b/compiler+runtime/src/cpp/jank/evaluate.cpp
@@ -4,6 +4,8 @@
 #include <CppInterOp/CppInterOpInterpreter.h>
 #include <CppInterOp/CppInterOp.h>
 
+#include <cpptrace/from_current.hpp>
+
 #include <jank/runtime/context.hpp>
 #include <jank/runtime/ns.hpp>
 #include <jank/runtime/visit.hpp>
@@ -683,5 +685,52 @@ namespace jank::evaluate
     /* TODO: How do we get source info here? Or can we detect this earlier? */
     cpp_util::ensure_convertible(expr).expect_ok();
     return eval(wrap_expression(expr, "cpp_delete", {})).call();
+  }
+
+  bool safe_eval(jtl::immutable_string const &code, read::source_position const &p)
+  {
+    static auto var_1{ __rt_ctx->find_var("clojure.core", "*1") };
+    static auto var_2{ __rt_ctx->find_var("clojure.core", "*2") };
+    static auto var_3{ __rt_ctx->find_var("clojure.core", "*3") };
+    static auto var_e{ __rt_ctx->find_var("clojure.core", "*e") };
+
+    cpptrace::try_catch(
+      [&] {
+        auto const value{ __rt_ctx->eval_string(code, p).unwrap() };
+
+        var_3->set(var_2->deref()).expect_ok();
+        var_2->set(var_1->deref()).expect_ok();
+        var_1->set(value).expect_ok();
+
+        return true;
+      },
+      [&](error_ref const e) { var_e->set(make_box<obj::exception_info>(e)).expect_ok(); },
+      [&](object_ref const e) {
+        if(e.get_type() == runtime::object_type::exception_info)
+        {
+          var_e->set(e).expect_ok();
+        }
+        else
+        {
+          auto const ex{ runtime::ex_info(e.to_string(), {}) };
+          ex->raw_trace
+            = std::make_unique<cpptrace::raw_trace>(cpptrace::raw_trace_from_current_exception());
+          var_e->set(ex).expect_ok();
+        }
+      },
+      [&](std::exception const &e) {
+        auto const ex{ runtime::ex_info(e.what(), {}) };
+        ex->raw_trace
+          = std::make_unique<cpptrace::raw_trace>(cpptrace::raw_trace_from_current_exception());
+        var_e->set(ex).expect_ok();
+      },
+      [] {
+        auto const ex{ runtime::ex_info("uncaught exception", {}) };
+        ex->raw_trace
+          = std::make_unique<cpptrace::raw_trace>(cpptrace::raw_trace_from_current_exception());
+        var_e->set(ex).expect_ok();
+      });
+
+    return false;
   }
 }

--- a/compiler+runtime/src/cpp/jank/evaluate.cpp
+++ b/compiler+runtime/src/cpp/jank/evaluate.cpp
@@ -694,15 +694,15 @@ namespace jank::evaluate
     static auto var_3{ __rt_ctx->find_var("clojure.core", "*3") };
     static auto var_e{ __rt_ctx->find_var("clojure.core", "*e") };
 
+    bool success{ false };
     cpptrace::try_catch(
       [&] {
         auto const value{ __rt_ctx->eval_string(code, p).unwrap() };
+        success = true;
 
         var_3->set(var_2->deref()).expect_ok();
         var_2->set(var_1->deref()).expect_ok();
         var_1->set(value).expect_ok();
-
-        return true;
       },
       [&](error_ref const e) { var_e->set(make_box<obj::exception_info>(e)).expect_ok(); },
       [&](object_ref const e) {
@@ -731,6 +731,6 @@ namespace jank::evaluate
         var_e->set(ex).expect_ok();
       });
 
-    return false;
+    return success;
   }
 }

--- a/compiler+runtime/src/cpp/jank/runtime/ns.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/ns.cpp
@@ -89,12 +89,13 @@ namespace jank::runtime
     if(redefined)
     {
       auto const v{ expect_object<var>(*found_var) };
-      error::warn(
-        util::format("'{}' already referred to {} in namespace '{}' but has been replaced by {}",
-                     unqualified_sym->to_string(),
-                     v->to_code_string(),
-                     name->to_string(),
-                     new_var->to_code_string()));
+      util::print("{}",
+                  error::warn(util::format(
+                    "'{}' already referred to {} in namespace '{}' but has been replaced by {}",
+                    unqualified_sym->to_string(),
+                    v->to_code_string(),
+                    name->to_string(),
+                    new_var->to_code_string())));
     }
     *locked_vars
       = make_box<obj::persistent_hash_map>((*locked_vars)->data.set(unqualified_sym, new_var));

--- a/compiler+runtime/src/cpp/jank/runtime/obj/exception_info.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/exception_info.cpp
@@ -62,20 +62,23 @@ namespace jank::runtime::obj
       util::format_to(sb, "\n  {}", cause_to_via(cause).to_code_string());
     }
     util::format_to(sb, "]\n");
-    util::format_to(sb, " :trace\n [");
-    bool needs_indent{};
-    for(auto const &frame : resolved_trace->frames)
+    if(resolved_trace)
     {
-      if(needs_indent)
+      util::format_to(sb, " :trace\n [");
+      bool needs_indent{};
+      for(auto const &frame : resolved_trace->frames)
       {
-        util::format_to(sb, "\n  ");
+        if(needs_indent)
+        {
+          util::format_to(sb, "\n  ");
+        }
+
+        util::format_to(sb, "{}", frame_to_vec(frame).to_code_string());
+
+        needs_indent = true;
       }
-
-      util::format_to(sb, "{}", frame_to_vec(frame).to_code_string());
-
-      needs_indent = true;
+      util::format_to(sb, "]}");
     }
-    util::format_to(sb, "]}");
     return sb.release();
   }
 
@@ -113,9 +116,12 @@ namespace jank::runtime::obj
     trans.insert_unique(via_kw, make_box<obj::persistent_vector>(via_trans.persistent()));
 
     runtime::detail::native_transient_vector trace_trans;
-    for(auto const &frame : resolved_trace->frames)
+    if(resolved_trace)
     {
-      trace_trans.push_back(frame_to_vec(frame));
+      for(auto const &frame : resolved_trace->frames)
+      {
+        trace_trans.push_back(frame_to_vec(frame));
+      }
     }
     trans.insert_unique(trace_kw, make_box<obj::persistent_vector>(trace_trans.persistent()));
 

--- a/compiler+runtime/src/cpp/jank/runtime/obj/exception_info.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/exception_info.cpp
@@ -9,6 +9,7 @@
 #include <jank/runtime/core/make_box.hpp>
 #include <jank/util/try.hpp>
 #include <jank/util/fmt.hpp>
+#include <jank/error/report.hpp>
 
 namespace jank::runtime::obj
 {
@@ -16,6 +17,12 @@ namespace jank::runtime::obj
     : object{ obj_type, obj_behaviors }
     , message{ message }
     , data{ data }
+  {
+  }
+
+  exception_info::exception_info(error_ref error)
+    : object{ obj_type, obj_behaviors }
+    , error{ error }
   {
   }
 
@@ -45,6 +52,19 @@ namespace jank::runtime::obj
     }
 
     return make_box<obj::persistent_hash_map>(trans.persistent());
+  }
+
+  jtl::immutable_string exception_info::to_string() const
+  {
+    /* Pretty-print the error_ref if we have it or else fall back to the exception data. */
+    if(error.is_some())
+    {
+      return jank::error::report(error.unwrap());
+    }
+    else
+    {
+      return to_code_string();
+    }
   }
 
   jtl::immutable_string exception_info::to_code_string() const

--- a/compiler+runtime/src/cpp/jank/util/cli.cpp
+++ b/compiler+runtime/src/cpp/jank/util/cli.cpp
@@ -510,7 +510,7 @@ OPTIONS
             util::format_to(sb, " {}", flag.second);
           }
         }
-        error::warn(sb.release());
+        util::print("{}", error::warn(sb.release()));
       }
       else if(!pending_positional_args.empty())
       {

--- a/compiler+runtime/src/cpp/jank/util/try.cpp
+++ b/compiler+runtime/src/cpp/jank/util/try.cpp
@@ -218,7 +218,7 @@ namespace jank::util
 
   void print_exception(error_ref const e)
   {
-    error::report(e);
+    util::print(stderr, "{}", error::report(e));
 
     /* We want to find the deepest stack trace, since that will
      * be closest to the actual problem. However, if there is no

--- a/compiler+runtime/src/cpp/main.cpp
+++ b/compiler+runtime/src/cpp/main.cpp
@@ -173,11 +173,13 @@ namespace jank
       if((ext == ".cpp" && opts.output_target != util::cli::compilation_target::cpp)
          || (ext == ".o" && opts.output_target != util::cli::compilation_target::object))
       {
-        error::warn(util::format("The output file name '{}' has the extension '{}', but the output "
-                                 "target is '{}'. These appear to be mismatched.",
-                                 opts.output_module_filename,
-                                 ext.string(),
-                                 util::cli::compilation_target_str(opts.output_target)));
+        util::print("{}",
+                    error::warn(util::format(
+                      "The output file name '{}' has the extension '{}', but the output "
+                      "target is '{}'. These appear to be mismatched.",
+                      opts.output_module_filename,
+                      ext.string(),
+                      util::cli::compilation_target_str(opts.output_target))));
       }
     }
 

--- a/compiler+runtime/src/jank/clojure/stacktrace.jank
+++ b/compiler+runtime/src/jank/clojure/stacktrace.jank
@@ -1,0 +1,6 @@
+(ns clojure.stacktrace)
+
+(defn print-cause-trace
+  "Pretty-print an exception_info."
+  ([tr] (print-cause-trace tr nil))
+  ([tr n] (prn tr)))

--- a/compiler+runtime/src/jank/clojure/stacktrace.jank
+++ b/compiler+runtime/src/jank/clojure/stacktrace.jank
@@ -3,4 +3,4 @@
 (defn print-cause-trace
   "Pretty-print an exception_info."
   ([tr] (print-cause-trace tr nil))
-  ([tr n] (prn tr)))
+  ([tr n] (print (str tr))))

--- a/compiler+runtime/src/jank/jank/nrepl/server/eval.jank
+++ b/compiler+runtime/src/jank/jank/nrepl/server/eval.jank
@@ -23,21 +23,31 @@ namespace jank::nrepl::server::eval
 
       return true;
     }
-    catch(error_ref const e)
-    {
-      var_e->set(make_box(e->message));
-    }
     catch(object_ref const e)
     {
-      var_e->set(e);
+      visit_object(
+        [&](auto const typed_o) {
+          using T = typename decltype(typed_o)::value_type;
+
+          if constexpr(std::is_same_v<T, obj::exception_info>)
+          {
+            var_e->set(typed_o);
+          }
+          else
+          {
+            var_e->set(make_box<obj::exception_info>(typed_o.to_string(), jank_nil));
+          }
+        },
+        e
+      );
     }
     catch(std::exception const &e)
     {
-      var_e->set(make_box(e.what()));
+      var_e->set(make_box<obj::exception_info>(e.what(), jank_nil));
     }
     catch(...)
     {
-      var_e->set(make_box(\"uncaught exception\"));
+      var_e->set(make_box<obj::exception_info>(\"uncaught exception\", jank_nil));
     }
 
     return false;

--- a/compiler+runtime/src/jank/jank/nrepl/server/eval.jank
+++ b/compiler+runtime/src/jank/jank/nrepl/server/eval.jank
@@ -1,6 +1,8 @@
 (ns jank.nrepl.server.eval)
 
 (cpp/raw "
+#include <cpptrace/basic.hpp>
+
 #include <jank/error/report.hpp>
 
 namespace jank::nrepl::server::eval
@@ -31,21 +33,16 @@ namespace jank::nrepl::server::eval
     }
     catch(object_ref const e)
     {
-      visit_object(
-        [&](auto const typed_o) {
-          using T = typename decltype(typed_o)::value_type;
-
-          if constexpr(std::is_same_v<T, obj::exception_info>)
-          {
-            var_e->set(typed_o);
-          }
-          else
-          {
-            var_e->set(make_box<obj::exception_info>(typed_o.to_string(), jank_nil));
-          }
-        },
-        e
-      );
+      if(e.get_type() == runtime::object_type::exception_info)
+      {
+        var_e->set(e);
+      }
+      else
+      {
+        auto const ex{ runtime::ex_info(e.to_string(), {}) };
+        ex->raw_trace = std::make_unique<cpptrace::raw_trace>(cpptrace::generate_raw_trace());
+        var_e->set(ex);
+      }
     }
     catch(std::exception const &e)
     {

--- a/compiler+runtime/src/jank/jank/nrepl/server/eval.jank
+++ b/compiler+runtime/src/jank/jank/nrepl/server/eval.jank
@@ -1,61 +1,5 @@
-(ns jank.nrepl.server.eval)
-
-(cpp/raw "
-#include <cpptrace/basic.hpp>
-
-#include <jank/error/report.hpp>
-
-namespace jank::nrepl::server::eval
-{
-  using namespace jank;
-  using namespace jank::runtime;
-
-  inline bool safe_eval(jtl::immutable_string const &code, read::source_position const &p)
-  {
-    static auto var_1{ __rt_ctx->find_var(\"clojure.core\", \"*1\") };
-    static auto var_2{ __rt_ctx->find_var(\"clojure.core\", \"*2\") };
-    static auto var_3{ __rt_ctx->find_var(\"clojure.core\", \"*3\") };
-    static auto var_e{ __rt_ctx->find_var(\"clojure.core\", \"*e\") };
-
-    try
-    {
-      auto const value{ __rt_ctx->eval_string(code, p).unwrap() };
-
-      var_3->set(var_2->deref()).expect_ok();
-      var_2->set(var_1->deref()).expect_ok();
-      var_1->set(value).expect_ok();
-
-      return true;
-    }
-    catch(error_ref const e)
-    {
-      var_e->set(make_box<obj::exception_info>(e));
-    }
-    catch(object_ref const e)
-    {
-      if(e.get_type() == runtime::object_type::exception_info)
-      {
-        var_e->set(e);
-      }
-      else
-      {
-        auto const ex{ runtime::ex_info(e.to_string(), {}) };
-        ex->raw_trace = std::make_unique<cpptrace::raw_trace>(cpptrace::generate_raw_trace());
-        var_e->set(ex);
-      }
-    }
-    catch(std::exception const &e)
-    {
-      var_e->set(make_box<obj::exception_info>(e.what(), jank_nil));
-    }
-    catch(...)
-    {
-      var_e->set(make_box<obj::exception_info>(\"uncaught exception\", jank_nil));
-    }
-
-    return false;
-  }
-}")
+(ns jank.nrepl.server.eval
+  (:include "jank/evaluate.hpp"))
 
 (defn safe-eval
   "Evaluate code similar to `eval`, but catch any errors. Returns whether the
@@ -65,15 +9,11 @@ namespace jank::nrepl::server::eval
   ;; means we can't as easily intercept them. This is unlike java where
   ;; everything goes through System.out/System.err.
 
-  ;; TODO(jank): We can't catch cpp exceptions from jank code, so any evaluation
-  ;; error will crash the server. Instead we create a safe evaluation wrapper in
-  ;; C++ and catch the exceptions there.
-
   (let [p (cpp/jank.read.source_position.
            (cpp/jtl.usize 0)
            (cpp/jtl.usize line)
            (cpp/jtl.usize col))]
-    (cpp/jank.nrepl.server.eval.safe_eval code p)))
+    (cpp/jank.evaluate.safe_eval code p)))
 
 (comment
   (+ 1 2)

--- a/compiler+runtime/src/jank/jank/nrepl/server/eval.jank
+++ b/compiler+runtime/src/jank/jank/nrepl/server/eval.jank
@@ -1,6 +1,8 @@
 (ns jank.nrepl.server.eval)
 
 (cpp/raw "
+#include <jank/error/report.hpp>
+
 namespace jank::nrepl::server::eval
 {
   using namespace jank;
@@ -22,6 +24,11 @@ namespace jank::nrepl::server::eval
       var_1->set(value).expect_ok();
 
       return true;
+    }
+    catch(error_ref const e)
+    {
+      error::report(e);
+      var_e->set(make_box<obj::exception_info>(e->message, jank_nil));
     }
     catch(object_ref const e)
     {

--- a/compiler+runtime/src/jank/jank/nrepl/server/eval.jank
+++ b/compiler+runtime/src/jank/jank/nrepl/server/eval.jank
@@ -27,8 +27,7 @@ namespace jank::nrepl::server::eval
     }
     catch(error_ref const e)
     {
-      error::report(e);
-      var_e->set(make_box<obj::exception_info>(e->message, jank_nil));
+      var_e->set(make_box<obj::exception_info>(e));
     }
     catch(object_ref const e)
     {

--- a/compiler+runtime/src/jank/jank/nrepl/server/handler/eval.jank
+++ b/compiler+runtime/src/jank/jank/nrepl/server/handler/eval.jank
@@ -31,12 +31,11 @@
                                           [(safe-eval code line col) *ns*])))
         [success res-ns] ret]
     (cond
-      ;; Eval results in error. For now, just report the exception as a value.
-      ;; If we return :exception then CIDER will try to load clojure.stacktrace.
+      ;; Eval results in error.
       (not success)
       [{:out stdout}
        {:err stderr}
-       {:value  (str *e)
+       {:ex     (pr-str *e)
         :status [:done :eval-error]}]
 
       ;; Client requests an inspection of the last result.

--- a/compiler+runtime/src/jank/jank/nrepl/server/handler/eval.jank
+++ b/compiler+runtime/src/jank/jank/nrepl/server/handler/eval.jank
@@ -38,8 +38,8 @@
        ;; The error contents will be in :ex for CIDER, but also
        ;; populate :err for clients which don't specially handle :ex
        ;; responses.
-       {:err (pr-str *e)}
-       {:ex     (pr-str *e)
+       {:err (str *e)}
+       {:ex     (str *e)
         :status [:done :eval-error]}]
 
       ;; Client requests an inspection of the last result.

--- a/compiler+runtime/src/jank/jank/nrepl/server/handler/eval.jank
+++ b/compiler+runtime/src/jank/jank/nrepl/server/handler/eval.jank
@@ -35,6 +35,10 @@
       (not success)
       [{:out stdout}
        {:err stderr}
+       ;; The error contents will be in :ex for CIDER, but also
+       ;; populate :err for clients which don't specially handle :ex
+       ;; responses.
+       {:err (pr-str *e)}
        {:ex     (pr-str *e)
         :status [:done :eval-error]}]
 

--- a/compiler+runtime/test/bash/module/compiled-modules/pass-test
+++ b/compiler+runtime/test/bash/module/compiled-modules/pass-test
@@ -191,7 +191,7 @@
     (jank "compile-module" module-a)
     (with-hidden-file (module-a-path)
       (is (true? (-> (jank "run-main" module-a)
-                     :out
+                     :err
                      (string/includes? "The registered module `jank-test.a` has no source files.")))))))
 
 (defn -main []

--- a/compiler+runtime/test/bash/module/reload/pass-test
+++ b/compiler+runtime/test/bash/module/reload/pass-test
@@ -62,7 +62,8 @@
           dependency-module-path "src/jank_test/reload/dependency.cljc"
           original-dependent-content (slurp dependent-module-path)]
       (with-open [repl-writer (io/writer (:in proc))
-                  repl-reader (io/reader (:out proc))]
+                  repl-out-reader (io/reader (:out proc))
+                  repl-err-reader (io/reader (:err proc))]
         (doto repl-writer
           (send-command "(require '[jank-test.reload.dependent :as d])\n")
           (send-command "(d/first-fn)\n" :111))
@@ -70,14 +71,14 @@
         ;; Wait for repl to start
         (Thread/sleep 2000)
         (is (string/includes?
-             (read-available repl-reader :111)
+             (read-available repl-out-reader :111)
              "Hello"))
 
         (send-command repl-writer "(d/hi)\n" :222)
 
         (Thread/sleep 500)
         (is (string/includes?
-             (read-available repl-reader :222)
+             (read-available repl-err-reader :222)
              "The symbol `d/hi` could not be resolved."))
 
         (testing "new var should be added to the module"
@@ -92,7 +93,7 @@
 
           (Thread/sleep 500)
           (is (string/includes?
-               (read-available repl-reader :333)
+               (read-available repl-out-reader :333)
                "Hi!")))
 
         (testing "var removed from the source should still available"
@@ -103,7 +104,7 @@
 
           (Thread/sleep 500)
           (is (string/includes?
-               (read-available repl-reader :444)
+               (read-available repl-out-reader :444)
                "Hi!")))
         (testing "dependency module should not reload"
           (doto dependency-module-path
@@ -117,7 +118,7 @@
           (Thread/sleep 500)
 
           (is (string/includes?
-               (read-available repl-reader :555)
+               (read-available repl-err-reader :555)
                "The symbol `dep/hi` could not be resolved."))))
       (ps/destroy proc))))
 
@@ -127,7 +128,8 @@
           dependent-module-path "src/jank_test/reload_all/dependent.cljc"
           dependency-module-path "src/jank_test/reload_all/dependency.cljc"]
       (with-open [repl-writer (io/writer (:in proc))
-                  repl-reader (io/reader (:out proc))]
+                  repl-out-reader (io/reader (:out proc))
+                  repl-err-reader (io/reader (:err proc))]
         (doto repl-writer
           (send-command "(require '[jank-test.reload-all.dependent :as d])\n")
           (send-command "(d/first-fn)\n" :111))
@@ -135,14 +137,14 @@
         ;; Wait for repl to start
         (Thread/sleep 2000)
         (is (string/includes?
-             (read-available repl-reader :111)
+             (read-available repl-out-reader :111)
              "Hello"))
 
         (send-command repl-writer "(d/hi)\n" :222)
 
         (Thread/sleep 500)
         (is (string/includes?
-             (read-available repl-reader :222)
+             (read-available repl-err-reader :222)
              "The symbol `d/hi` could not be resolved."))
 
         (testing "module is reloaded"
@@ -157,7 +159,7 @@
 
           (Thread/sleep 500)
           (is (string/includes?
-               (read-available repl-reader :333)
+               (read-available repl-out-reader :333)
                "Hi!")))
 
         (testing "module's dependency is also reloaded"
@@ -171,7 +173,7 @@
 
           (Thread/sleep 500)
           (is (string/includes?
-               (read-available repl-reader :444)
+               (read-available repl-err-reader :444)
                "The symbol `dep/hi` could not be resolved."))
 
           (doto repl-writer
@@ -180,7 +182,7 @@
 
           (Thread/sleep 500)
           (is (string/includes?
-               (read-available repl-reader :555)
+               (read-available repl-out-reader :555)
                "Hi in dependency!"))))
       (ps/destroy proc))))
 

--- a/compiler+runtime/test/bash/module/reload/pass-test
+++ b/compiler+runtime/test/bash/module/reload/pass-test
@@ -57,13 +57,12 @@
 
 (deftest a-single-module-reload
   (with-backup "src/jank_test/reload"
-    (let [proc (ps/process ["jank" "--module-path" "src" "repl"])
+    (let [proc (ps/process {:err :out} "jank --module-path src repl")
           dependent-module-path "src/jank_test/reload/dependent.cljc"
           dependency-module-path "src/jank_test/reload/dependency.cljc"
           original-dependent-content (slurp dependent-module-path)]
       (with-open [repl-writer (io/writer (:in proc))
-                  repl-out-reader (io/reader (:out proc))
-                  repl-err-reader (io/reader (:err proc))]
+                  repl-reader (io/reader (:out proc))]
         (doto repl-writer
           (send-command "(require '[jank-test.reload.dependent :as d])\n")
           (send-command "(d/first-fn)\n" :111))
@@ -71,14 +70,14 @@
         ;; Wait for repl to start
         (Thread/sleep 2000)
         (is (string/includes?
-             (read-available repl-out-reader :111)
+             (read-available repl-reader :111)
              "Hello"))
 
         (send-command repl-writer "(d/hi)\n" :222)
 
         (Thread/sleep 500)
         (is (string/includes?
-             (read-available repl-err-reader :222)
+             (read-available repl-reader :222)
              "The symbol `d/hi` could not be resolved."))
 
         (testing "new var should be added to the module"
@@ -93,7 +92,7 @@
 
           (Thread/sleep 500)
           (is (string/includes?
-               (read-available repl-out-reader :333)
+               (read-available repl-reader :333)
                "Hi!")))
 
         (testing "var removed from the source should still available"
@@ -104,7 +103,7 @@
 
           (Thread/sleep 500)
           (is (string/includes?
-               (read-available repl-out-reader :444)
+               (read-available repl-reader :444)
                "Hi!")))
         (testing "dependency module should not reload"
           (doto dependency-module-path
@@ -118,18 +117,17 @@
           (Thread/sleep 500)
 
           (is (string/includes?
-               (read-available repl-err-reader :555)
+               (read-available repl-reader :555)
                "The symbol `dep/hi` could not be resolved."))))
       (ps/destroy proc))))
 
 (deftest reload-all
   (with-backup "src/jank_test/reload_all"
-    (let [proc (ps/process ["jank" "--module-path" "src" "repl"])
+    (let [proc (ps/process {:err :out} "jank --module-path src repl")
           dependent-module-path "src/jank_test/reload_all/dependent.cljc"
           dependency-module-path "src/jank_test/reload_all/dependency.cljc"]
       (with-open [repl-writer (io/writer (:in proc))
-                  repl-out-reader (io/reader (:out proc))
-                  repl-err-reader (io/reader (:err proc))]
+                  repl-reader (io/reader (:out proc))]
         (doto repl-writer
           (send-command "(require '[jank-test.reload-all.dependent :as d])\n")
           (send-command "(d/first-fn)\n" :111))
@@ -137,14 +135,14 @@
         ;; Wait for repl to start
         (Thread/sleep 2000)
         (is (string/includes?
-             (read-available repl-out-reader :111)
+             (read-available repl-reader :111)
              "Hello"))
 
         (send-command repl-writer "(d/hi)\n" :222)
 
         (Thread/sleep 500)
         (is (string/includes?
-             (read-available repl-err-reader :222)
+             (read-available repl-reader :222)
              "The symbol `d/hi` could not be resolved."))
 
         (testing "module is reloaded"
@@ -159,7 +157,7 @@
 
           (Thread/sleep 500)
           (is (string/includes?
-               (read-available repl-out-reader :333)
+               (read-available repl-reader :333)
                "Hi!")))
 
         (testing "module's dependency is also reloaded"
@@ -173,7 +171,7 @@
 
           (Thread/sleep 500)
           (is (string/includes?
-               (read-available repl-err-reader :444)
+               (read-available repl-reader :444)
                "The symbol `dep/hi` could not be resolved."))
 
           (doto repl-writer
@@ -182,7 +180,7 @@
 
           (Thread/sleep 500)
           (is (string/includes?
-               (read-available repl-out-reader :555)
+               (read-available repl-reader :555)
                "Hi in dependency!"))))
       (ps/destroy proc))))
 


### PR DESCRIPTION
Minimal implementation to get stack traces in CIDER. Sends the nREPL `:ex` field when the evaluation throws, which causes CIDER to eval `(clojure.stacktrace/print-cause-trace *e)`, also implemented minimally here.

I made an effort to always put an `exception_info` in `*e` for consistency, even if we don't have a stack trace or any additional metadata (e.g. if the thrown value was a C++ exception or some jank value).

It would be good for someone using a different nREPL client to test this out. Other clients may use some different `clojure.stacktrace` functionality. I tested by evaluating these:
```
(throw :some-value)
(throw (cpp/std.runtime_error "A runtime error"))
(throw (ex-info "some error" {:hello :world}))
(/ 1 nil)
```

Note that even in CIDER we don't get the "full experience", since that requires cider-nrepl. We just get a text buffer with the pretty-printed `exception_info`.