### PR TITLE
Guard against concurrent access to clang::Interpreter

### DIFF
--- a/compiler+runtime/include/cpp/jank/jit/processor.hpp
+++ b/compiler+runtime/include/cpp/jank/jit/processor.hpp
@@ -92,7 +92,6 @@ namespace jank::jit
     std::map<char const *, std::string_view> vfs;
 
     /*** XXX: Everything here is thread-safe. ***/
-    folly::Synchronized<jtl::ptr<CppInternal::Interpreter>, std::recursive_mutex>
-      interpreter;
+    folly::Synchronized<jtl::ptr<CppInternal::Interpreter>, std::recursive_mutex> interpreter;
   };
 }

--- a/compiler+runtime/include/cpp/jank/jit/processor.hpp
+++ b/compiler+runtime/include/cpp/jank/jit/processor.hpp
@@ -92,7 +92,7 @@ namespace jank::jit
     std::map<char const *, std::string_view> vfs;
 
     /*** XXX: Everything here is thread-safe. ***/
-    mutable folly::Synchronized<jtl::ptr<CppInternal::Interpreter>, std::recursive_mutex>
+    folly::Synchronized<jtl::ptr<CppInternal::Interpreter>, std::recursive_mutex>
       interpreter;
   };
 }

--- a/compiler+runtime/include/cpp/jank/jit/processor.hpp
+++ b/compiler+runtime/include/cpp/jank/jit/processor.hpp
@@ -2,7 +2,9 @@
 
 #include <filesystem>
 #include <map>
+#include <mutex>
 
+#include <folly/Synchronized.h>
 #include <jtl/result.hpp>
 #include <jtl/string_builder.hpp>
 
@@ -82,7 +84,6 @@ namespace jank::jit
              jtl::immutable_string const &lib);
 
     /*** XXX: Everything here is immutable after initialization. ***/
-    /*** XXX: Calls through the interpreter and LLVM JIT runtime are thread-safe. ***/
     native_vector<std::filesystem::path> library_dirs;
 
     /* The files within this map will get added into Clang's VFS prior to the creation of
@@ -91,6 +92,7 @@ namespace jank::jit
     std::map<char const *, std::string_view> vfs;
 
     /*** XXX: Everything here is thread-safe. ***/
-    jtl::ptr<CppInternal::Interpreter> interpreter;
+    mutable folly::Synchronized<jtl::ptr<CppInternal::Interpreter>, std::recursive_mutex>
+      interpreter;
   };
 }

--- a/compiler+runtime/src/cpp/jank/analyze/cpp_util.cpp
+++ b/compiler+runtime/src/cpp/jank/analyze/cpp_util.cpp
@@ -31,7 +31,8 @@ namespace jank::analyze::cpp_util
    * After that failure, Clang gets back into a good state. */
   static void reset_sfinae_state()
   {
-    static_cast<void>(runtime::__rt_ctx->jit_prc.interpreter->Parse("1"));
+    auto locked_interpreter{ runtime::__rt_ctx->jit_prc.interpreter.lock() };
+    static_cast<void>((*locked_interpreter)->Parse("1"));
   }
 
   jtl::string_result<void> instantiate_if_needed(jtl::ptr<void> scope)
