### PR TITLE
Fix infinite reparsing

### DIFF
--- a/compiler+runtime/src/cpp/jank/read/reparse.cpp
+++ b/compiler+runtime/src/cpp/jank/read/reparse.cpp
@@ -2,6 +2,7 @@
 #include <jank/read/parse.hpp>
 #include <jank/runtime/context.hpp>
 #include <jank/runtime/core/meta.hpp>
+#include <jank/runtime/rtti.hpp>
 #include <jank/runtime/visit.hpp>
 #include <jank/runtime/module/loader.hpp>
 #include <jank/util/fmt/print.hpp>
@@ -105,10 +106,13 @@ namespace jank::read::parse
      * see if it's one of the types we support. If not, we'll error out.
      * We can do more here, going forward, by supporting various sequences and such,
      * but this will be fine for now. */
-    if(o.get_type() == object_type::persistent_list
-       || o.get_type() == object_type::persistent_vector)
+    if(o.get_type() == object_type::persistent_list)
     {
-      return reparse_nth(o, n);
+      return reparse_nth(expect_object<runtime::obj::persistent_list>(o), n);
+    }
+    else if(o.get_type() == object_type::persistent_vector)
+    {
+      return reparse_nth(expect_object<runtime::obj::persistent_vector>(o), n);
     }
     else
     {

--- a/compiler+runtime/test/jank/form/try/fail-try-unknown-type.jank
+++ b/compiler+runtime/test/jank/form/try/fail-try-unknown-type.jank
@@ -1,0 +1,3 @@
+(try
+  :success
+  (catch not_a_real_type _))


### PR DESCRIPTION
Noticed this when testing exceptions and typo-ing the catch type like `(try (catch fake_type _))`. It causes infinite recursion on `main` because of a missing downcast.

This fixes https://github.com/jank-lang/jank/issues/981