### PR TITLE
WIP: Add "cargo check"-type workflow

### DIFF
--- a/compiler+runtime/include/cpp/jank/util/cli.hpp
+++ b/compiler+runtime/include/cpp/jank/util/cli.hpp
@@ -23,7 +23,8 @@ namespace jank::util::cli
      * If that's not possible, we'll error out. */
     unspecified,
     cpp,
-    object
+    object,
+    none,
   };
 
   constexpr char const *compilation_target_str(compilation_target const target)
@@ -36,6 +37,8 @@ namespace jank::util::cli
         return "cpp";
       case compilation_target::object:
         return "object";
+      case compilation_target::none:
+        return "none";
       default:
         return "unknown";
     }
@@ -51,6 +54,8 @@ namespace jank::util::cli
         return "cpp";
       case compilation_target::object:
         return "o";
+      case compilation_target::none:
+        return "";
       default:
         return "unknown";
     }

--- a/compiler+runtime/src/cpp/jank/error/report_dynamic.cpp
+++ b/compiler+runtime/src/cpp/jank/error/report_dynamic.cpp
@@ -770,10 +770,15 @@ namespace jank::error
 
     auto const terminal_width{ jtl::terminal::get_size().width };
     auto const max_width{ std::min(terminal_width, 100ull) };
+    auto const file_name{ e->source.file.substr(e->source.file.rfind("/") + 1) };
 
     util::println("{}", header(kind_str(e->kind), max_width));
-    util::println("{}error:{} {}\n",
+
+    util::println("{}{}:{}:{}: error:{} {}\n",
                   text_style::bold | text_style::red,
+                  file_name,
+                  e->source.start.line,
+                  e->source.start.col,
                   text_style::reset,
                   e->message);
 

--- a/compiler+runtime/src/cpp/jank/runtime/context_dynamic.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/context_dynamic.cpp
@@ -271,6 +271,8 @@ namespace jank::runtime
           }
           return ok();
         }
+      case util::cli::compilation_target::none:
+        return ok();
       case util::cli::compilation_target::unspecified:
       default:
         return err(util::format("Unable to write module, given output target '{}'.",

--- a/compiler+runtime/src/cpp/jank/util/cli.cpp
+++ b/compiler+runtime/src/cpp/jank/util/cli.cpp
@@ -458,6 +458,10 @@ OPTIONS
           {
             opts.output_target = compilation_target::object;
           }
+          else if(value == "none")
+          {
+            opts.output_target = compilation_target::none;
+          }
           else
           {
             throw util::format("Invalid output type '{}'.", value);

--- a/compiler+runtime/src/cpp/main.cpp
+++ b/compiler+runtime/src/cpp/main.cpp
@@ -208,8 +208,11 @@ namespace jank
 
     __rt_ctx->compile_module(opts.target_module).expect_ok();
 
-    jank::aot::processor const aot_prc{};
-    aot_prc.build_executable(opts.target_module).expect_ok();
+    if(opts.output_target != util::cli::compilation_target::none)
+    {
+      jank::aot::processor const aot_prc{};
+      aot_prc.build_executable(opts.target_module).expect_ok();
+    }
   }
 }
 

--- a/lein-jank/src/leiningen/jank.clj
+++ b/lein-jank/src/leiningen/jank.clj
@@ -132,6 +132,19 @@ namespaces or files."
           test-runner      (generate-test-runner! nses (vec selectors))]
       (dispatch-jank project opts "run" [test-runner] []))))
 
+(defn check!
+  "Check the project for errors without running codegen, starting at
+the :main entrypoint.
+
+USAGE: lein check"
+  [project & args]
+  ;; TODO: a project shouldn't need a main namespace to check.
+  (let [[opts args] (ljc/parse-opts #'compile! args ljc/standard-options)
+        check-opts  ["--output-target" "none"]] ;; don't to codegen
+    (if-let [main (:main project)]
+      (dispatch-jank project opts "compile" (concat [main] check-opts) args)
+      (lmain/warn "No :main entrypoint for project."))))
+
 (defn check-health!
   "Perform a health check on your jank install."
   [project & args]
@@ -143,6 +156,7 @@ namespaces or files."
                       :repl #'repl!
                       :compile #'compile!
                       :compile-module #'compile-module!
+                      :check #'check!
                       :check-health #'check-health!
                       :test #'test!})
 
@@ -188,6 +202,9 @@ namespaces or files."
 
               "test" ^{:doc "Run your project's test suite."}
               ["jank" "test"]
+
+              "check" ^{:doc "Check the project for errors."}
+              ["jank" "check"]
 
               "check-health" ^{:doc "Perform a health check on your jank install."}
               ["jank" "check-health"]}})


### PR DESCRIPTION
This is just an exploratory PR for high-level feedback. We can ignore the implementation details for now.

This PR is towards a `cargo check` workflow with the jank compiler, which can be run by the user's editor to show jank compiler warnings/errors.

What's done here:
- Add a `compilation_target::none` to avoid codegen, since we only care about getting the jank analysis errors quickly.
- Use an easier-to-parse error format `file:line:col` like standard GCC errors. This also makes the errors display nicer in emacs `compilation-mode` since it can easily pick out the start of the next error. They look a little ugly though so maybe we find a better way.

What needs to be figured out:
- What does the workflow look like with `lein`? `lein check` would be equivalent to `cargo check` (adding all the compiler flags for the project and calling the jank compiler without codegen). But `lein` is too slow to start for a CLI linting tool. Maybe we just ignore that for now until we get a faster CLI?
- Can `jank compile` output more than 1 compiler error? It seems to short-circuit for now.

---

I've copy-pasted https://github.com/turbo-cafe/flymake-kondor/ into my emacs config and modified it to invoke jank and parse the jank errors. We can publish this as an official `flymake-jank` plugin later. jank errors now show up when I save a `jank-mode` buffer, just like any other linter/compiler plugin.

It should be possible to do the same with vim/quickfix.

<img width="735" height="229" alt="image" src="https://github.com/user-attachments/assets/b3b4c300-1593-40fd-b7a4-5a870112d16e" />

<img width="581" height="273" alt="image" src="https://github.com/user-attachments/assets/b0fb8c56-6783-43ca-b2b4-7cbf46a98a27" />