@@ -75,12 +76,12 @@ namespace jank::analyze::cpp_util
   jtl::string_result<jtl::ptr<void>>
   instantiate(jtl::ptr<void> const scope, native_vector<Cpp::TemplateArgInfo> const &args)
   {
-    auto &diag{ runtime::__rt_ctx->jit_prc.interpreter->getCompilerInstance()->getDiagnostics() };
+    auto locked_interpreter{ runtime::__rt_ctx->jit_prc.interpreter.lock() };
+    auto &diag{ (*locked_interpreter)->getCompilerInstance()->getDiagnostics() };
     /* TODO: Capture the diagnostic output instead of showing it. Then put it together
      * in our own format. Until we have that, we might as well show it. */
     clang::DiagnosticErrorTrap const trap{ diag };
-    clang::Sema::SFINAETrap const sfinae_trap{ runtime::__rt_ctx->jit_prc.interpreter->getSema(),
-                                               true };
+    clang::Sema::SFINAETrap const sfinae_trap{ (*locked_interpreter)->getSema(), true };
 
     auto const res{ Cpp::InstantiateTemplate(scope, args.data(), args.size()) };
     if(!res || sfinae_trap.hasErrorOccurred() || trap.hasErrorOccurred())
@@ -190,13 +191,14 @@ namespace jank::analyze::cpp_util
 
   jtl::string_result<jtl::ptr<void>> resolve_literal_type(jtl::immutable_string const &literal)
   {
-    auto &diag{ runtime::__rt_ctx->jit_prc.interpreter->getCompilerInstance()->getDiagnostics() };
+    auto locked_interpreter{ runtime::__rt_ctx->jit_prc.interpreter.lock() };
+    auto &diag{ (*locked_interpreter)->getCompilerInstance()->getDiagnostics() };
     clang::DiagnosticErrorTrap const trap{ diag };
 
     auto const alias{ runtime::__rt_ctx->unique_namespaced_string() };
     /* We add a new line so that a trailing // comment won't interfere with our code. */
     auto const code{ util::format("using {} = {}\n;", runtime::munge(alias), literal) };
-    auto parse_res{ runtime::__rt_ctx->jit_prc.interpreter->Parse(code.c_str()) };
+    auto parse_res{ (*locked_interpreter)->Parse(code.c_str()) };
     if(!parse_res || trap.hasErrorOccurred())
     {
       reset_sfinae_state();
@@ -244,7 +246,8 @@ namespace jank::analyze::cpp_util
   jtl::string_result<literal_value_result>
   resolve_literal_value(jtl::immutable_string const &literal)
   {
-    auto &diag{ runtime::__rt_ctx->jit_prc.interpreter->getCompilerInstance()->getDiagnostics() };
+    auto locked_interpreter{ runtime::__rt_ctx->jit_prc.interpreter.lock() };
+    auto &diag{ (*locked_interpreter)->getCompilerInstance()->getDiagnostics() };
     clang::DiagnosticErrorTrap const trap{ diag };
 
     auto const alias{ runtime::munge(runtime::__rt_ctx->unique_namespaced_string()) };
@@ -257,7 +260,7 @@ namespace jank::analyze::cpp_util
       alias,
       literal) };
     //util::println("cpp/value code: {}", code);
-    auto parse_res{ runtime::__rt_ctx->jit_prc.interpreter->Parse(code.c_str()) };
+    auto parse_res{ (*locked_interpreter)->Parse(code.c_str()) };
     if(!parse_res || trap.hasErrorOccurred())
     {
       return err("Unable to parse C++ literal.");
@@ -272,7 +275,7 @@ namespace jank::analyze::cpp_util
       return err("Invalid C++ literal.");
     }
 
-    auto exec_res{ runtime::__rt_ctx->jit_prc.interpreter->Execute(*parse_res) };
+    auto exec_res{ (*locked_interpreter)->Execute(*parse_res) };
     if(exec_res)
     {
       return err("Unable to load C++ literal.");
@@ -414,19 +417,20 @@ namespace jank::analyze::cpp_util
    * this for exception catching. */
   void register_rtti(jtl::ptr<void> const type)
   {
-    auto &diag{ runtime::__rt_ctx->jit_prc.interpreter->getCompilerInstance()->getDiagnostics() };
+    auto locked_interpreter{ runtime::__rt_ctx->jit_prc.interpreter.lock() };
+    auto &diag{ (*locked_interpreter)->getCompilerInstance()->getDiagnostics() };
     clang::DiagnosticErrorTrap const trap{ diag };
     auto const alias{ runtime::__rt_ctx->unique_namespaced_string() };
     auto const code{ util::format("&typeid({})", Cpp::GetTypeAsString(type)) };
     clang::Value value;
-    auto exec_res{ runtime::__rt_ctx->jit_prc.interpreter->ParseAndExecute(code.c_str(), &value) };
+    auto exec_res{ (*locked_interpreter)->ParseAndExecute(code.c_str(), &value) };
     if(exec_res || trap.hasErrorOccurred())
     {
       throw error::codegen_internal_failure(
         util::format("Unable to get RTTI for `{}`.", Cpp::GetTypeAsString(type)));
     }
 
-    auto const lljit{ runtime::__rt_ctx->jit_prc.interpreter->getExecutionEngine() };
+    auto const lljit{ (*locked_interpreter)->getExecutionEngine() };
     llvm::orc::SymbolMap symbols;
     llvm::orc::MangleAndInterner interner{ lljit->getExecutionSession(), lljit->getDataLayout() };
     auto const &symbol{ Cpp::MangleRTTI(type) };
@@ -1486,12 +1490,13 @@ namespace jank::analyze::cpp_util
   bool is_trait_convertible(jtl::ptr<void> const type)
   {
     static auto const convert_template{ Cpp::GetScopeFromCompleteName("jank::runtime::convert") };
+    auto locked_interpreter{ runtime::__rt_ctx->jit_prc.interpreter.lock() };
     Cpp::TemplateArgInfo const arg{ Cpp::GetCanonicalType(
       Cpp::GetTypeWithoutCv(Cpp::GetNonReferenceType(type))) };
-    clang::Sema::SFINAETrap const trap{ runtime::__rt_ctx->jit_prc.interpreter->getSema(), true };
+    clang::Sema::SFINAETrap const trap{ (*locked_interpreter)->getSema(), true };
     Cpp::TCppScope_t instantiation{};
     {
-      auto &diag{ runtime::__rt_ctx->jit_prc.interpreter->getCompilerInstance()->getDiagnostics() };
+      auto &diag{ (*locked_interpreter)->getCompilerInstance()->getDiagnostics() };
       auto old_client{ diag.takeClient() };
       diag.setClient(new clang::IgnoringDiagConsumer{}, true);
       util::scope_exit const finally{ [&] { diag.setClient(old_client.release(), true); } };

--- a/compiler+runtime/src/cpp/jank/analyze/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/analyze/processor.cpp
@@ -4047,7 +4047,8 @@ namespace jank::analyze
        *
        * We silence the diagnostics for this because it'll likely fail for any invalid symbols
        * anyway. */
-      auto &diag{ runtime::__rt_ctx->jit_prc.interpreter->getCompilerInstance()->getDiagnostics() };
+      auto locked_interpreter{ runtime::__rt_ctx->jit_prc.interpreter.lock() };
+      auto &diag{ (*locked_interpreter)->getCompilerInstance()->getDiagnostics() };
       auto old_client{ diag.takeClient() };
       diag.setClient(new clang::IgnoringDiagConsumer{}, true);
       util::scope_exit const finally{ [&] { diag.setClient(old_client.release(), true); } };

--- a/compiler+runtime/src/cpp/jank/environment/check_health.cpp
+++ b/compiler+runtime/src/cpp/jank/environment/check_health.cpp
@@ -292,8 +292,10 @@ namespace jank::environment
   static jtl::immutable_string check_cpp_jit()
   {
     bool error{};
-    auto def_err{ runtime::__rt_ctx->jit_prc.interpreter->ParseAndExecute(
-      "std::string jank_cpp_health_check(){ return \"healthy\"; }") };
+    auto locked_interpreter{ runtime::__rt_ctx->jit_prc.interpreter.lock() };
+    auto def_err{ (*locked_interpreter)
+                    ->ParseAndExecute(
+                      "std::string jank_cpp_health_check(){ return \"healthy\"; }") };
     if(def_err)
     {
       error = true;
@@ -301,9 +303,7 @@ namespace jank::environment
     else
     {
       clang::Value v;
-      auto call_err{
-        runtime::__rt_ctx->jit_prc.interpreter->ParseAndExecute("jank_cpp_health_check()", &v)
-      };
+      auto call_err{ (*locked_interpreter)->ParseAndExecute("jank_cpp_health_check()", &v) };
       if(call_err)
       {
         error = true;

--- a/compiler+runtime/src/cpp/jank/jit/object_dynamic.cpp
+++ b/compiler+runtime/src/cpp/jank/jit/object_dynamic.cpp
@@ -216,7 +216,8 @@ namespace jank::jit
 
   void install_object_tracking_plugin()
   {
-    auto const ee{ runtime::__rt_ctx->jit_prc.interpreter->getExecutionEngine() };
+    auto locked_interpreter{ runtime::__rt_ctx->jit_prc.interpreter.lock() };
+    auto const ee{ (*locked_interpreter)->getExecutionEngine() };
     auto &ol{ ee->getObjLinkingLayer() };
     auto &oll{ llvm::cast<llvm::orc::ObjectLinkingLayer>(ol) };
     oll.addPlugin(std::make_shared<object_tracking_plugin>(global_tracker()));

--- a/compiler+runtime/src/cpp/jank/jit/processor_dynamic.cpp
+++ b/compiler+runtime/src/cpp/jank/jit/processor_dynamic.cpp
@@ -344,9 +344,10 @@ namespace jank::jit
     }
 
     /* We need to include our special runtime PCH. */
-    interpreter.reset(created_interpreter);
+    auto locked_interpreter{ interpreter.lock() };
+    locked_interpreter->reset(created_interpreter);
 
-    auto const ee{ interpreter->getExecutionEngine() };
+    auto const ee{ (*locked_interpreter)->getExecutionEngine() };
 
     if constexpr(jtl::current_platform != jtl::platform::windows_like)
     {
@@ -388,7 +389,7 @@ namespace jank::jit
     {
       if(util::cli::opts.perf_profiling_enabled)
       {
-        auto const ee{ interpreter->getExecutionEngine() };
+        auto const ee{ (*locked_interpreter)->getExecutionEngine() };
         auto &es{ ee->getExecutionSession() };
         auto &ol{ ee->getObjLinkingLayer() };
         auto &oll{ llvm::cast<llvm::orc::ObjectLinkingLayer>(ol) };
@@ -582,7 +583,8 @@ namespace jank::jit
       formatted = util::format_cpp_source(s).expect_ok();
       util::println("\n{}\n", formatted);
     }
-    auto err(interpreter->ParseAndExecute({ formatted.data(), formatted.size() }, ret));
+    auto locked_interpreter{ interpreter.lock() };
+    auto err((*locked_interpreter)->ParseAndExecute({ formatted.data(), formatted.size() }, ret));
     if(err)
     {
       llvm::logAllUnhandledErrors(jtl::move(err), llvm::errs(), "error: ");
@@ -592,7 +594,8 @@ namespace jank::jit
 
   void processor::load_object(jtl::immutable_string_view const &path) const
   {
-    auto const ee{ interpreter->getExecutionEngine() };
+    auto locked_interpreter{ interpreter.lock() };
+    auto const ee{ (*locked_interpreter)->getExecutionEngine() };
     auto file{ llvm::MemoryBuffer::getFile(std::string_view{ path }) };
     if(!file)
     {
@@ -665,7 +668,8 @@ namespace jank::jit
       jtl::immutable_string_view{ module_name.data(), module_name.size() }) };
     //m->print(llvm::outs(), nullptr);
 
-    auto const ee(interpreter->getExecutionEngine());
+    auto locked_interpreter{ interpreter.lock() };
+    auto const ee((*locked_interpreter)->getExecutionEngine());
     llvm::cantFail(ee->addIRModule(jtl::move(m)));
     llvm::cantFail(ee->initialize(ee->getMainJITDylib()));
   }
@@ -691,7 +695,8 @@ namespace jank::jit
 
   jtl::string_result<void> processor::remove_symbol(jtl::immutable_string const &name) const
   {
-    auto const ee{ interpreter->getExecutionEngine() };
+    auto locked_interpreter{ interpreter.lock() };
+    auto const ee{ (*locked_interpreter)->getExecutionEngine() };
     llvm::orc::SymbolNameSet to_remove{};
     to_remove.insert(ee->mangleAndIntern(name.c_str()));
     auto const error{ ee->getMainJITDylib().remove(to_remove) };
@@ -705,7 +710,8 @@ namespace jank::jit
 
   jtl::string_result<void *> processor::find_symbol(jtl::immutable_string const &name) const
   {
-    if(auto symbol{ interpreter->getSymbolAddress(name.c_str()) })
+    auto locked_interpreter{ interpreter.lock() };
+    if(auto symbol{ (*locked_interpreter)->getSymbolAddress(name.c_str()) })
     {
       return symbol.get().toPtr<void *>();
     }
@@ -920,8 +926,10 @@ namespace jank::jit
         }
       }
 
+
+      auto locked_interpreter{ prc.interpreter.lock() };
       llvm::cantFail(
-        static_cast<clang::Interpreter &>(*prc.interpreter).LoadDynamicLibrary(path.data()));
+        static_cast<clang::Interpreter &>(**locked_interpreter).LoadDynamicLibrary(path.data()));
     }
   }
 
@@ -932,7 +940,8 @@ namespace jank::jit
 
   void processor::load_static_library(jtl::immutable_string const &path) const
   {
-    auto const ee{ interpreter->getExecutionEngine() };
+    auto locked_interpreter{ interpreter.lock() };
+    auto const ee{ (*locked_interpreter)->getExecutionEngine() };
     llvm::cantFail(ee->linkStaticLibraryInto(ee->getMainJITDylib(), path.c_str()));
   }
 }

--- a/compiler+runtime/src/cpp/jank/runtime/context_dynamic.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/context_dynamic.cpp
@@ -140,7 +140,8 @@ namespace jank::runtime
   {
     profile::timer const timer{ "rt eval_cpp_string" };
 
-    auto parse_res{ jit_prc.interpreter->Parse({ code.data(), code.size() }) };
+    auto locked_interpreter{ jit_prc.interpreter.lock() };
+    auto parse_res{ (*locked_interpreter)->Parse({ code.data(), code.size() }) };
     if(!parse_res)
     {
       /* TODO: Helper to turn an llvm::Error into a string. */
@@ -157,7 +158,7 @@ namespace jank::runtime
       write_module(module_name, code).expect_ok();
     }
 
-    auto exec_res(jit_prc.interpreter->Execute(partial_tu));
+    auto exec_res((*locked_interpreter)->Execute(partial_tu));
     if(exec_res)
     {
       llvm::logAllUnhandledErrors(std::move(exec_res), llvm::errs(), "error: ");

--- a/compiler+runtime/src/cpp/jank/util/clang.cpp
+++ b/compiler+runtime/src/cpp/jank/util/clang.cpp
@@ -321,7 +321,7 @@ namespace jank::util
     }
 
     jank_debug_assert(runtime::__rt_ctx);
-    return result
-      = runtime::__rt_ctx->jit_prc.interpreter->getExecutionEngine()->getTargetTriple().str();
+    auto locked_interpreter{ runtime::__rt_ctx->jit_prc.interpreter.lock() };
+    return result = (*locked_interpreter)->getExecutionEngine()->getTargetTriple().str();
   }
 }

--- a/compiler+runtime/test/cpp/jank/analyze/cpp_util.cpp
+++ b/compiler+runtime/test/cpp/jank/analyze/cpp_util.cpp
@@ -10,7 +10,8 @@ TEST_SUITE("analyze/cpp_util")
 {
   TEST_CASE("resolve_candidates orders candidates by relevance")
   {
-    auto parse_result{ jank::runtime::__rt_ctx->jit_prc.interpreter->Parse(R"cpp(
+    auto locked_interpreter{ jank::runtime::__rt_ctx->jit_prc.interpreter.lock() };
+    auto parse_result{ (*locked_interpreter)->Parse(R"cpp(
       namespace jank::test::resolve_candidates
       {
         int foo(int);
@@ -71,7 +72,8 @@ TEST_SUITE("analyze/cpp_util")
 
   TEST_CASE("resolve_candidates ranks access/const violations above conversion failures")
   {
-    auto parse_result{ jank::runtime::__rt_ctx->jit_prc.interpreter->Parse(R"cpp(
+    auto locked_interpreter{ jank::runtime::__rt_ctx->jit_prc.interpreter.lock() };
+    auto parse_result{ (*locked_interpreter)->Parse(R"cpp(
       namespace jank::test::resolve_candidates_members
       {
         struct widget

--- a/compiler+runtime/test/cpp/jank/jit/processor.cpp
+++ b/compiler+runtime/test/cpp/jank/jit/processor.cpp
@@ -56,7 +56,8 @@ namespace jank::jit
       /* We will intentionally introduce some bad C++ code and we don't want Clang outputting
        * compiler errors to stderr. If there are actual test issues which cause diagnostic
        * issues, the test will fail anyway and we can run it separately to see the errors. */
-      auto &diag{ runtime::__rt_ctx->jit_prc.interpreter->getCompilerInstance()->getDiagnostics() };
+      auto locked_interpreter{ runtime::__rt_ctx->jit_prc.interpreter.lock() };
+      auto &diag{ (*locked_interpreter)->getCompilerInstance()->getDiagnostics() };
       auto old_client{ diag.takeClient() };
       diag.setClient(new clang::IgnoringDiagConsumer{}, true);
       util::scope_exit const finally{ [&] { diag.setClient(old_client.release(), true); } };


### PR DESCRIPTION
`clang::Interpreter` isn't thread-safe so we need to guard against concurrent access to it in the `processor` (for example by `deferred_cpp_function`s being realized on separate threads).

Here I've blasted locks all over the `processor` member functions, but we can also try to be more fine-grained about it. Alternatively we can wrap it in a `folly::Synchronized` if that's still en vogue in the jank codebase.

Fixes https://github.com/jank-lang/jank/issues/986